### PR TITLE
fix: minor code and bug fixes from review

### DIFF
--- a/public/watch.css
+++ b/public/watch.css
@@ -90,7 +90,7 @@ svg {
   [class*="PrePlayReviewsPage-page-"]{
     margin-left: 14rem;
   }
-  [class=*="Page-page-"] {
+  [class*="Page-page-"] {
     margin-left: 14rem;
   }
 }

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -103,8 +103,18 @@ router.get('/settings/public', async (req, res) => {
 router.get('/libraries', async (req, res, next) => {
   const settings = getSettings();
 
+  const enabledLibraries = settings.plex.libraries
+    .filter((lib) => lib.enabled)
+    .sort((a, b) => parseInt(a.id) - parseInt(b.id));
+
   if (!settings.main.libraryCounts) {
-    return res.status(200).json([]);
+    return res.status(200).json(
+      enabledLibraries.map((lib) => ({
+        id: lib.id,
+        name: lib.name,
+        type: lib.type,
+      }))
+    );
   }
 
   const userRepository = getRepository(User);
@@ -114,10 +124,6 @@ router.get('/libraries', async (req, res, next) => {
       where: { id: 1 },
     });
     const plexApi = new PlexAPI({ plexToken: admin.plexToken });
-
-    const enabledLibraries = settings.plex.libraries
-      .filter((lib) => lib.enabled)
-      .sort((a, b) => parseInt(a.id) - parseInt(b.id));
 
     // Get media counts for each enabled library
     const results = await Promise.all(

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -112,6 +112,7 @@ router.get('/libraries', async (req, res, next) => {
       enabledLibraries.map((lib) => ({
         id: lib.id,
         name: lib.name,
+        enabled: lib.enabled,
         type: lib.type,
       }))
     );
@@ -134,6 +135,7 @@ router.get('/libraries', async (req, res, next) => {
         return {
           id: lib.id,
           name: lib.name,
+          enabled: lib.enabled,
           type: lib.type,
           mediaCount: totalSize,
         };

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -988,10 +988,21 @@ settingsRoutes.get('/about', async (req, res) => {
   } as SettingsAboutResponse);
 });
 
-settingsRoutes.get('/releases', async (_req, res) => {
-  const githubApi = new GithubAPI();
-  const releases = await githubApi.getStreamarrReleases();
-  res.status(200).json(releases);
+settingsRoutes.get('/releases', async (_req, res, next) => {
+  try {
+    const githubApi = new GithubAPI();
+    const releases = await githubApi.getStreamarrReleases();
+    res.status(200).json(releases);
+  } catch (e) {
+    logger.error('Failed to retrieve releases from GitHub', {
+      label: 'Settings',
+      errorMessage: e.message,
+    });
+    next({
+      status: 500,
+      message: 'Unable to retrieve releases from GitHub.',
+    });
+  }
 });
 
 settingsRoutes.get(

--- a/src/components/NotificationList/index.tsx
+++ b/src/components/NotificationList/index.tsx
@@ -134,7 +134,6 @@ const NotificationsList = () => {
         icon: <TrashIcon className="size-7" />,
         message: e.message,
       });
-      throw e;
     } finally {
       revalidate();
     }


### PR DESCRIPTION
This pull request introduces several improvements and fixes across both the frontend and backend. The main highlights include improved error handling for GitHub releases retrieval, a bug fix in a CSS selector, and streamlined logic for returning enabled libraries in the API.

**Backend improvements:**

* Improved error handling in the `/settings/releases` endpoint by adding a try/catch block, logging errors, and returning a 500 error if GitHub releases cannot be retrieved.
* Updated the `/libraries` endpoint to always return a list of enabled libraries (with id, name, and type) even if `libraryCounts` is not set, instead of returning an empty array.
* Refactored the `/libraries` endpoint to avoid redundant filtering and sorting of enabled libraries by moving this logic outside of the conditional block.

**Frontend and style fixes:**

* Fixed a typo in a CSS attribute selector to properly match class names containing `Page-page-`, ensuring correct margin styling is applied.
* Removed an unnecessary `throw` statement in the notification deletion logic to prevent unhandled exceptions in the UI.