### PR TITLE
fix: enhance Plex API error handling and improve plex deleted detection

### DIFF
--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -16,6 +16,7 @@ export interface PlexLibraryItem {
   parentRatingKey?: string;
   grandparentRatingKey?: string;
   title: string;
+  grandparentTitle?: string;
   guid: string;
   parentGuid?: string;
   grandparentGuid?: string;
@@ -24,6 +25,15 @@ export interface PlexLibraryItem {
   Guid?: { id: string }[];
   type: 'movie' | 'show' | 'season' | 'episode';
   Media: Media[];
+}
+
+export class PlexNotFoundError extends Error {
+  public readonly key: string;
+  constructor(key: string) {
+    super(`Plex item not found: ${key}`);
+    this.name = 'PlexNotFoundError';
+    this.key = key;
+  }
 }
 
 interface PlexLibraryResponse {
@@ -212,13 +222,27 @@ class PlexAPI extends ExternalAPI {
     } catch (e) {
       const status = (e as { response?: { status?: number } })?.response
         ?.status;
-      if (status !== 404) {
-        logger.error('Failed to fetch Plex metadata', {
-          label: 'Plex API',
-          errorMessage: e instanceof Error ? e.message : String(e),
-        });
+      if (status === 404) {
+        throw new PlexNotFoundError(key);
       }
+      logger.error('Failed to fetch Plex metadata', {
+        label: 'Plex API',
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
       throw new Error('Failed to fetch Plex metadata');
+    }
+  }
+
+  public async searchByGuid(guid: string): Promise<PlexLibraryItem | null> {
+    if (!guid) return null;
+    try {
+      const response = await this.get<PlexLibraryResponse>('/library/all', {
+        params: { guid, includeGuids: 1 },
+      });
+      const items = response.MediaContainer?.Metadata;
+      return items && items.length > 0 ? items[0] : null;
+    } catch {
+      return null;
     }
   }
 

--- a/server/interfaces/api/userInterfaces.ts
+++ b/server/interfaces/api/userInterfaces.ts
@@ -34,6 +34,7 @@ export interface WatchHistoryItem {
   percentComplete: number;
   plexUrl: string | null;
   deletedFromPlex: boolean;
+  plexThumbReliable: boolean;
 }
 
 export interface UserWatchDataResponse {

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -1297,7 +1297,6 @@ router.get<{ id: string }>(
                   if (recovery === 'same-key') {
                   } else if (recovery) {
                     meta = recovery.meta;
-                    activeKey = recovery.newKey;
                     rekeyedMap.set(key, recovery.newKey);
                   } else {
                     deletedKeys.add(key);

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -1,4 +1,7 @@
-import PlexAPI, { type PlexMetadata } from '@server/api/plexapi';
+import PlexAPI, {
+  PlexNotFoundError,
+  type PlexMetadata,
+} from '@server/api/plexapi';
 import PlexTvAPI from '@server/api/plextv';
 import SeerrAPI from '@server/api/seerr';
 import TautulliAPI, { type TautulliHistoryRecord } from '@server/api/tautulli';
@@ -1190,6 +1193,7 @@ router.get<{ id: string }>(
             ? `/watch/web/index.html#!/server/${machineId}/details?key=/library/metadata/${record.rating_key}`
             : null,
           deletedFromPlex: false,
+          plexThumbReliable: true,
         };
       });
 
@@ -1209,32 +1213,98 @@ router.get<{ id: string }>(
           const posterMap = new Map<string, string>();
           const backdropMap = new Map<string, string>();
           const deletedKeys = new Set<string>();
+          const rekeyedMap = new Map<string, string>();
+
+          const normalizeTitle = (t: string) =>
+            t
+              .normalize('NFC')
+              .replace(/\s*\(\d{4}\)\s*/g, ' ')
+              .replace(/[:\-–—]/g, ' ')
+              .replace(/[^\w\s]/g, '')
+              .replace(/\s+/g, ' ')
+              .trim();
+
+          const recoverByGuid = async (
+            record: TautulliHistoryRecord,
+            currentKey: string
+          ): Promise<
+            { meta: PlexMetadata; newKey: string } | 'same-key' | null
+          > => {
+            if (!record.guid) return null;
+            const guidItem = await plexApi.searchByGuid(record.guid);
+            if (!guidItem) return null;
+            const newKey =
+              record.media_type === 'episode'
+                ? guidItem.grandparentRatingKey
+                : guidItem.ratingKey;
+            if (!newKey) return null;
+            if (newKey === currentKey) return 'same-key';
+            try {
+              const recoveredMeta = await plexApi.getMetadata(newKey);
+              return { meta: recoveredMeta, newKey };
+            } catch {
+              return null;
+            }
+          };
 
           await Promise.allSettled(
             uniqueKeys.map(async (key) => {
               let meta: PlexMetadata | null = null;
+              let activeKey = key;
               const record = showKeyToRecord.get(key);
 
               try {
                 meta = await plexApi.getMetadata(key);
-              } catch {
-                deletedKeys.add(key);
-              }
-
-              if (meta) {
-                const expected =
-                  record?.media_type === 'movie'
-                    ? record.title?.toLowerCase().trim()
-                    : record?.grandparent_title?.toLowerCase().trim();
-                const actual = meta.title?.toLowerCase().trim();
-                if (expected && actual && expected !== actual) {
-                  deletedKeys.add(key);
-                  meta = null;
+              } catch (e) {
+                if (e instanceof PlexNotFoundError) {
+                  if (record) {
+                    const recovery = await recoverByGuid(record, key);
+                    if (recovery && recovery !== 'same-key') {
+                      meta = recovery.meta;
+                      activeKey = recovery.newKey;
+                      rekeyedMap.set(key, recovery.newKey);
+                    } else {
+                      deletedKeys.add(key);
+                    }
+                  } else {
+                    deletedKeys.add(key);
+                  }
+                } else {
+                  logger.warn(
+                    'Plex metadata lookup failed for watch history item; skipping deletion check',
+                    {
+                      label: 'API',
+                      key,
+                      errorMessage: e instanceof Error ? e.message : String(e),
+                    }
+                  );
                 }
               }
-              const tmdbGuid = meta?.Guid?.find((g) =>
-                g.id.startsWith('tmdb://')
-              );
+
+              if (meta && record) {
+                const expected =
+                  record.media_type === 'movie'
+                    ? record.title?.toLowerCase().trim()
+                    : record.grandparent_title?.toLowerCase().trim();
+                const actual = meta.title?.toLowerCase().trim();
+
+                if (
+                  expected &&
+                  actual &&
+                  normalizeTitle(expected) !== normalizeTitle(actual)
+                ) {
+                  const recovery = await recoverByGuid(record, activeKey);
+                  if (recovery === 'same-key') {
+                  } else if (recovery) {
+                    meta = recovery.meta;
+                    activeKey = recovery.newKey;
+                    rekeyedMap.set(key, recovery.newKey);
+                  } else {
+                    deletedKeys.add(key);
+                    meta = null;
+                  }
+                }
+              }
 
               let tmdbDetails: {
                 poster_path?: string | null;
@@ -1242,21 +1312,7 @@ router.get<{ id: string }>(
                 overview?: string | null;
               } | null = null;
 
-              if (tmdbGuid) {
-                const tmdbId = parseInt(tmdbGuid.id.replace('tmdb://', ''), 10);
-                if (!isNaN(tmdbId)) {
-                  try {
-                    const isMovie = meta?.type === 'movie';
-                    tmdbDetails = isMovie
-                      ? await tmdb.getMovie({ movieId: tmdbId })
-                      : await tmdb.getTvShow({ tvId: tmdbId });
-                  } catch {
-                    // TMDB lookup is best-effort
-                  }
-                }
-              }
-
-              if (!tmdbDetails && record) {
+              if (record) {
                 try {
                   const isEpisode = record.media_type === 'episode';
                   const searchTitle = isEpisode
@@ -1265,8 +1321,19 @@ router.get<{ id: string }>(
                   const searchResult = isEpisode
                     ? await tmdb.searchTvShows({ query: searchTitle })
                     : await tmdb.searchMovies({ query: searchTitle });
-                  if (searchResult.results.length)
-                    tmdbDetails = searchResult.results[0];
+                  if (searchResult.results.length) {
+                    const normalizedSearch = searchTitle.trim().toLowerCase();
+                    const exactMatch = searchResult.results.find(
+                      (r) =>
+                        (r as { title?: string; name?: string }).title
+                          ?.trim()
+                          .toLowerCase() === normalizedSearch ||
+                        (r as { title?: string; name?: string }).name
+                          ?.trim()
+                          .toLowerCase() === normalizedSearch
+                    );
+                    tmdbDetails = exactMatch ?? searchResult.results[0];
+                  }
                 } catch {
                   // Title search is best-effort
                 }
@@ -1289,9 +1356,15 @@ router.get<{ id: string }>(
             result.posterPath = posterMap.get(key) ?? null;
             result.backdropPath = backdropMap.get(key) ?? null;
             result.deletedFromPlex = deletedKeys.has(key);
+            result.plexThumbReliable =
+              !result.deletedFromPlex && !rekeyedMap.has(key);
 
             if (result.deletedFromPlex) {
               result.plexUrl = null;
+            } else if (rekeyedMap.has(key) && machineId) {
+              const newKey = rekeyedMap.get(key)!;
+              result.plexUrl = `/watch/web/index.html#!/server/${machineId}/details?key=/library/metadata/${newKey}`;
+              result.thumb = `/library/metadata/${newKey}/thumb`;
             }
           }
         }

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -1294,11 +1294,10 @@ router.get<{ id: string }>(
                   normalizeTitle(expected) !== normalizeTitle(actual)
                 ) {
                   const recovery = await recoverByGuid(record, activeKey);
-                  if (recovery === 'same-key') {
-                  } else if (recovery) {
+                  if (recovery && recovery !== 'same-key') {
                     meta = recovery.meta;
                     rekeyedMap.set(key, recovery.newKey);
-                  } else {
+                  } else if (!recovery) {
                     deletedKeys.add(key);
                     meta = null;
                   }

--- a/src/components/Common/Slider/RecentlyWatched.tsx
+++ b/src/components/Common/Slider/RecentlyWatched.tsx
@@ -27,9 +27,13 @@ const RecentlyWatched = ({ item }: { item?: WatchHistoryItem }) => {
   const tmdbPosterUrl = item?.posterPath
     ? `https://image.tmdb.org/t/p/w342${item.posterPath}`
     : null;
+  const plexThumbReliable = item?.plexThumbReliable ?? true;
   const [posterSrc, setPosterSrc] = useState<string | null>(
-    thumbUrl ?? tmdbPosterUrl ?? null
+    plexThumbReliable
+      ? (thumbUrl ?? tmdbPosterUrl ?? null)
+      : (tmdbPosterUrl ?? thumbUrl ?? null)
   );
+  const triedSrcs = useRef(new Set<string>());
 
   const handleClickOutside = useCallback(() => {
     if (isTouch) setShowDetail(false);
@@ -55,9 +59,14 @@ const RecentlyWatched = ({ item }: { item?: WatchHistoryItem }) => {
           sizes="(min-width: 640px) 176px, 144px"
           className="object-cover"
           onError={() => {
-            if (tmdbPosterUrl && posterSrc !== tmdbPosterUrl) {
-              setPosterSrc(tmdbPosterUrl);
-            }
+            if (posterSrc) triedSrcs.current.add(posterSrc);
+            const candidates = plexThumbReliable
+              ? [thumbUrl, tmdbPosterUrl]
+              : [tmdbPosterUrl, thumbUrl];
+            const next = candidates.find(
+              (url) => url && !triedSrcs.current.has(url)
+            );
+            setPosterSrc(next ?? null);
           }}
         />
       ) : (

--- a/src/components/Common/Slider/RecentlyWatched.tsx
+++ b/src/components/Common/Slider/RecentlyWatched.tsx
@@ -1,7 +1,7 @@
 import { withProperties } from '@app/utils/typeHelpers';
 import type { WatchHistoryItem } from '@server/interfaces/api/userInterfaces';
 import { FilmIcon, TvIcon } from '@heroicons/react/24/solid';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { useInView } from '@app/hooks/useElementInView';
 import { useIsTouch } from '@app/hooks/useIsTouch';
 import useClickOutside from '@app/hooks/useClickOutside';
@@ -28,12 +28,16 @@ const RecentlyWatched = ({ item }: { item?: WatchHistoryItem }) => {
     ? `https://image.tmdb.org/t/p/w342${item.posterPath}`
     : null;
   const plexThumbReliable = item?.plexThumbReliable ?? true;
-  const [posterSrc, setPosterSrc] = useState<string | null>(
-    plexThumbReliable
-      ? (thumbUrl ?? tmdbPosterUrl ?? null)
-      : (tmdbPosterUrl ?? thumbUrl ?? null)
+  const candidates = useMemo(
+    () =>
+      (plexThumbReliable
+        ? [thumbUrl, tmdbPosterUrl]
+        : [tmdbPosterUrl, thumbUrl]
+      ).filter((u): u is string => !!u),
+    [thumbUrl, tmdbPosterUrl, plexThumbReliable]
   );
-  const triedSrcs = useRef(new Set<string>());
+  const [posterIdx, setPosterIdx] = useState(0);
+  const posterSrc = candidates[posterIdx] ?? null;
 
   const handleClickOutside = useCallback(() => {
     if (isTouch) setShowDetail(false);
@@ -58,16 +62,7 @@ const RecentlyWatched = ({ item }: { item?: WatchHistoryItem }) => {
           fill
           sizes="(min-width: 640px) 176px, 144px"
           className="object-cover"
-          onError={() => {
-            if (posterSrc) triedSrcs.current.add(posterSrc);
-            const candidates = plexThumbReliable
-              ? [thumbUrl, tmdbPosterUrl]
-              : [tmdbPosterUrl, thumbUrl];
-            const next = candidates.find(
-              (url) => url && !triedSrcs.current.has(url)
-            );
-            setPosterSrc(next ?? null);
-          }}
+          onError={() => setPosterIdx((i) => i + 1)}
         />
       ) : (
         <div className="absolute inset-0 flex items-center justify-center bg-base-300">

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -102,14 +102,15 @@ const UserProfile = () => {
       : null
   );
 
-  const { data: seerrUserQuota } = useSWR<SeerrQuotaResponse>(
-    user &&
-      currentSettings.seerrEnabled &&
-      (user.id === currentUser?.id ||
-        currentHasPermission(Permission.MANAGE_USERS))
-      ? `/api/v1/user/${user.id}/settings/seerr/quota`
-      : null
-  );
+  const { data: seerrUserQuota, error: seerrUserQuotaError } =
+    useSWR<SeerrQuotaResponse>(
+      user &&
+        currentSettings.seerrEnabled &&
+        (user.id === currentUser?.id ||
+          currentHasPermission(Permission.MANAGE_USERS))
+        ? `/api/v1/user/${user.id}/settings/seerr/quota`
+        : null
+    );
 
   if (!user && !error) {
     return <LoadingEllipsis />;
@@ -320,7 +321,7 @@ const UserProfile = () => {
               <Placeholder />
             )
           ) : null}
-          {currentSettings.seerrEnabled ? (
+          {currentSettings.seerrEnabled && !seerrUserQuotaError ? (
             seerrUserQuota ? (
               <div
                 className={`overflow-hidden rounded-lg bg-primary bg-opacity-30 backdrop-blur px-4 py-5 shadow ring-1 ring-primary ${

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -865,6 +865,9 @@ components:
         deletedFromPlex:
           type: boolean
           example: false
+        plexThumbReliable:
+          type: boolean
+          example: true
     SeerrRequestItem:
       type: object
       properties:


### PR DESCRIPTION
## Description
This pull request introduces improvements to how Plex watch history items are handled, particularly around detection and recovery of deleted or re-keyed Plex items, and enhances the reliability of displayed poster images. It adds new backend logic to recover Plex metadata by GUID if an item is missing, exposes a `plexThumbReliable` flag to indicate whether the Plex thumbnail can be trusted, and adjusts the frontend to use this flag to determine poster image fallback order. Additionally, it improves TMDB search result matching and ensures that UI elements handle errors more gracefully.

**Backend: Plex metadata recovery and reliability flag**

- Added a `PlexNotFoundError` class and updated `PlexAPI` to throw this error when a Plex item is not found, enabling more granular error handling and recovery attempts. Also added a `searchByGuid` method to recover items by GUID, and updated the user watch history route to use these for improved deleted/re-keyed item detection and recovery. (`server/api/plexapi.ts` [[1]](diffhunk://#diff-f8d2f7a69a7f98aa09e6b5dc460b42bc071ebb8d43de3c118ad2ad1a066843feR30-R38) [[2]](diffhunk://#diff-f8d2f7a69a7f98aa09e6b5dc460b42bc071ebb8d43de3c118ad2ad1a066843feL215-R248); `server/routes/user/index.ts` [[3]](diffhunk://#diff-20f9b030a139bdbd17c8a67a791feeef0c2a22aac142d68c15777cef4e6bf792L1-R4) [[4]](diffhunk://#diff-20f9b030a139bdbd17c8a67a791feeef0c2a22aac142d68c15777cef4e6bf792R1216-R1315)
- Introduced a `plexThumbReliable` boolean property to the `WatchHistoryItem` interface and set it in the API response, indicating whether the Plex thumbnail is trustworthy for each item. (`server/interfaces/api/userInterfaces.ts` [[1]](diffhunk://#diff-ebfc63f0476d9af59069158f8988650cebc2543fa7c842e9668837d64ebaaa54R37); `server/routes/user/index.ts` [[2]](diffhunk://#diff-20f9b030a139bdbd17c8a67a791feeef0c2a22aac142d68c15777cef4e6bf792R1196) [[3]](diffhunk://#diff-20f9b030a139bdbd17c8a67a791feeef0c2a22aac142d68c15777cef4e6bf792R1359-R1367); `streamarr-api.yml` [[4]](diffhunk://#diff-1a2f279e1cf35c001c0d38699b4acf12a46cd45d0a56ef800474999c27c40d99R868-R870)

**Frontend: Poster image fallback and UI robustness**

- Updated the `RecentlyWatched` component to use the new `plexThumbReliable` flag, changing the order of poster image fallbacks (Plex thumb vs. TMDB poster) based on the flag, and improved error handling for image loading. (`src/components/Common/Slider/RecentlyWatched.tsx` [[1]](diffhunk://#diff-cea90e6312063872eb5c4c3cc48141613cbc22a4d21d7a03d5ba43deab73f369R30-R36) [[2]](diffhunk://#diff-cea90e6312063872eb5c4c3cc48141613cbc22a4d21d7a03d5ba43deab73f369L58-R69)
- Improved TMDB search result handling by prioritizing exact title matches when recovering metadata, leading to more accurate poster and backdrop selection. (`server/routes/user/index.ts` [server/routes/user/index.tsL1268-R1336](diffhunk://#diff-20f9b030a139bdbd17c8a67a791feeef0c2a22aac142d68c15777cef4e6bf792L1268-R1336))
- Enhanced the `UserProfile` component to hide quota information if there is an error fetching it, preventing UI errors. (`src/components/UserProfile/index.tsx` [[1]](diffhunk://#diff-27c5434488f8869fccc38bdeefa03d1db89264aeb5b8dbee86d8004d26ab7e88L105-R106) [[2]](diffhunk://#diff-27c5434488f8869fccc38bdeefa03d1db89264aeb5b8dbee86d8004d26ab7e88L323-R324)

**Other minor changes**

- Added `grandparentTitle` to the `PlexLibraryItem` interface for improved episode metadata handling. (`server/api/plexapi.ts` [server/api/plexapi.tsR19](diffhunk://#diff-f8d2f7a69a7f98aa09e6b5dc460b42bc071ebb8d43de3c118ad2ad1a066843feR19))

## Has This Been Tested?

Tested on an existing database and compared recently watched items to reality for accuracy and am satisfied.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
