### PR TITLE
refactor: updated Docker build and release workflow and removed old deps

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,76 @@
+name: Streamarr Docker
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build_and_push:
+    name: Build & Publish Docker Images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Get version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            COMMIT_TAG=${{ github.sha }}
+          tags: |
+            nickelsh1ts/streamarr:latest
+            nickelsh1ts/streamarr:${{ steps.version.outputs.version }}
+            ghcr.io/nickelsh1ts/streamarr:latest
+            ghcr.io/nickelsh1ts/streamarr:${{ steps.version.outputs.version }}
+
+  discord:
+    name: Send Discord Notification
+    needs: build_and_push
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Build Job Status
+        uses: technote-space/workflow-conclusion-action@v3
+      - name: Combine Job Status
+        id: status
+        run: |
+          failures=(neutral, skipped, timed_out, action_required)
+          if [[ ${array[@]} =~ $WORKFLOW_CONCLUSION ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+          else
+            echo "status=$WORKFLOW_CONCLUSION" >> $GITHUB_OUTPUT
+          fi
+      - name: Post Status to Discord
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          status: ${{ steps.status.outputs.status }}
+          title: ${{ github.workflow }}
+          nofail: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,12 +61,15 @@ jobs:
       - name: Combine Job Status
         id: status
         run: |
-          failures=(neutral, skipped, timed_out, action_required)
-          if [[ ${array[@]} =~ $WORKFLOW_CONCLUSION ]]; then
-            echo "status=failure" >> $GITHUB_OUTPUT
-          else
-            echo "status=$WORKFLOW_CONCLUSION" >> $GITHUB_OUTPUT
-          fi
+          failures=(neutral skipped timed_out action_required)
+          status="$WORKFLOW_CONCLUSION"
+          for failure in "${failures[@]}"; do
+            if [ "$WORKFLOW_CONCLUSION" = "$failure" ]; then
+              status="failure"
+              break
+            fi
+          done
+          echo "status=$status" >> "$GITHUB_OUTPUT"
       - name: Post Status to Discord
         uses: sarisia/actions-status-discord@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,15 @@ jobs:
       - name: Combine Job Status
         id: status
         run: |
-          failures=(neutral, skipped, timed_out, action_required)
-          if [[ ${array[@]} =~ $WORKFLOW_CONCLUSION ]]; then
-            echo "status=failure" >> $GITHUB_OUTPUT
-          else
-            echo "status=$WORKFLOW_CONCLUSION" >> $GITHUB_OUTPUT
-          fi
+          failures=(neutral skipped timed_out action_required)
+          status="$WORKFLOW_CONCLUSION"
+          for failure in "${failures[@]}"; do
+            if [ "$WORKFLOW_CONCLUSION" = "$failure" ]; then
+              status="failure"
+              break
+            fi
+          done
+          echo "status=$status" >> "$GITHUB_OUTPUT"
       - name: Post Status to Discord
         uses: sarisia/actions-status-discord@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,8 @@ permissions:
   contents: write
 
 jobs:
-  semantic-release:
-    name: Tag and release latest version
+  release:
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -25,33 +25,16 @@ jobs:
         run: npm install -g corepack --force && corepack enable
       - name: Ensure Yarn is correct version
         run: corepack prepare yarn@4.9.2 --activate
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies
         run: yarn
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_TOKEN }}
         run: npx semantic-release
 
   discord:
     name: Send Discord Notification
-    needs: semantic-release
+    needs: release
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "@formatjs/cli": "^6.12.2",
     "@semantic-release/changelog": "6.0.3",
     "@semantic-release/commit-analyzer": "13.0.1",
-    "@semantic-release/exec": "7.1.0",
     "@semantic-release/git": "10.0.1",
     "@svgr/webpack": "8.1.0",
     "@tailwindcss/aspect-ratio": "0.4.2",
@@ -168,7 +167,6 @@
     "prettier-plugin-tailwindcss": "0.7.2",
     "sass": "^1.97.3",
     "semantic-release": "^25.0.3",
-    "semantic-release-docker-buildx": "^1.0.1",
     "stylelint": "^17.3.0",
     "tailwindcss": "3.4.19",
     "ts-node": "^10.9.2",
@@ -196,6 +194,9 @@
     ]
   },
   "release": {
+    "branches": [
+      "main"
+    ],
     "plugins": [
       "@semantic-release/commit-analyzer",
       "@semantic-release/release-notes-generator",
@@ -205,7 +206,12 @@
           "changelogFile": "CHANGELOG.md"
         }
       ],
-      "@semantic-release/npm",
+      [
+        "@semantic-release/npm",
+        {
+          "npmPublish": false
+        }
+      ],
       [
         "@semantic-release/git",
         {
@@ -216,34 +222,12 @@
           "message": "chore(release): ${nextRelease.version}"
         }
       ],
-      "semantic-release-docker-buildx",
       [
         "@semantic-release/github",
         {
           "addReleases": "bottom"
         }
       ]
-    ],
-    "branches": [
-      "main"
-    ],
-    "npmPublish": false,
-    "publish": [
-      {
-        "path": "semantic-release-docker-buildx",
-        "buildArgs": {
-          "COMMIT_TAG": "$GIT_SHA"
-        },
-        "imageNames": [
-          "nickelsh1ts/streamarr",
-          "ghcr.io/nickelsh1ts/streamarr"
-        ],
-        "platforms": [
-          "linux/amd64",
-          "linux/arm64"
-        ]
-      },
-      "@semantic-release/github"
     ]
   },
   "packageManager": "yarn@4.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5581,22 +5581,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@semantic-release/exec@npm:7.1.0":
-  version: 7.1.0
-  resolution: "@semantic-release/exec@npm:7.1.0"
-  dependencies:
-    "@semantic-release/error": "npm:^4.0.0"
-    aggregate-error: "npm:^3.0.0"
-    debug: "npm:^4.0.0"
-    execa: "npm:^9.0.0"
-    lodash-es: "npm:^4.17.21"
-    parse-json: "npm:^8.0.0"
-  peerDependencies:
-    semantic-release: ">=24.1.0"
-  checksum: 10c0/ee9cbc719d39e669304cd3f9dbd2eb9e4808466581b1815e2a039a5d2fb2d1a02660941bb7ff667c0373cde074a755a48c55daba10191a61e5e7f0020852b8ce
-  languageName: node
-  linkType: hard
-
 "@semantic-release/git@npm:10.0.1":
   version: 10.0.1
   resolution: "@semantic-release/git@npm:10.0.1"
@@ -18754,17 +18738,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semantic-release-docker-buildx@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "semantic-release-docker-buildx@npm:1.0.1"
-  dependencies:
-    execa: "npm:^5.0.0"
-  peerDependencies:
-    semantic-release: ">=11.0.0 <18.0.0"
-  checksum: 10c0/cb56e01ff55859092a495865e09f6ab433b3377a77109dbd4fbdf7d9ab2f29373e300d0f58c10e6a1327f7bd5e55dec592fec45172ec3381cce870ad1014834e
-  languageName: node
-  linkType: hard
-
 "semantic-release@npm:^25.0.3":
   version: 25.0.3
   resolution: "semantic-release@npm:25.0.3"
@@ -19578,7 +19551,6 @@ __metadata:
     "@heroicons/react": "npm:^2.2.0"
     "@semantic-release/changelog": "npm:6.0.3"
     "@semantic-release/commit-analyzer": "npm:13.0.1"
-    "@semantic-release/exec": "npm:7.1.0"
     "@semantic-release/git": "npm:10.0.1"
     "@svgr/webpack": "npm:8.1.0"
     "@tailwindcss/aspect-ratio": "npm:0.4.2"
@@ -19680,7 +19652,6 @@ __metadata:
     sass: "npm:^1.97.3"
     secure-random-password: "npm:^0.2.3"
     semantic-release: "npm:^25.0.3"
-    semantic-release-docker-buildx: "npm:^1.0.1"
     sharp: "npm:^0.34.5"
     socket.io: "npm:^4.8.3"
     socket.io-client: "npm:^4.8.3"


### PR DESCRIPTION
#### Description
This pull request refactors the release and Docker image publishing process by moving Docker build and push steps out of the main release workflow and into a dedicated GitHub Actions workflow. It also simplifies the `package.json` release configuration by removing Docker-related plugins and settings, and clarifies the release branch configuration. The most important changes are grouped below.

**CI/CD Workflow Changes:**

* Added a new `.github/workflows/docker.yml` workflow to handle Docker image building and publishing on release events, including multi-platform builds and notifications to Discord.
* Removed Docker build, push, and login steps from `.github/workflows/release.yml`, so the release workflow now only handles semantic versioning and npm publishing.

**Release Configuration Simplification:**

* Removed `semantic-release-docker-buildx` and `@semantic-release/exec` from the `package.json` dependencies and release plugins, cleaning up unused Docker publishing logic. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L117) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L171) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L219-L246)
* Updated the `release` configuration in `package.json` to explicitly set the `main` branch as the release branch and to ensure that `@semantic-release/npm` is configured not to publish to npm. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R197-R199) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R209-R214)

**Workflow Naming Consistency:**

* Renamed the main job in `.github/workflows/release.yml` from `semantic-release` to `release` for clarity and consistency.