### PR TITLE
fix: update excluded colors to new naming conventions

### DIFF
--- a/src/utils/themeUtils.ts
+++ b/src/utils/themeUtils.ts
@@ -10,11 +10,11 @@ export const srgbToLinear = (c: number) => {
 export const getAllTailwindColors = (): string[] => {
   const allColors: string[] = [];
   const excludeColors = [
-    'lightBlue',
-    'warmGray',
-    'trueGray',
-    'coolGray',
-    'blueGray',
+    'sky',
+    'stone',
+    'neutral',
+    'gray',
+    'slate',
     'inherit',
     'current',
     'transparent',


### PR DESCRIPTION
## Description

TailwindCSS renamed some of their default color pallets.

## Has This Been Tested?

No testing really needed

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `yarn build`
- [ ] Translation keys `yarn i18n:extract`
- [ ] Database migration (if required)
