### PR TITLE
fix(auth): disable user revalidation on auth pages

### DIFF
--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -2,6 +2,7 @@ import { UserType } from '@server/constants/user';
 import type { PermissionCheckOptions } from '@server/lib/permissions';
 import { hasPermission, Permission } from '@server/lib/permissions';
 import type { NotificationAgentKey } from '@server/lib/settings';
+import { usePathname } from 'next/navigation';
 import type { MutatorCallback } from 'swr';
 import useSWR from 'swr';
 
@@ -63,13 +64,21 @@ export const useUser = ({
   id,
   initialData,
 }: { id?: number; initialData?: User } = {}): UserHookResponse => {
+  const pathname = usePathname();
+  const isAuthPage = /^\/(signin|signup|setup|resetpassword(?:\/|$))/.test(
+    pathname || ''
+  );
+
   const {
     data,
     error,
     mutate: revalidate,
   } = useSWR<User>(id ? `/api/v1/user/${id}` : `/api/v1/auth/me`, {
     fallbackData: initialData,
-    refreshInterval: 30000,
+    refreshInterval: !isAuthPage ? 30000 : 0,
+    revalidateOnFocus: !isAuthPage,
+    revalidateOnMount: !isAuthPage,
+    revalidateOnReconnect: !isAuthPage,
     errorRetryInterval: 30000,
     shouldRetryOnError: false,
   });


### PR DESCRIPTION
## Description

Disables automatic SWR revalidation on auth pages (`/signin`, `/signup`, `/setup`, `/resetpassword`) to reduce unnecessary `/api/v1/auth/me` polling during authentication flows.

**Seerr PR:** [seerr-team/seerr#2213](https://github.com/Fallenbagel/seerr/pull/2213) (commit `1f04eeb`)  
**Seerr commit:** [`1f04eeb`](https://github.com/Fallenbagel/seerr/commit/1f04eeb)

## Changes

- Modified [`src/hooks/useUser.ts`](src/hooks/useUser.ts):
  - Added `usePathname()` hook to detect current route
  - Added `isAuthPage` regex to identify auth routes
  - Disabled SWR revalidation on auth pages:
    - `refreshInterval: 0` (disables polling every 30s)
    - `revalidateOnFocus: false` (no refresh when window regains focus)
    - `revalidateOnMount: false` (no refresh on component mount)
    - `revalidateOnReconnect: false` (no refresh on network reconnection)

## Performance Impact

- **Polling reduction:** Auth pages no longer make `/api/v1/auth/me` requests every 30 seconds
- **Focus/Mount/Reconnect:** These automatic revalidations are also disabled on auth pages
- **Manual revalidation preserved:** `UserContext` continues to call `revalidate()` on pathname changes, ensuring post-Plex-auth session fetch works correctly

## Testing

✅ Verified that Plex authentication flow completes successfully  
✅ User redirects to `/watch` after login  
✅ TypeScript compilation passes  
✅ All auth routes properly detected

## Notes

- Auth page regex includes `/signin/plex/loading` subroute (already covered by pattern)
- Implementation matches Seerr's approach but adapts routes for Streamarr's routing conventions (`/signin` instead of `/login`, added `/signup`)
- Improvements on Seerr: UserContext's manual `revalidate()` call still proceeds normally, preventing any login flow disruptions