### PR TITLE
fix: enable iframe URL handling and support for query strings

### DIFF
--- a/src/components/Watch/index.tsx
+++ b/src/components/Watch/index.tsx
@@ -61,12 +61,12 @@ const Watch = ({ children, ...props }) => {
         window.location.search +
         window.location.hash;
 
-      const firstHash = parentUrl.indexOf('#');
-      const secondHash =
-        firstHash !== -1 ? parentUrl.indexOf('#', firstHash + 1) : -1;
-      if (secondHash !== -1) {
-        // Collapse double-hashbang: keep only the last #! segment
-        parentUrl = parentUrl.slice(0, firstHash) + parentUrl.slice(secondHash);
+      const firstHashbang = parentUrl.indexOf('#!');
+      const lastHashbang = parentUrl.lastIndexOf('#!');
+      if (firstHashbang !== lastHashbang) {
+        // Collapse duplicate hashbang segments: keep only the last #! segment
+        parentUrl =
+          parentUrl.slice(0, firstHashbang) + parentUrl.slice(lastHashbang);
         window.history.replaceState(
           { ...window.history.state, as: parentUrl, url: parentUrl },
           '',

--- a/src/components/Watch/index.tsx
+++ b/src/components/Watch/index.tsx
@@ -12,8 +12,6 @@ import { colord } from 'colord';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-//TODO: Add support for jellyfin - local users should access jellyfin and plex users access plex
-
 const Watch = ({ children, ...props }) => {
   const { hasPermission } = useUser();
   const isAdmin = hasPermission(Permission.ADMIN);
@@ -53,16 +51,36 @@ const Watch = ({ children, ...props }) => {
 
   // Track the parent window's location for the iframe src
   useEffect(() => {
-    let lastParentUrl = window.location.pathname + window.location.hash;
+    let lastParentUrl =
+      window.location.pathname + window.location.search + window.location.hash;
     let lastIframeUrl = '';
     setIframeUrl(lastParentUrl.replace('/watch', ''));
     const interval = setInterval(() => {
-      const parentUrl = window.location.pathname + window.location.hash;
+      let parentUrl =
+        window.location.pathname +
+        window.location.search +
+        window.location.hash;
+
+      const firstHash = parentUrl.indexOf('#');
+      const secondHash =
+        firstHash !== -1 ? parentUrl.indexOf('#', firstHash + 1) : -1;
+      if (secondHash !== -1) {
+        // Collapse double-hashbang: keep only the last #! segment
+        parentUrl = parentUrl.slice(0, firstHash) + parentUrl.slice(secondHash);
+        window.history.replaceState(
+          { ...window.history.state, as: parentUrl, url: parentUrl },
+          '',
+          parentUrl
+        );
+      }
+
       const iframeUrlNow = innerFrame
-        ? innerFrame.location.pathname + innerFrame.location.hash
+        ? innerFrame.location.pathname +
+          innerFrame.location.search +
+          innerFrame.location.hash
         : '';
 
-      // If parent location changed (sidebar/menu navigation)
+      // If parent location changed (sidebar/menu navigation or Plex parent navigation)
       if (parentUrl !== lastParentUrl) {
         lastParentUrl = parentUrl;
         setIframeUrl(parentUrl.replace('/watch', ''));
@@ -72,7 +90,15 @@ const Watch = ({ children, ...props }) => {
       else if (iframeUrlNow && iframeUrlNow !== lastIframeUrl) {
         lastIframeUrl = iframeUrlNow;
         if ('/watch' + iframeUrlNow !== parentUrl) {
-          window.history.replaceState(null, '', '/watch' + iframeUrlNow);
+          window.history.replaceState(
+            {
+              ...window.history.state,
+              as: '/watch' + iframeUrlNow,
+              url: '/watch' + iframeUrlNow,
+            },
+            '',
+            '/watch' + iframeUrlNow
+          );
           setIframeUrl(iframeUrlNow.replace('/watch', ''));
           lastParentUrl = '/watch' + iframeUrlNow;
         }
@@ -132,7 +158,6 @@ const Watch = ({ children, ...props }) => {
             }, 700);
           }
           e.preventDefault();
-          // console.log('Double click detected!');
         });
       });
     }, 600);


### PR DESCRIPTION
## Description
This pull request improves the URL synchronization logic between the parent window and the embedded iframe in the `Watch` component. The changes ensure that both query parameters and hash fragments are properly handled, and that navigation state remains consistent, especially when dealing with complex hashbang scenarios or navigation events from either the parent or the iframe.

Key improvements to URL synchronization and navigation handling:

* The parent and iframe URLs now include `window.location.search` (query parameters) in addition to `pathname` and `hash`, ensuring full URL synchronization between the parent and the iframe.
* Logic was added to detect and collapse double-hashbangs in the URL, keeping only the last `#!` segment to prevent malformed URLs and navigation issues. The browser history state is updated accordingly using `window.history.replaceState`.
* When the iframe's location changes, the parent window's history state is now updated with the correct `as` and `url` fields, improving navigation consistency and supporting frameworks that rely on these properties.

Minor cleanup:

* Removed a commented-out `console.log` statement related to double-click detection for cleaner code.

## Has This Been Tested?

Tested by navigating to and from and around plex within watch proxy route with and without hashbangs and query strings.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
