### PR TITLE
feat: added library count toggle setting for homepage

### DIFF
--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -36,6 +36,7 @@ export interface PublicSettingsResponse {
   supportUrl: string;
   supportEmail: string;
   extendedHome: boolean;
+  libraryCounts?: boolean;
   enableSignUp: boolean;
   statusUrl: string;
   statusEnabled: boolean;

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -151,6 +151,7 @@ export interface MainSettings {
   supportUrl: string;
   supportEmail: string;
   extendedHome: boolean;
+  libraryCounts?: boolean;
   customLogo?: string;
   customLogoSmall?: string;
   enableTrialPeriod: boolean;
@@ -175,6 +176,7 @@ export interface FullPublicSettings extends PublicSettings {
   supportUrl: string;
   supportEmail: string;
   extendedHome: boolean;
+  libraryCounts?: boolean;
   customLogo?: string;
   customLogoSmall?: string;
   enableSignUp: boolean;
@@ -306,6 +308,7 @@ class Settings {
         supportUrl: '',
         supportEmail: '',
         extendedHome: true,
+        libraryCounts: true,
         enableTrialPeriod: false,
         trialPeriodDays: 30,
         theme: {
@@ -537,6 +540,7 @@ class Settings {
       supportUrl: this.data.main.supportUrl,
       supportEmail: this.data.main.supportEmail,
       extendedHome: this.data.main.extendedHome,
+      libraryCounts: this.data.main.libraryCounts,
       customLogo: this.data.main.customLogo,
       customLogoSmall: this.data.main.customLogoSmall,
       enableSignUp: this.data.main.enableSignUp,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -102,6 +102,11 @@ router.get('/settings/public', async (req, res) => {
 
 router.get('/libraries', async (req, res, next) => {
   const settings = getSettings();
+
+  if (!settings.main.libraryCounts) {
+    return res.status(200).json([]);
+  }
+
   const userRepository = getRepository(User);
   try {
     const admin = await userRepository.findOneOrFail({

--- a/src/components/Admin/Settings/General/index.tsx
+++ b/src/components/Admin/Settings/General/index.tsx
@@ -146,6 +146,7 @@ const GeneralSettings = () => {
           supportUrl: data?.supportUrl,
           supportEmail: data?.supportEmail,
           extendedHome: data?.extendedHome,
+          libraryCounts: data?.libraryCounts,
           theme: data?.theme,
           customLogo: null as File | null,
           customLogoSmall: null as File | null,
@@ -166,6 +167,7 @@ const GeneralSettings = () => {
               supportUrl: values.supportUrl,
               supportEmail: values.supportEmail,
               extendedHome: values.extendedHome,
+              libraryCounts: values.libraryCounts,
               theme: values.theme,
             });
             updateSettings({ theme: values.theme });
@@ -858,6 +860,31 @@ const GeneralSettings = () => {
                     name="extendedHome"
                     onChange={() => {
                       setFieldValue('extendedHome', !values.extendedHome);
+                    }}
+                    className="checkbox-primary checkbox"
+                  />
+                </div>
+                <div className="grid grid-cols-1 sm:grid-cols-3 space-y-2 sm:space-x-2 sm:space-y-0">
+                  <label htmlFor="libraryCounts" className="col-span-1">
+                    <span className="mr-2">
+                      <FormattedMessage
+                        id="generalSettings.libraryCounts.label"
+                        defaultMessage="Show Library Counts"
+                      />
+                    </span>
+                    <p className="text-sm text-neutral">
+                      <FormattedMessage
+                        id="generalSettings.libraryCounts.description"
+                        defaultMessage="Display the number of items in each library on the homepage"
+                      />
+                    </p>
+                  </label>
+                  <Field
+                    type="checkbox"
+                    id="libraryCounts"
+                    name="libraryCounts"
+                    onChange={() => {
+                      setFieldValue('libraryCounts', !values.libraryCounts);
                     }}
                     className="checkbox-primary checkbox"
                   />

--- a/src/components/Index/Hero/index.tsx
+++ b/src/components/Index/Hero/index.tsx
@@ -151,6 +151,7 @@ export default function Hero() {
               </div>
             </form>
           )}
+          {currentSettings.libraryCounts && (
           <div className="flex flex-wrap space-x-4 items-center max-md:place-content-center mx-4 md:mx-0 mt-3 md:mt-7 mb-3 divide-x-2 divide-accent">
             {mediaLibraries ? (
               mediaLibraries.length > 0 && (
@@ -175,6 +176,7 @@ export default function Hero() {
               <LoadingEllipsis />
             )}
           </div>
+          )}
         </div>
         <div className="md:ps-3 mt-auto mb-20 mx-auto md:mx-0">
           {currentSettings.extendedHome && (

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -17,6 +17,7 @@ const defaultSettings: PublicSettingsResponse = {
   supportUrl: '',
   supportEmail: '',
   extendedHome: true,
+  libraryCounts: true,
   enableSignUp: false,
   statusUrl: '',
   statusEnabled: false,

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -1268,6 +1268,12 @@
   "generalSettings.extendedHome.label": {
     "defaultMessage": "Enable Extended Homepage"
   },
+  "generalSettings.libraryCounts.description": {
+    "defaultMessage": "Display the number of items in each library on the homepage"
+  },
+  "generalSettings.libraryCounts.label": {
+    "defaultMessage": "Show Library Counts"
+  },
   "generalSettings.logo.uploadError": {
     "defaultMessage": "Failed to upload logos"
   },

--- a/src/i18n/locale/es.json
+++ b/src/i18n/locale/es.json
@@ -1280,6 +1280,12 @@
   "generalSettings.extendedHome.label": {
     "defaultMessage": "Habilitar Página de Inicio Extendida"
   },
+  "generalSettings.libraryCounts.description": {
+    "defaultMessage": "Mostrar la cantidad de elementos en cada biblioteca en la página de inicio"
+  },
+  "generalSettings.libraryCounts.label": {
+    "defaultMessage": "Mostrar Conteo de Bibliotecas"
+  },
   "generalSettings.logo.uploadError": {
     "defaultMessage": "Error al subir los logos"
   },


### PR DESCRIPTION
#### Description
This pull request adds a new `libraryCounts` setting to the application, allowing administrators to control whether the number of items in each library is displayed on the homepage. The change is integrated across backend interfaces, frontend components, and internationalization files to ensure consistent functionality and user experience.

**Backend: Settings and API**

* Added the optional `libraryCounts` property to the `PublicSettingsResponse`, `MainSettings`, and `FullPublicSettings` interfaces, allowing this setting to be managed and exposed via the API. [[1]](diffhunk://#diff-40a513ebf788fbd640c7a87c61eafd0531acec6153701802eab3adf2ad1dc3b5R39) [[2]](diffhunk://#diff-520bb25d3321468eb99f5cc0cd44754a1ab93a5502c4d373a3f1477f1d020d96R150) [[3]](diffhunk://#diff-520bb25d3321468eb99f5cc0cd44754a1ab93a5502c4d373a3f1477f1d020d96R175)
* Set a default value for `libraryCounts` in the `Settings` class and ensured it is included when serializing settings for the frontend. [[1]](diffhunk://#diff-520bb25d3321468eb99f5cc0cd44754a1ab93a5502c4d373a3f1477f1d020d96R307) [[2]](diffhunk://#diff-520bb25d3321468eb99f5cc0cd44754a1ab93a5502c4d373a3f1477f1d020d96R537)

**Frontend: Admin and Homepage**

* Added a checkbox for the `libraryCounts` setting in the admin general settings UI, with label and description, and ensured its value is properly handled in form state and submission. [[1]](diffhunk://#diff-5e41efe747e6eb760be28d6f6d768f045017698c3753e16fc932a3646c28365dR867-R891) [[2]](diffhunk://#diff-5e41efe747e6eb760be28d6f6d768f045017698c3753e16fc932a3646c28365dR149) [[3]](diffhunk://#diff-5e41efe747e6eb760be28d6f6d768f045017698c3753e16fc932a3646c28365dR170)
* Updated the homepage hero component to conditionally show library counts based on the `libraryCounts` setting. [[1]](diffhunk://#diff-2c4008491900846a12d3f73e6859c501cf76fd30edced0d4f27f369f6be8d796R154) [[2]](diffhunk://#diff-2c4008491900846a12d3f73e6859c501cf76fd30edced0d4f27f369f6be8d796R179)
* Set a default value for `libraryCounts` in the frontend settings context.

**Internationalization**

* Added English and Spanish translations for the new `libraryCounts` setting label and description. [[1]](diffhunk://#diff-44dad73c083519cc1ee6cc31426a9c033cfd8ed9080b6ac8403bea720d807c72R1271-R1276) [[2]](diffhunk://#diff-57165941d597c813ab1ebe2caa775a092a9eb137ff324ed3b2cb20e2e5898a15R1283-R1288)
