### PR TITLE
feat: add GitHub releases endpoint and integrate with settings reducing api calls

### DIFF
--- a/server/api/github.ts
+++ b/server/api/github.ts
@@ -1,27 +1,9 @@
 import cacheManager from '@server/lib/cache';
+import type { GitHubRelease } from '@server/interfaces/api/settingsInterfaces';
 import logger from '@server/logger';
 import ExternalAPI from './externalapi';
 
 const GITHUB_CACHE_TTL = 1800;
-
-export interface GitHubRelease {
-  url: string;
-  assets_url: string;
-  upload_url: string;
-  html_url: string;
-  id: number;
-  node_id: string;
-  tag_name: string;
-  target_commitish: string;
-  name: string;
-  draft: boolean;
-  prerelease: boolean;
-  created_at: string;
-  published_at: string;
-  tarball_url: string;
-  zipball_url: string;
-  body: string;
-}
 
 interface GithubCommit {
   sha: string;

--- a/server/api/github.ts
+++ b/server/api/github.ts
@@ -2,7 +2,9 @@ import cacheManager from '@server/lib/cache';
 import logger from '@server/logger';
 import ExternalAPI from './externalapi';
 
-interface GitHubRelease {
+const GITHUB_CACHE_TTL = 1800;
+
+export interface GitHubRelease {
   url: string;
   assets_url: string;
   upload_url: string;
@@ -65,7 +67,8 @@ class GithubAPI extends ExternalAPI {
     try {
       const data = await this.get<GitHubRelease[]>(
         '/repos/nickelsh1ts/streamarr/releases',
-        { params: { per_page: take } }
+        { params: { per_page: take } },
+        GITHUB_CACHE_TTL
       );
 
       return data;
@@ -88,7 +91,8 @@ class GithubAPI extends ExternalAPI {
     try {
       const data = await this.get<GithubCommit[]>(
         '/repos/nickelsh1ts/streamarr/commits',
-        { params: { per_page: take, branch } }
+        { params: { per_page: take, branch } },
+        GITHUB_CACHE_TTL
       );
 
       return data;

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -87,3 +87,22 @@ export interface PythonServiceStatusResponse {
   lastHealthy: string | null;
   consecutiveFailures: number;
 }
+
+export interface GitHubRelease {
+  url: string;
+  assets_url: string;
+  upload_url: string;
+  html_url: string;
+  id: number;
+  node_id: string;
+  tag_name: string;
+  target_commitish: string;
+  name: string;
+  draft: boolean;
+  prerelease: boolean;
+  created_at: string;
+  published_at: string;
+  tarball_url: string;
+  zipball_url: string;
+  body: string;
+}

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -1,6 +1,7 @@
 import PlexAPI from '@server/api/plexapi';
 import PlexTvAPI from '@server/api/plextv';
 import TautulliAPI from '@server/api/tautulli';
+import GithubAPI from '@server/api/github';
 import LidarrAPI from '@server/api/servarr/lidarr';
 import ProwlarrAPI from '@server/api/servarr/prowlarr';
 import { getRepository } from '@server/datasource';
@@ -985,6 +986,12 @@ settingsRoutes.get('/about', async (req, res) => {
     tz: process.env.TZ,
     appDataPath: appDataPath(),
   } as SettingsAboutResponse);
+});
+
+settingsRoutes.get('/releases', async (_req, res) => {
+  const githubApi = new GithubAPI();
+  const releases = await githubApi.getStreamarrReleases();
+  res.status(200).json(releases);
 });
 
 settingsRoutes.get(

--- a/src/components/Admin/Settings/JobsCache/index.tsx
+++ b/src/components/Admin/Settings/JobsCache/index.tsx
@@ -24,8 +24,6 @@ import { useEffect, useReducer, useState } from 'react';
 import useSWR from 'swr';
 import { useIntl, FormattedMessage } from 'react-intl';
 
-//BUG: github api makes excessive hits and misses
-
 interface Job {
   id: string;
   name?: string;
@@ -599,27 +597,39 @@ const JobsCacheSettings = () => {
             </tr>
           </thead>
           <Table.TBody>
-            <tr>
-              <Table.TD>The Movie Database (tmdb)</Table.TD>
-              <Table.TD>{cacheData?.imageCache.tmdb.imageCount ?? 0}</Table.TD>
-              <Table.TD>
-                {formatBytes(cacheData?.imageCache.tmdb.size ?? 0)}
-              </Table.TD>
-            </tr>
-            <tr>
-              <Table.TD>
-                <FormattedMessage
-                  id="imageCache.qrcode"
-                  defaultMessage="Invite QR Codes"
-                />
-              </Table.TD>
-              <Table.TD>
-                {cacheData?.imageCache.qrcode?.imageCount ?? 0}
-              </Table.TD>
-              <Table.TD>
-                {formatBytes(cacheData?.imageCache.qrcode?.size ?? 0)}
-              </Table.TD>
-            </tr>
+            {!isLoading ? (
+              <>
+                <tr>
+                  <Table.TD>The Movie Database (tmdb)</Table.TD>
+                  <Table.TD>
+                    {cacheData?.imageCache.tmdb.imageCount ?? 0}
+                  </Table.TD>
+                  <Table.TD>
+                    {formatBytes(cacheData?.imageCache.tmdb.size ?? 0)}
+                  </Table.TD>
+                </tr>
+                <tr>
+                  <Table.TD>
+                    <FormattedMessage
+                      id="imageCache.qrcode"
+                      defaultMessage="Invite QR Codes"
+                    />
+                  </Table.TD>
+                  <Table.TD>
+                    {cacheData?.imageCache.qrcode?.imageCount ?? 0}
+                  </Table.TD>
+                  <Table.TD>
+                    {formatBytes(cacheData?.imageCache.qrcode?.size ?? 0)}
+                  </Table.TD>
+                </tr>
+              </>
+            ) : (
+              <tr>
+                <Table.TD colSpan={3} className="text-center">
+                  <LoadingEllipsis />
+                </Table.TD>
+              </tr>
+            )}
           </Table.TBody>
         </Table>
       </div>

--- a/src/components/Admin/Settings/System/Releases/index.tsx
+++ b/src/components/Admin/Settings/System/Releases/index.tsx
@@ -13,7 +13,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 const ReactMarkdown = dynamic(() => import('react-markdown'), {
   ssr: false,
 });
-import type { GitHubRelease } from '@server/api/github';
+import type { GitHubRelease } from '@server/interfaces/api/settingsInterfaces';
 
 interface ReleaseProps {
   release: GitHubRelease;

--- a/src/components/Admin/Settings/System/Releases/index.tsx
+++ b/src/components/Admin/Settings/System/Releases/index.tsx
@@ -13,27 +13,7 @@ import { useIntl, FormattedMessage } from 'react-intl';
 const ReactMarkdown = dynamic(() => import('react-markdown'), {
   ssr: false,
 });
-const REPO_RELEASE_API =
-  'https://api.github.com/repos/nickelsh1ts/streamarr/releases?per_page=20';
-
-interface GitHubRelease {
-  url: string;
-  assets_url: string;
-  upload_url: string;
-  html_url: string;
-  id: number;
-  node_id: string;
-  tag_name: string;
-  target_commitish: string;
-  name: string;
-  draft: boolean;
-  prerelease: boolean;
-  created_at: string;
-  published_at: string;
-  tarball_url: string;
-  zipball_url: string;
-  body: string;
-}
+import type { GitHubRelease } from '@server/api/github';
 
 interface ReleaseProps {
   release: GitHubRelease;
@@ -115,7 +95,7 @@ interface ReleasesProps {
 }
 
 const Releases = ({ currentVersion }: ReleasesProps) => {
-  const { data, error } = useSWR<GitHubRelease[]>(REPO_RELEASE_API);
+  const { data, error } = useSWR<GitHubRelease[]>('/api/v1/settings/releases');
 
   if (!data && !error) {
     return <LoadingEllipsis />;

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -3507,6 +3507,42 @@ paths:
                   appDataPath:
                     type: string
                     example: /app/config
+  /settings/releases:
+    get:
+      summary: Get GitHub releases
+      description: Returns a list of Streamarr releases from GitHub, served through the server-side cache.
+      tags:
+        - settings
+      responses:
+        '200':
+          description: List of releases
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    url:
+                      type: string
+                    html_url:
+                      type: string
+                    id:
+                      type: number
+                    tag_name:
+                      type: string
+                    name:
+                      type: string
+                    draft:
+                      type: boolean
+                    prerelease:
+                      type: boolean
+                    created_at:
+                      type: string
+                    published_at:
+                      type: string
+                    body:
+                      type: string
   /settings/restart-required:
     get:
       summary: Check if server restart is required

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -3510,9 +3510,12 @@ paths:
   /settings/releases:
     get:
       summary: Get GitHub releases
-      description: Returns a list of Streamarr releases from GitHub, served through the server-side cache.
+      description: Returns a list of Streamarr releases from GitHub, served through the server-side cache. Requires admin authentication.
       tags:
         - settings
+      security:
+        - cookieAuth: []
+        - apiKey: []
       responses:
         '200':
           description: List of releases
@@ -3525,11 +3528,19 @@ paths:
                   properties:
                     url:
                       type: string
+                    assets_url:
+                      type: string
+                    upload_url:
+                      type: string
                     html_url:
                       type: string
                     id:
                       type: number
+                    node_id:
+                      type: string
                     tag_name:
+                      type: string
+                    target_commitish:
                       type: string
                     name:
                       type: string
@@ -3541,8 +3552,17 @@ paths:
                       type: string
                     published_at:
                       type: string
+                    tarball_url:
+                      type: string
+                    zipball_url:
+                      type: string
                     body:
                       type: string
+                  additionalProperties: true
+        '401':
+          description: Unauthorized - user not authenticated
+        '403':
+          description: Forbidden - user lacks admin permission
   /settings/restart-required:
     get:
       summary: Check if server restart is required


### PR DESCRIPTION
#### Description
This pull request introduces server-side caching for GitHub release and commit API calls, and updates the frontend to fetch release data through a new backend endpoint. These changes improve performance and reduce unnecessary API requests. Additionally, the OpenAPI documentation is updated to reflect the new endpoint.

**Backend caching and API changes:**

* Added a cache TTL constant (`GITHUB_CACHE_TTL`) and applied caching to GitHub release and commit API calls in `GithubAPI`, reducing excessive hits to the GitHub API (`server/api/github.ts`). [[1]](diffhunk://#diff-309be2b5451df1c5087e90ad9859b80147c4dd78b00429b4368736fb097f00dbL5-R7) [[2]](diffhunk://#diff-309be2b5451df1c5087e90ad9859b80147c4dd78b00429b4368736fb097f00dbL68-R71) [[3]](diffhunk://#diff-309be2b5451df1c5087e90ad9859b80147c4dd78b00429b4368736fb097f00dbL91-R95)
* Introduced a new backend route `/api/v1/settings/releases` that returns cached GitHub release data (`server/routes/settings/index.ts`). [[1]](diffhunk://#diff-6bfb870aaae2a6a7d991a6dcbad3c4f8a1096576565230c9b688d0257a8012b6R4) [[2]](diffhunk://#diff-6bfb870aaae2a6a7d991a6dcbad3c4f8a1096576565230c9b688d0257a8012b6R991-R996)

**Frontend updates:**

* Updated the releases page to fetch data from the new backend endpoint instead of directly from GitHub, and to use the shared `GitHubRelease` type from the backend (`src/components/Admin/Settings/System/Releases/index.tsx`). [[1]](diffhunk://#diff-da7c83b907b10626d0f2a798be38e723dc8060db608746937367c895fbc43b63L16-R16) [[2]](diffhunk://#diff-da7c83b907b10626d0f2a798be38e723dc8060db608746937367c895fbc43b63L118-R98)

**Documentation:**

* Added OpenAPI documentation for the new `/settings/releases` endpoint in `streamarr-api.yml` to describe the response schema and usage.

**UI improvements:**

* Improved cache jobs table loading state handling for better user experience (`src/components/Admin/Settings/JobsCache/index.tsx`). [[1]](diffhunk://#diff-4b07d63ffa54f8677cb819ee1ae5afcff40777df35c8bca761aa6e4808f6fa0dR600-R606) [[2]](diffhunk://#diff-4b07d63ffa54f8677cb819ee1ae5afcff40777df35c8bca761aa6e4808f6fa0dR625-R632)
