### PR TITLE
refactor: python service now runs via next and not independant

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ ENV PORT=3000
 
 ENTRYPOINT [ "/sbin/tini", "--" ]
 
-CMD ["/bin/sh", "-c", "./venv/bin/gunicorn --no-control-socket -w 2 -b 0.0.0.0:5005 python.plex_invite:app & yarn start"]
+CMD ["yarn", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,4 +70,4 @@ ENV PORT=3000
 
 ENTRYPOINT [ "/sbin/tini", "--" ]
 
-CMD ["/bin/sh", "-c", "./venv/bin/gunicorn --pid /tmp/gunicorn.pid --no-control-socket -w 2 -b 0.0.0.0:5005 python.plex_invite:app & yarn start"]
+CMD ["/bin/sh", "-c", "./venv/bin/gunicorn --no-control-socket -w 2 -b 0.0.0.0:5005 python.plex_invite:app & yarn start"]

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -10,10 +10,10 @@ RUN apk add --no-cache python3 py3-pip
 
 # Create and activate virtual environment, then install Python dependencies
 RUN if [ -f server/python/requirements.txt ]; then \
-    python3 -m venv /opt/venv && \
-    . /opt/venv/bin/activate && \
-    pip install --no-cache-dir -r server/python/requirements.txt; \
-fi
+  python3 -m venv /opt/venv && \
+  . /opt/venv/bin/activate && \
+  pip install --no-cache-dir -r server/python/requirements.txt; \
+  fi
 
 # Make sure the virtual environment is in PATH
 ENV PATH="/opt/venv/bin:$PATH"
@@ -27,4 +27,4 @@ FROM deps AS runner
 
 WORKDIR /app
 
-CMD ["/bin/sh", "-c", "python3 server/python/plex_invite.py & yarn dev"]
+CMD ["yarn", "dev"]

--- a/package.json
+++ b/package.json
@@ -25,9 +25,7 @@
     "cypress:build": "yarn build && yarn cypress:prepare",
     "css-build": "tailwindcss -o public/tailwind.css",
     "css-watch": "tailwindcss -o public/tailwind.css --watch",
-    "start:python": "cd server/python && CONFIG_DIRECTORY=../../config gunicorn -w 2 -b 0.0.0.0:5005 --timeout 60 --graceful-timeout 30 --keep-alive 5 plex_invite:app",
-    "dev:all": "concurrently \"yarn dev\" \"cd server/python && CONFIG_DIRECTORY=../../config python3 plex_invite.py\"",
-    "start:all": "concurrently \"yarn start\" \"yarn start:python\""
+    "start:python": "cd server/python && CONFIG_DIRECTORY=../../config gunicorn -w 2 -b 0.0.0.0:5005 --timeout 60 --graceful-timeout 30 --keep-alive 5 plex_invite:app"
   },
   "repository": {
     "type": "git",
@@ -147,7 +145,6 @@
     "@typescript-eslint/parser": "8.56.0",
     "autoprefixer": "^10.4.24",
     "commitizen": "4.3.1",
-    "concurrently": "^9.2.1",
     "copyfiles": "^2.4.1",
     "cy-mobile-commands": "^0.3.0",
     "cypress": "^15.10.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "cypress:build": "yarn build && yarn cypress:prepare",
     "css-build": "tailwindcss -o public/tailwind.css",
     "css-watch": "tailwindcss -o public/tailwind.css --watch",
-    "start:python": "cd server/python && CONFIG_DIRECTORY=../../config gunicorn --pid /tmp/gunicorn.pid -w 2 -b 0.0.0.0:5005 --timeout 60 --graceful-timeout 30 --keep-alive 5 plex_invite:app",
+    "start:python": "cd server/python && CONFIG_DIRECTORY=../../config gunicorn -w 2 -b 0.0.0.0:5005 --timeout 60 --graceful-timeout 30 --keep-alive 5 plex_invite:app",
     "dev:all": "concurrently \"yarn dev\" \"cd server/python && CONFIG_DIRECTORY=../../config python3 plex_invite.py\"",
     "start:all": "concurrently \"yarn start\" \"yarn start:python\""
   },

--- a/server/index.ts
+++ b/server/index.ts
@@ -174,7 +174,10 @@ app
     pythonService.initialize();
     process.on('exit', () => pythonService.destroy());
     process.on('SIGINT', () => process.exit(0));
-    process.on('SIGTERM', () => process.exit(0));
+    process.on('SIGTERM', () => {
+      pythonService.prepareForServerRestart();
+      process.exit(0);
+    });
     io.on('connection', async (socket) => {
       const req = socket.request as SocketRequest;
       // Check for valid session and user

--- a/server/index.ts
+++ b/server/index.ts
@@ -53,6 +53,10 @@ const dev = process.env.NODE_ENV !== 'production';
 const app = next({ dev });
 const handle = app.getRequestHandler();
 
+process.on('exit', () => pythonService.destroy());
+process.on('SIGINT', () => process.exit(0));
+process.on('SIGTERM', () => process.exit(0));
+
 app
   .prepare()
   .then(async () => {
@@ -98,6 +102,7 @@ app
     ]);
     // Start Jobs
     startJobs();
+    const pythonReady = pythonService.start();
     const server = express();
     if (settings.main.trustProxy) {
       server.set('trust proxy', 1);
@@ -171,13 +176,6 @@ app
     server.set('io', io);
     setSocketIO(io);
     restartManager.initialize(httpServer, io);
-    pythonService.initialize();
-    process.on('exit', () => pythonService.destroy());
-    process.on('SIGINT', () => process.exit(0));
-    process.on('SIGTERM', () => {
-      pythonService.prepareForServerRestart();
-      process.exit(0);
-    });
     io.on('connection', async (socket) => {
       const req = socket.request as SocketRequest;
       // Check for valid session and user
@@ -242,6 +240,7 @@ app
           .json({ message: errorInfo.message, errors: errorInfo.errors });
       }
     );
+    await pythonReady;
     const port = Number(process.env.PORT) || 3000;
     const host = process.env.HOST;
     if (host) {

--- a/server/lib/restartManager.ts
+++ b/server/lib/restartManager.ts
@@ -236,11 +236,12 @@ class RestartManager {
       if (dataSource.isInitialized) {
         await dataSource.destroy();
       }
-      pythonService.prepareForServerRestart();
 
       if (isDocker()) {
         process.exit(0);
       }
+
+      pythonService.prepareForServerRestart();
       process.removeAllListeners('SIGINT');
       process.removeAllListeners('SIGTERM');
       process.removeAllListeners('exit');

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -528,45 +528,55 @@ userSettingsRoutes.post<{ id: string }>(
         });
       }
 
-      const librariesResponse = await axios.get(
-        'http://localhost:5005/library-details',
-        {
-          params: {
-            token: mainUser.plexToken,
-            server_id: plexSettings.machineId,
-            email: user.email,
-          },
-          timeout: 15000,
+      let librariesToPin: { id: string; name: string; type: string }[];
+
+      if (user.id === 1) {
+        librariesToPin = plexSettings.libraries.map((lib) => ({
+          id: lib.id,
+          name: lib.name,
+          type: lib.type,
+        }));
+      } else {
+        const librariesResponse = await axios.get(
+          'http://localhost:5005/library-details',
+          {
+            params: {
+              token: mainUser.plexToken,
+              server_id: plexSettings.machineId,
+              email: user.email,
+            },
+            timeout: 15000,
+          }
+        );
+
+        if (
+          !librariesResponse.data.success ||
+          !librariesResponse.data.libraries
+        ) {
+          return next({
+            status: 500,
+            message: 'Failed to get library information.',
+          });
         }
-      );
 
-      if (
-        !librariesResponse.data.success ||
-        !librariesResponse.data.libraries
-      ) {
-        return next({
-          status: 500,
-          message: 'Failed to get library information.',
-        });
-      }
-
-      const allLibraries = librariesResponse.data.libraries;
-      const userSharedLibraries = user.settings?.sharedLibraries;
-      let librariesToPin = allLibraries.filter((lib: { id: string }) =>
-        getSettings().main.sharedLibraries.split('|').includes(lib.id)
-      );
-
-      if (userSharedLibraries && userSharedLibraries !== 'all') {
-        const allowedLibraryIds = userSharedLibraries.split('|');
+        const allLibraries = librariesResponse.data.libraries;
+        const userSharedLibraries = user.settings?.sharedLibraries;
         librariesToPin = allLibraries.filter((lib: { id: string }) =>
-          allowedLibraryIds.includes(lib.id)
+          getSettings().main.sharedLibraries.split('|').includes(lib.id)
         );
-      } else if (userSharedLibraries && userSharedLibraries === 'all') {
-        librariesToPin = allLibraries.filter((lib: { id: string }) =>
-          getSettings().plex.libraries.some(
-            (library) => library.id === lib.id && library.enabled
-          )
-        );
+
+        if (userSharedLibraries && userSharedLibraries !== 'all') {
+          const allowedLibraryIds = userSharedLibraries.split('|');
+          librariesToPin = allLibraries.filter((lib: { id: string }) =>
+            allowedLibraryIds.includes(lib.id)
+          );
+        } else if (userSharedLibraries && userSharedLibraries === 'all') {
+          librariesToPin = allLibraries.filter((lib: { id: string }) =>
+            getSettings().plex.libraries.some(
+              (library) => library.id === lib.id && library.enabled
+            )
+          );
+        }
       }
 
       if (librariesToPin.length === 0) {

--- a/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
@@ -37,6 +37,8 @@ import 'react-datepicker/dist/react-datepicker.css';
 import ConfirmButton from '@app/components/Common/ConfirmButton';
 import PythonServiceAlert from '@app/components/Admin/Settings/PythonServiceAlert';
 
+//BUG: Fix bug where server admin/owner cannot pin libraries or hide button if this is expected
+
 const UserSettingsGeneral = () => {
   const intl = useIntl();
   const { locale, setLocale } = useLocale();

--- a/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
@@ -37,8 +37,6 @@ import 'react-datepicker/dist/react-datepicker.css';
 import ConfirmButton from '@app/components/Common/ConfirmButton';
 import PythonServiceAlert from '@app/components/Admin/Settings/PythonServiceAlert';
 
-//BUG: Fix bug where server admin/owner cannot pin libraries or hide button if this is expected
-
 const UserSettingsGeneral = () => {
   const intl = useIntl();
   const { locale, setLocale } = useLocale();

--- a/yarn.lock
+++ b/yarn.lock
@@ -8027,16 +8027,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:4.1.2, chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
-  version: 4.1.2
-  resolution: "chalk@npm:4.1.2"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
-  languageName: node
-  linkType: hard
-
 "chalk@npm:^2.3.2, chalk@npm:^2.4.1":
   version: 2.4.2
   resolution: "chalk@npm:2.4.2"
@@ -8055,6 +8045,16 @@ __metadata:
     ansi-styles: "npm:^4.1.0"
     supports-color: "npm:^7.1.0"
   checksum: 10c0/ee650b0a065b3d7a6fda258e75d3a86fc8e4effa55871da730a9e42ccb035bf5fd203525e5a1ef45ec2582ecc4f65b47eb11357c526b84dd29a14fb162c414d2
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.1, chalk@npm:^4.1.2":
+  version: 4.1.2
+  resolution: "chalk@npm:4.1.2"
+  dependencies:
+    ansi-styles: "npm:^4.1.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10c0/4a3fef5cc34975c898ffe77141450f679721df9dde00f6c304353fa9c8b571929123b26a0e4617bde5018977eb655b31970c297b91b63ee83bb82aeb04666880
   languageName: node
   linkType: hard
 
@@ -8674,23 +8674,6 @@ __metadata:
     readable-stream: "npm:^3.0.2"
     typedarray: "npm:^0.0.6"
   checksum: 10c0/29565dd9198fe1d8cf57f6cc71527dbc6ad67e12e4ac9401feb389c53042b2dceedf47034cbe702dfc4fd8df3ae7e6bfeeebe732cc4fa2674e484c13f04c219a
-  languageName: node
-  linkType: hard
-
-"concurrently@npm:^9.2.1":
-  version: 9.2.1
-  resolution: "concurrently@npm:9.2.1"
-  dependencies:
-    chalk: "npm:4.1.2"
-    rxjs: "npm:7.8.2"
-    shell-quote: "npm:1.8.3"
-    supports-color: "npm:8.1.1"
-    tree-kill: "npm:1.2.2"
-    yargs: "npm:17.7.2"
-  bin:
-    conc: dist/bin/concurrently.js
-    concurrently: dist/bin/concurrently.js
-  checksum: 10c0/da37f239f82eb7ac24f5ddb56259861e5f1d6da2ade7602b6ea7ad3101b13b5ccec02a77b7001402d1028ff2fdc38eed55644b32853ad5abf30e057002a963aa
   languageName: node
   linkType: hard
 
@@ -18649,7 +18632,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:7.8.2, rxjs@npm:^7.5.1, rxjs@npm:^7.5.5":
+"rxjs@npm:^7.5.1, rxjs@npm:^7.5.5":
   version: 7.8.2
   resolution: "rxjs@npm:7.8.2"
   dependencies:
@@ -19090,13 +19073,6 @@ __metadata:
   version: 3.0.0
   resolution: "shebang-regex@npm:3.0.0"
   checksum: 10c0/1dbed0726dd0e1152a92696c76c7f06084eb32a90f0528d11acd764043aacf76994b2fb30aa1291a21bd019d6699164d048286309a278855ee7bec06cf6fb690
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
   languageName: node
   linkType: hard
 
@@ -19659,7 +19635,6 @@ __metadata:
     bowser: "npm:^2.14.1"
     colord: "npm:^2.9.3"
     commitizen: "npm:4.3.1"
-    concurrently: "npm:^9.2.1"
     connect-typeorm: "npm:^2.0.0"
     cookie-parser: "npm:^1.4.7"
     copyfiles: "npm:^2.4.1"
@@ -20116,15 +20091,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:8.1.1, supports-color@npm:^8.1.1":
-  version: 8.1.1
-  resolution: "supports-color@npm:8.1.1"
-  dependencies:
-    has-flag: "npm:^4.0.0"
-  checksum: 10c0/ea1d3c275dd604c974670f63943ed9bd83623edc102430c05adb8efc56ba492746b6e95386e7831b872ec3807fd89dd8eb43f735195f37b5ec343e4234cc7e89
-  languageName: node
-  linkType: hard
-
 "supports-color@npm:^10.2.2":
   version: 10.2.2
   resolution: "supports-color@npm:10.2.2"
@@ -20147,6 +20113,15 @@ __metadata:
   dependencies:
     has-flag: "npm:^4.0.0"
   checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "supports-color@npm:8.1.1"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10c0/ea1d3c275dd604c974670f63943ed9bd83623edc102430c05adb8efc56ba492746b6e95386e7831b872ec3807fd89dd8eb43f735195f37b5ec343e4234cc7e89
   languageName: node
   linkType: hard
 
@@ -22204,21 +22179,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:17.7.2, yargs@npm:^17.0.0, yargs@npm:^17.7.2":
-  version: 17.7.2
-  resolution: "yargs@npm:17.7.2"
-  dependencies:
-    cliui: "npm:^8.0.1"
-    escalade: "npm:^3.1.1"
-    get-caller-file: "npm:^2.0.5"
-    require-directory: "npm:^2.1.1"
-    string-width: "npm:^4.2.3"
-    y18n: "npm:^5.0.5"
-    yargs-parser: "npm:^21.1.1"
-  checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
-  languageName: node
-  linkType: hard
-
 "yargs@npm:^15.3.1":
   version: 15.4.1
   resolution: "yargs@npm:15.4.1"
@@ -22250,6 +22210,21 @@ __metadata:
     y18n: "npm:^5.0.5"
     yargs-parser: "npm:^20.2.2"
   checksum: 10c0/b1dbfefa679848442454b60053a6c95d62f2d2e21dd28def92b647587f415969173c6e99a0f3bab4f1b67ee8283bf735ebe3544013f09491186ba9e8a9a2b651
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.0.0, yargs@npm:^17.7.2":
+  version: 17.7.2
+  resolution: "yargs@npm:17.7.2"
+  dependencies:
+    cliui: "npm:^8.0.1"
+    escalade: "npm:^3.1.1"
+    get-caller-file: "npm:^2.0.5"
+    require-directory: "npm:^2.1.1"
+    string-width: "npm:^4.2.3"
+    y18n: "npm:^5.0.5"
+    yargs-parser: "npm:^21.1.1"
+  checksum: 10c0/ccd7e723e61ad5965fffbb791366db689572b80cca80e0f96aad968dfff4156cd7cd1ad18607afe1046d8241e6fb2d6c08bf7fa7bfb5eaec818735d8feac8f05
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### Description
This pull request refactors how the Python service (Plex Sync) is managed by the Node.js backend, simplifying process management and improving reliability. The changes remove legacy PID file handling, streamline Docker and local development startup commands, and ensure the Python service is started, monitored, and stopped more robustly. There are also improvements to user library pinning logic and cleanup of development dependencies.

**Python Service Management Improvements:**

* Refactored `pythonService` management to remove PID file handling and use process detection via `/proc` or `pgrep`, improving reliability and simplifying code. The service is now started using `execSync` and monitored with improved health checks and cleanup logic. (`server/lib/pythonService.ts`) [[1]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L5-R13) [[2]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045R24-L33) [[3]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L51-L73) [[4]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L93-R112) [[5]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L114-R129) [[6]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L135-L186) [[7]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L203-R193) [[8]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L259-R244) [[9]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L294-R263) [[10]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L333-R315) [[11]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L368-L410) [[12]](diffhunk://#diff-2e89d696ff453942787dce23c87f1b705db10f0c246f88d916537fb4037f0045L429-L465)
* Updated `server/index.ts` to start the Python service asynchronously and ensure it is ready before starting the Node.js server, with improved signal handling for clean shutdowns. [[1]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68R56-R59) [[2]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68R105) [[3]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68L174-L177) [[4]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68R243)
* Simplified Docker and local development startup commands to only run the Node.js service, removing background Python process startup from Dockerfiles. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L73-R73) [[2]](diffhunk://#diff-c4b61b6caa8ec64b5dad71df5483e4f74772ebd978e4ef9f412c213abea55d95L30-R30)

**Dependency and Script Cleanup:**

* Removed the `concurrently` dependency and related scripts from `package.json`, as Python service startup is now managed internally. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R28) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L150)

**User Library Pinning Logic:**

* Improved logic for pinning libraries to users, ensuring the admin user pins all libraries and regular users only pin shared libraries, with clearer handling for library selection. (`server/routes/user/usersettings.ts`) [[1]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926R531-R539) [[2]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L555-R564) [[3]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926R580)

**Restart Handling:**

* Adjusted restart management to ensure Python service cleanup is properly handled during server restarts. (`server/lib/restartManager.ts`)
#### Screenshot (if UI-related)

#### To-Dos

- [x] Successful build `yarn prepare && yarn build`
