### PR TITLE
fix(auth): resolve Plex OAuth client ID mismatch

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -157,7 +157,7 @@ app
     // Set up sessions
     const sessionRepository = getRepository(Session);
     const sessionMiddleware = session({
-      secret: settings.clientId,
+      secret: settings.sessionSecret,
       resave: false,
       saveUninitialized: false,
       name: 'streamarr.sid',

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -54,6 +54,7 @@ export interface PublicSettingsResponse {
   customLogo?: string;
   customLogoSmall?: string;
   theme: Theme;
+  plexClientIdentifier: string;
 }
 
 export interface CacheItem {

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomBytes, randomUUID } from 'crypto';
 import fs from 'fs';
 import { merge } from 'lodash';
 import path from 'path';
@@ -195,6 +195,7 @@ export interface FullPublicSettings extends PublicSettings {
   statusUrl: string;
   statusEnabled: boolean;
   theme: Theme;
+  plexClientIdentifier: string;
 }
 
 export interface NotificationAgentConfig {
@@ -265,6 +266,7 @@ export type JobId =
 
 interface AllSettings {
   clientId: string;
+  sessionSecret?: string;
   vapidPublic: string;
   vapidPrivate: string;
   main: MainSettings;
@@ -297,6 +299,7 @@ class Settings {
   constructor(initialSettings?: AllSettings) {
     this.data = {
       clientId: randomUUID(),
+      sessionSecret: '',
       vapidPrivate: '',
       vapidPublic: '',
       main: {
@@ -582,6 +585,7 @@ class Settings {
       statusUrl: this.data.uptime.externalUrl,
       statusEnabled: this.data.uptime.enabled,
       theme: this.data.main.theme,
+      plexClientIdentifier: this.clientId,
     };
   }
 
@@ -616,6 +620,15 @@ class Settings {
     }
 
     return this.data.clientId;
+  }
+
+  get sessionSecret(): string {
+    if (!this.data.sessionSecret) {
+      this.data.sessionSecret = randomBytes(32).toString('hex');
+      this.save();
+    }
+
+    return this.data.sessionSecret;
   }
 
   get vapidPublic(): string {

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -28,6 +28,7 @@ const defaultSettings: PublicSettingsResponse = {
   statusEnabled: false,
   customLogo: undefined,
   customLogoSmall: undefined,
+  plexClientIdentifier: '',
   theme: {
     primary: '#974ede',
     'primary-content': '#fff',

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -21,37 +21,26 @@ export interface PlexPin {
   code: string;
 }
 
-const uuidv4 = (): string => {
-  return ((1e7).toString() + -1e3 + -4e3 + -8e3 + -1e11).replace(
-    /[018]/g,
-    function (c) {
-      return (
-        parseInt(c) ^
-        (window.crypto.getRandomValues(new Uint8Array(1))[0] &
-          (15 >> (parseInt(c) / 4)))
-      ).toString(16);
-    }
-  );
-};
-
 class PlexOAuth {
   private plexHeaders?: PlexHeaders;
   private pin?: PlexPin;
   private popup?: Window;
   private authToken?: string;
 
-  public initializeHeaders(applicationTitle: string): void {
-    if (!window) {
+  public initializeHeaders(
+    applicationTitle: string,
+    plexClientIdentifier: string
+  ): void {
+    if (typeof window === 'undefined') {
       throw new Error(
         'Window is not defined. Are you calling this in the browser?'
       );
     }
 
-    let clientId = localStorage.getItem('plex-client-id');
-    if (!clientId) {
-      const uuid = uuidv4();
-      localStorage.setItem('plex-client-id', uuid);
-      clientId = uuid;
+    if (!plexClientIdentifier) {
+      throw new Error(
+        'Plex client identifier missing. Reload the page and try again.'
+      );
     }
 
     const browser = Bowser.getParser(window.navigator.userAgent);
@@ -59,7 +48,7 @@ class PlexOAuth {
       Accept: 'application/json',
       'X-Plex-Product': applicationTitle,
       'X-Plex-Version': '0.00.1',
-      'X-Plex-Client-Identifier': clientId,
+      'X-Plex-Client-Identifier': plexClientIdentifier,
       'X-Plex-Model': 'Plex OAuth',
       'X-Plex-Platform': browser.getBrowserName(),
       'X-Plex-Platform-Version': browser.getBrowserVersion(),
@@ -95,7 +84,10 @@ class PlexOAuth {
   public async login(): Promise<string> {
     const res = await fetch(`/api/v1/settings/public`, { cache: 'no-store' });
     const currentSettings: PublicSettingsResponse = await res.json();
-    this.initializeHeaders(currentSettings.applicationTitle);
+    this.initializeHeaders(
+      currentSettings.applicationTitle,
+      currentSettings.plexClientIdentifier
+    );
     await this.getPin();
 
     if (!this.plexHeaders || !this.pin) {

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -1343,6 +1343,11 @@ components:
         newPlexLogin:
           type: boolean
           example: true
+        plexClientIdentifier:
+          type: string
+          format: uuid
+          description: Instance Plex OAuth client identifier
+          example: 6919275e-142a-48d8-be6b-93594cbd4626
         supportUrl:
           type: string
           example: 'https://support.example.com'


### PR DESCRIPTION
## Description

Separates session signing from Plex OAuth client identification so both values remain stable for their own purpose.

This change:
- switches Express session secret from `settings.clientId` to a dedicated `settings.sessionSecret`
- adds lazy generation/persistence of `sessionSecret` in settings
- exposes `plexClientIdentifier` in public settings for the frontend Plex OAuth flow
- updates frontend Plex auth headers to use `plexClientIdentifier` from `/api/v1/settings/public`
- updates API/interface schema to include `plexClientIdentifier`

## Has This Been Tested?

Yes. Run an an existing database and no auth issues were present.

## Screenshots (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)