### PR TITLE
feat: add live tv menu item with per user access

### DIFF
--- a/docs/using-streamarr/settings/README.md
+++ b/docs/using-streamarr/settings/README.md
@@ -221,6 +221,22 @@ Configure the default invite quota settings for new users:
 - **Quota Limit** — Maximum number of invites a user can create
 - **Quota Days** — Time period (in days) for the quota to reset
 
+### Default Invite Settings
+
+Configure the default feature access granted when creating new invites:
+
+| Setting                    | Description                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------ |
+| **Allow Downloads**        | Grant download management access to invited users by default                               |
+| **Allow Live TV Access**   | Show the Live TV navigation item for invited users by default                              |
+| **Allow Plex Home Access** | Add invited users to Plex Home by default (creates a managed user under your Plex account) |
+
+These defaults pre-fill the corresponding toggles when creating new invites. Individual invites can always override these defaults.
+
+{% hint style="info" %}
+**Live TV Access** controls per-user nav visibility in Streamarr. It does not send any permission to Plex — modern Plex Live TV (DVR/OTA) is available to all Plex server members when configured with Plex Pass. This toggle simply controls whether the Live TV shortcut appears in a user's Streamarr navigation.
+{% endhint %}
+
 ---
 
 ## Trial Period

--- a/server/routes/signup.ts
+++ b/server/routes/signup.ts
@@ -366,7 +366,6 @@ signupRoutes.post('/plexauth', async (req, res) => {
             libraries: librarySectionIds,
             allow_sync: invite.downloads ?? false,
             allow_camera_upload: false,
-            allow_channels: invite.liveTv ?? false,
             plex_home: invite.plexHome ?? false,
             plex_base_url,
             user_token: user.plexToken,
@@ -621,6 +620,7 @@ signupRoutes.post('/localauth', async (req, res) => {
     } else {
       user.settings = new UserSettings();
     }
+    user.settings.allowLiveTv = invite.liveTv ?? false;
 
     if (
       settings.main.enableTrialPeriod &&

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -44,8 +44,8 @@ userSettingsRoutes.get<{ id: string }, UserSettingsGeneralResponse>(
         defaultQuotas,
         sharedLibraries: defaultSharedLibraries,
         downloads,
-        liveTv,
         plexHome,
+        liveTv: globalLiveTv,
         enableTrialPeriod,
         trialPeriodDays,
         releaseSched,
@@ -80,7 +80,7 @@ userSettingsRoutes.get<{ id: string }, UserSettingsGeneralResponse>(
         globalInvitesExpiryLimit: defaultQuotas.invites.quotaExpiryLimit,
         globalInvitesExpiryTime: defaultQuotas.invites.quotaExpiryTime,
         globalAllowDownloads: downloads,
-        globalLiveTv: liveTv,
+        globalLiveTv: globalLiveTv,
         globalPlexHome: plexHome,
         sharedLibraries: user.settings?.sharedLibraries ?? null,
         allowDownloads: user.settings?.allowDownloads ?? false,
@@ -129,13 +129,11 @@ userSettingsRoutes.post<
     // Store previous sharedLibraries value to detect changes
     const previousSharedLibraries = user.settings?.sharedLibraries;
     const previousAllowDownloads = user.settings?.allowDownloads;
-    const previousAllowLiveTv = user.settings?.allowLiveTv;
     const newSharedLibraries =
       req.body.sharedLibraries === '' || req.body.sharedLibraries === 'server'
         ? null
         : req.body.sharedLibraries;
     const newAllowDownloads = req.body.allowDownloads;
-    const newAllowLiveTv = req.body.allowLiveTv;
     const forcePlexSync = req.body.forcePlexSync === true;
 
     user.username = req.body.username;
@@ -193,7 +191,6 @@ userSettingsRoutes.post<
     const shouldSync =
       previousSharedLibraries !== newSharedLibraries ||
       previousAllowDownloads !== newAllowDownloads ||
-      previousAllowLiveTv !== newAllowLiveTv ||
       forcePlexSync;
 
     if (
@@ -207,7 +204,6 @@ userSettingsRoutes.post<
         await plexSync.syncUserLibraries(user, syncValue, {
           allowSync: req.body.allowDownloads,
           allowCameraUpload: false,
-          allowChannels: req.body.allowLiveTv,
           plexHome: false,
         });
       } catch (syncError) {

--- a/src/components/Layout/LibraryMenu/index.tsx
+++ b/src/components/Layout/LibraryMenu/index.tsx
@@ -114,6 +114,9 @@ const LibraryMenu = ({
     'other',
   ];
 
+  const liveTvDisabled =
+    !userSettings?.allowLiveTv && !hasPermission(Permission.ADMIN);
+
   const MenuLinks: MenuLinksProps[] = [
     {
       href: '/watch/web/index.html#!/media/tv.plex.provider.discover?source=home&pivot=discover.recommended',
@@ -165,6 +168,16 @@ const LibraryMenu = ({
       icon: <QueueListIcon className="w-7 h-7" />,
       regExp: 'source=playlists',
       hidden: !enablePlaylists,
+    },
+    {
+      href: '/watch/web/index.html#!/live-tv',
+      title: intl.formatMessage({
+        id: 'library.liveTV',
+        defaultMessage: 'Live TV',
+      }),
+      icon: <TvIcon className="h-7 w-7" />,
+      regExp: 'live-tv',
+      hidden: liveTvDisabled,
     },
   ];
 

--- a/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
@@ -46,8 +46,7 @@ const UserSettingsGeneral = () => {
   const [plexLibrariesDiffer, setPlexLibrariesDiffer] = useState(false);
   const [plexPermissionsDiffer, setPlexPermissionsDiffer] = useState<{
     allowDownloads: boolean;
-    allowLiveTv: boolean;
-  }>({ allowDownloads: false, allowLiveTv: false });
+  }>({ allowDownloads: false });
   const searchParams = useParams<{ userid: string }>();
   const {
     user,
@@ -102,7 +101,7 @@ const UserSettingsGeneral = () => {
   useEffect(() => {
     if (!data || !plexLibrariesData?.canFetchFromPlex) {
       setPlexLibrariesDiffer(false);
-      setPlexPermissionsDiffer({ allowDownloads: false, allowLiveTv: false });
+      setPlexPermissionsDiffer({ allowDownloads: false });
       return;
     }
 
@@ -144,11 +143,10 @@ const UserSettingsGeneral = () => {
     // === Permission comparison ===
     const plexPerms = plexLibrariesData.permissions;
     if (!plexPerms) {
-      setPlexPermissionsDiffer({ allowDownloads: false, allowLiveTv: false });
+      setPlexPermissionsDiffer({ allowDownloads: false });
     } else {
       setPlexPermissionsDiffer({
         allowDownloads: (data.allowDownloads ?? false) !== plexPerms.allowSync,
-        allowLiveTv: (data.allowLiveTv ?? false) !== plexPerms.allowChannels,
       });
     }
   }, [data, plexLibrariesData, allLibrariesData]);
@@ -218,9 +216,7 @@ const UserSettingsGeneral = () => {
           const canManageUsers = currentHasPermission(Permission.MANAGE_USERS);
 
           const shouldForceSync =
-            (plexLibrariesDiffer ||
-              plexPermissionsDiffer.allowDownloads ||
-              plexPermissionsDiffer.allowLiveTv) &&
+            (plexLibrariesDiffer || plexPermissionsDiffer.allowDownloads) &&
             isPlexUser &&
             canManageUsers;
 
@@ -646,8 +642,7 @@ const UserSettingsGeneral = () => {
                         </div>
                         <div className="col-span-1"></div>
                         <div className="col-span-2">
-                          {(plexPermissionsDiffer.allowDownloads ||
-                            plexPermissionsDiffer.allowLiveTv) && (
+                          {plexPermissionsDiffer.allowDownloads && (
                             <>
                               <div className="text-sm text-warning">
                                 <ExclamationTriangleIcon className="inline h-5 w-5 mr-1" />
@@ -669,20 +664,6 @@ const UserSettingsGeneral = () => {
                                     )}
                                   </span>
                                 )}
-                                {plexPermissionsDiffer.allowLiveTv && (
-                                  <span className="font-bold ml-1">
-                                    <FormattedMessage
-                                      id="settings.allowLiveTv"
-                                      defaultMessage=" Allow Live TV Access"
-                                    />
-                                    {plexLibrariesData?.permissions
-                                      ?.allowChannels ? (
-                                      <CheckCircleIcon className="inline h-5 w-5 ml-1 text-success mb-0.5" />
-                                    ) : (
-                                      <XCircleIcon className="inline h-5 w-5 ml-1 text-error mb-0.5" />
-                                    )}
-                                  </span>
-                                )}
                                 <FormattedMessage
                                   id="settings.saveChangesToSync"
                                   defaultMessage=" Save changes to sync."
@@ -691,11 +672,8 @@ const UserSettingsGeneral = () => {
                             </>
                           )}
                           {plexLibrariesData?.permissions &&
-                            (values.allowDownloads !==
-                              plexLibrariesData.permissions.allowSync ||
-                              values.allowLiveTv !==
-                                plexLibrariesData.permissions
-                                  .allowChannels) && (
+                            values.allowDownloads !==
+                              plexLibrariesData.permissions.allowSync && (
                               <div className="text-sm text-error">
                                 <ExclamationCircleIcon className="inline h-5 w-5 mr-1" />
                                 <FormattedMessage

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -288,7 +288,7 @@ components:
         liveTv:
           type: boolean
           example: false
-          description: Enable live TV feature globally
+          description: Default Live TV access for new invites
         plexHome:
           type: boolean
           example: false


### PR DESCRIPTION
## Description
This pull request refines how Live TV access is managed for users, moving away from syncing Live TV permissions directly with Plex and instead making Live TV a Streamarr-specific navigation feature. The changes clarify the distinction between Streamarr's Live TV navigation toggle and Plex's permissions, update the default invite settings documentation, and streamline related backend and frontend logic.

**Live TV Access Management:**

* Updated documentation to clarify that "Allow Live TV Access" controls only the visibility of the Live TV navigation item in Streamarr, not Plex permissions. Added a detailed note explaining this distinction. [[1]](diffhunk://#diff-5ce44cb0b23d075adeca73012f66ca40d157ee3439acb7fba52c8a259dc1f0afR224-R239) [[2]](diffhunk://#diff-1a2f279e1cf35c001c0d38699b4acf12a46cd45d0a56ef800474999c27c40d99L291-R291)
* Removed backend logic that attempted to sync Live TV access (`allowChannels`) with Plex when creating users or updating settings; Live TV access is now handled solely within Streamarr's user settings. [[1]](diffhunk://#diff-060c69815f04453023d851a63587ec56bf8e10bf0a554615560adc24cff16fe9L369) [[2]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L47-R48) [[3]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L83-R83) [[4]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L132-L138) [[5]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L196) [[6]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L210) [[7]](diffhunk://#diff-060c69815f04453023d851a63587ec56bf8e10bf0a554615560adc24cff16fe9R623)

**Frontend Updates:**

* Updated the library menu to conditionally show or hide the Live TV navigation item based on the user's `allowLiveTv` setting and admin permissions. [[1]](diffhunk://#diff-57f786e24554dc584951006e94ed2010fb9a5304c92f168b7e27036dfad87ca0R117-R119) [[2]](diffhunk://#diff-57f786e24554dc584951006e94ed2010fb9a5304c92f168b7e27036dfad87ca0R172-R181)
* Simplified the user settings page by removing Live TV permission sync checks and related UI elements, since Live TV access is now Streamarr-specific and not a Plex permission. [[1]](diffhunk://#diff-b6475f5bac1d99bed8c599571a99dbfbfabebcb8d20d4a5d69f8dd6545a429f4L49-R49) [[2]](diffhunk://#diff-b6475f5bac1d99bed8c599571a99dbfbfabebcb8d20d4a5d69f8dd6545a429f4L105-R104) [[3]](diffhunk://#diff-b6475f5bac1d99bed8c599571a99dbfbfabebcb8d20d4a5d69f8dd6545a429f4L147-L151) [[4]](diffhunk://#diff-b6475f5bac1d99bed8c599571a99dbfbfabebcb8d20d4a5d69f8dd6545a429f4L221-R219) [[5]](diffhunk://#diff-b6475f5bac1d99bed8c599571a99dbfbfabebcb8d20d4a5d69f8dd6545a429f4L649-R645) [[6]](diffhunk://#diff-b6475f5bac1d99bed8c599571a99dbfbfabebcb8d20d4a5d69f8dd6545a429f4L672-L685) [[7]](diffhunk://#diff-b6475f5bac1d99bed8c599571a99dbfbfabebcb8d20d4a5d69f8dd6545a429f4L694-R676)

**Default Invite Settings:**

* Added documentation and internal handling for default invite settings, including Live TV access, downloads, and Plex Home, to pre-fill options when creating new invites.

## Has This Been Tested?

Tested using both admin users and regular with and without live TV access

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
