### PR TITLE
fix(settings): prevent partial overwrite when merging updates

### DIFF
--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -1,9 +1,14 @@
 import { randomBytes, randomUUID } from 'crypto';
 import fs from 'fs';
-import { merge } from 'lodash';
+import { mergeWith } from 'lodash';
 import path from 'path';
 import webpush from 'web-push';
 import { Permission } from './permissions';
+
+const mergeSettings = <T>(current: T, incoming: Partial<T>): T =>
+  mergeWith({}, current, incoming, (_objValue, srcValue) =>
+    Array.isArray(srcValue) ? srcValue : undefined
+  ) as T;
 
 export interface Library {
   id: string;
@@ -437,7 +442,7 @@ class Settings {
       },
     };
     if (initialSettings) {
-      this.data = merge(this.data, initialSettings);
+      this.data = mergeSettings(this.data, initialSettings);
     }
   }
 
@@ -450,7 +455,7 @@ class Settings {
   }
 
   set main(data: MainSettings) {
-    this.data.main = data;
+    this.data.main = mergeSettings(this.data.main, data);
   }
 
   get plex(): PlexSettings {
@@ -458,7 +463,7 @@ class Settings {
   }
 
   set plex(data: PlexSettings) {
-    this.data.plex = data;
+    this.data.plex = mergeSettings(this.data.plex, data);
   }
 
   get tautulli(): TautulliSettings {
@@ -466,7 +471,7 @@ class Settings {
   }
 
   set tautulli(data: TautulliSettings) {
-    this.data.tautulli = data;
+    this.data.tautulli = mergeSettings(this.data.tautulli, data);
   }
 
   get uptime(): ServiceSettings {
@@ -474,7 +479,7 @@ class Settings {
   }
 
   set uptime(data: ServiceSettings) {
-    this.data.uptime = data;
+    this.data.uptime = mergeSettings(this.data.uptime, data);
   }
 
   get downloads(): DownloadClientSettings[] {
@@ -490,7 +495,7 @@ class Settings {
   }
 
   set tdarr(data: ServiceSettings) {
-    this.data.tdarr = data;
+    this.data.tdarr = mergeSettings(this.data.tdarr, data);
   }
 
   get bazarr(): ServiceSettings {
@@ -498,7 +503,7 @@ class Settings {
   }
 
   set bazarr(data: ServiceSettings) {
-    this.data.bazarr = data;
+    this.data.bazarr = mergeSettings(this.data.bazarr, data);
   }
 
   get radarr(): RadarrSettings[] {
@@ -510,7 +515,7 @@ class Settings {
   }
 
   set prowlarr(data: ServiceSettings) {
-    this.data.prowlarr = data;
+    this.data.prowlarr = mergeSettings(this.data.prowlarr, data);
   }
 
   get lidarr(): ServiceSettings {
@@ -518,7 +523,7 @@ class Settings {
   }
 
   set lidarr(data: ServiceSettings) {
-    this.data.lidarr = data;
+    this.data.lidarr = mergeSettings(this.data.lidarr, data);
   }
 
   get overseerr(): ServiceSettings {
@@ -526,7 +531,7 @@ class Settings {
   }
 
   set overseerr(data: ServiceSettings) {
-    this.data.overseerr = data;
+    this.data.overseerr = mergeSettings(this.data.overseerr, data);
   }
 
   set radarr(data: RadarrSettings[]) {
@@ -546,7 +551,7 @@ class Settings {
   }
 
   set public(data: PublicSettings) {
-    this.data.public = data;
+    this.data.public = mergeSettings(this.data.public, data);
   }
 
   get fullPublicSettings(): FullPublicSettings {
@@ -594,7 +599,7 @@ class Settings {
   }
 
   set notifications(data: NotificationSettings) {
-    this.data.notifications = data;
+    this.data.notifications = mergeSettings(this.data.notifications, data);
   }
 
   get jobs(): Record<JobId, JobSettings> {
@@ -602,7 +607,7 @@ class Settings {
   }
 
   set jobs(data: Record<JobId, JobSettings>) {
-    this.data.jobs = data;
+    this.data.jobs = mergeSettings(this.data.jobs, data);
   }
 
   get onboarding(): OnboardingSettings {
@@ -610,7 +615,7 @@ class Settings {
   }
 
   set onboarding(data: OnboardingSettings) {
-    this.data.onboarding = data;
+    this.data.onboarding = mergeSettings(this.data.onboarding, data);
   }
 
   get clientId(): string {
@@ -682,7 +687,7 @@ class Settings {
     const data = fs.readFileSync(SETTINGS_PATH, 'utf-8');
 
     if (data) {
-      this.data = merge(this.data, JSON.parse(data));
+      this.data = mergeSettings(this.data, JSON.parse(data));
       this.save();
     }
     return this;

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -393,7 +393,7 @@ userSettingsRoutes.post<{ id: string }, UserSettingsNotificationsResponse>(
         );
       }
 
-      userRepository.save(user);
+      await userRepository.save(user);
 
       res.status(200).json({
         pgpKey: user.settings.pgpKey,


### PR DESCRIPTION
## Description

Fixes settings persistence edge cases by:
- awaiting user notification settings saves before responding
- preventing partial settings overwrites by safely merging object updates while replacing incoming arrays

## Has This Been Tested?

Yes.

I tested saving settings on:
- an existing database
- a new database

## Screenshots (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)