### PR TITLE
chore(docs): updated docs and fixed mistakes

### DIFF
--- a/docs/support/need-help.md
+++ b/docs/support/need-help.md
@@ -148,8 +148,8 @@ Available log levels:
 
 - `error` — Errors only
 - `warn` — Warnings and errors
-- `info` — General information (default)
-- `debug` — Detailed debugging information
+- `info` — General information
+- `debug` — Detailed debugging information (default)
 
 ---
 

--- a/docs/using-streamarr/calendar/README.md
+++ b/docs/using-streamarr/calendar/README.md
@@ -86,27 +86,21 @@ Users with **Create Events** or **Manage Events** permission can create local ev
 1. Click **Create Event** or click on a calendar date
 2. Fill in event details:
 
-| Field                 | Description                       |
-| --------------------- | --------------------------------- |
-| **Summary**           | Event title                       |
-| **Description**       | Event details (supports Markdown) |
-| **Start Date/Time**   | When the event starts             |
-| **End Date/Time**     | When the event ends (optional)    |
-| **All Day**           | Mark as an all-day event          |
-| **Category**          | Event category for filtering      |
-| **Send Notification** | Notify users about this event     |
+| Field                 | Description                        |
+| --------------------- | ---------------------------------- |
+| **Summary**           | Event title                        |
+| **Description**       | Event details                      |
+| **Start Date/Time**   | When the event starts              |
+| **End Date/Time**     | When the event ends (optional)     |
+| **All Day**           | Mark as an all-day event           |
+| **Categories**        | Optional categories for organizing |
+| **Send Notification** | Notify users about this event      |
 
 3. Click **Create**
 
 ### Event Categories
 
-Organize events with categories:
-
-- **Announcement** — Server announcements
-- **Maintenance** — Scheduled maintenance
-- **Release** — Content releases
-- **Watch Party** — Group watching events
-- **Custom** — Other events
+Events can be tagged with free-form categories for organization and filtering. Categories are stored as a text field — there are no predefined values, so you can use whatever labels make sense for your server (e.g., "Announcement", "Maintenance", "Watch Party").
 
 ---
 

--- a/docs/using-streamarr/settings/README.md
+++ b/docs/using-streamarr/settings/README.md
@@ -335,10 +335,11 @@ Connect Overseerr for request management.
 
 Connect Tdarr for transcoding management.
 
-| Setting            | Description                  |
-| ------------------ | ---------------------------- |
-| **Hostname or IP** | Address of your Tdarr server |
-| **Port**           | Default is `8265`            |
+| Setting            | Description                             |
+| ------------------ | --------------------------------------- |
+| **Enable**         | Enable or disable the Tdarr integration |
+| **Hostname or IP** | Address of your Tdarr server            |
+| **Port**           | Default is `8265`                       |
 
 #### Tautulli
 

--- a/docs/using-streamarr/settings/onboarding.md
+++ b/docs/using-streamarr/settings/onboarding.md
@@ -14,7 +14,7 @@ Streamarr provides **two separate onboarding tracks**:
 - **User Onboarding** — Welcomes regular users and guides them through the main interface (watching, invites, schedule, etc.)
 - **Admin Onboarding** — Welcomes administrators and guides them through admin-specific features (settings, services, user management)
 
-Each track has its own welcome slides and tutorial steps, and is triggered independently based on the user's role. Both tracks are fully customizable by administrators.
+Each track has its own welcome slides and tutorial steps, and is triggered independently based on the user's role. User onboarding content is fully customizable by administrators, while admin onboarding content is built into the application.
 
 ---
 
@@ -239,11 +239,11 @@ Streamarr ships with five admin-specific tutorial steps (all in spotlight mode):
 | 4     | Services Settings | Integrate with Seerr, Radarr, Sonarr, and other services     | `/admin/settings/services`   |
 | 5     | Manage Users      | View and manage users, permissions, and library access       | `/admin/settings`            |
 
-### Customizing Admin Onboarding
+### Admin Onboarding Content
 
-Admin welcome slides and tutorial steps can be customized using the same editor interface as user onboarding. The onboarding settings page separates content by type — switch between **User** and **Admin** content using the content type selector.
+Admin welcome slides and tutorial steps are **built into the application** and are not editable from the admin settings UI. Unlike user onboarding content (which is stored in the database and fully customizable), admin onboarding content is defined in the frontend code (`src/utils/adminOnboarding.tsx`) and provides a consistent first-run experience for all administrators.
 
-All the same features are available: custom images, video embeds, custom HTML, drag-and-drop reordering, and preview mode.
+The admin onboarding content covers core admin tasks (user management, service configuration, notification setup) and is designed to get new administrators up and running quickly.
 
 ### Resetting Admin Onboarding
 

--- a/docs/using-streamarr/settings/system.md
+++ b/docs/using-streamarr/settings/system.md
@@ -87,13 +87,13 @@ The restart behavior depends on your environment:
 | **Docker (Production)**     | Exits the process (`process.exit(0)`); the container restart policy restarts the service |
 | **Bare Metal (Production)** | Gracefully shuts down connections, then respawns the process automatically               |
 
-During a restart:
+During a production restart:
 
 1. Socket.IO connections are disconnected
 2. The HTTP server is closed (with a 3-second drain timeout)
 3. The database connection is destroyed
-4. The Python service is prepared for shutdown
-5. The server restarts in its new configuration
+4. **Docker**: The process exits — the container restart policy handles the rest
+5. **Bare Metal**: The Plex Sync service is preserved (kept running across the restart), signal handlers are reset, and a new server process is spawned
 
 The UI shows a "Restarting..." indicator followed by "Reconnecting..." while it waits for the server to come back online (up to 45 seconds).
 


### PR DESCRIPTION
#### Description
This pull request updates documentation to add comprehensive details about the new server/service restart system, clarifies onboarding customization, and improves accuracy and clarity in several feature descriptions. The most significant changes are grouped below.

**Restart System Documentation:**

- Added a detailed section describing the restart system, including tracked settings, backend components (`restartManager`, `pythonService`), frontend hooks (`useServerRestart`, `usePythonRestart`), UI components, API endpoints, and environment-specific restart behavior. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R286-R331) [[2]](diffhunk://#diff-fc3fd11423a2b72acc456ef98556d25bd66e5d9e9c31cec7a5791d027f30479bL90-R96) [[3]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R529-R530)
- Listed new custom hooks related to restart and system health (`useServerRestart`, `usePythonRestart`, `useClickOutside`, etc.) in the hooks overview.

**Onboarding System Clarification:**

- Clarified that admin onboarding content is built-in and not customizable via the UI, while user onboarding remains fully customizable. Updated descriptions in both the main onboarding doc and the admin onboarding section. [[1]](diffhunk://#diff-1b1b2aacba9631ff50d66a39baadc943100819ceaae8208133b6ce006acdc27fL17-R17) [[2]](diffhunk://#diff-1b1b2aacba9631ff50d66a39baadc943100819ceaae8208133b6ce006acdc27fL242-R246)
- Updated the `OnboardingSettings` interface to include the `adminOnboardingCompleted` flag.

**Feature & UI Documentation Improvements:**

- Updated event categories documentation: clarified that categories are free-form text and removed the list of predefined categories.
- Improved Tdarr integration table formatting and clarified the enable/disable setting.
- Adjusted log level documentation to correctly indicate that `debug` is now the default log level, not `info`.
