### PR TITLE
fix(auth): disable user revalidation on auth pages

### DIFF
--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -16,8 +16,14 @@ interface UserContextProps {
  * the login page if their session ever becomes invalid.
  */
 export const UserContext = ({ initialUser, children }: UserContextProps) => {
-  const { user, error, revalidate } = useUser({ initialData: initialUser });
   const pathname = usePathname();
+  const isAuthPage = /^\/(signin|signup|setup|resetpassword(?:\/|$))/.test(
+    pathname || ''
+  );
+  const { user, error, revalidate } = useUser({
+    initialData: initialUser,
+    disableAutoRevalidation: isAuthPage,
+  });
   const routing = useRef(false);
 
   useEffect(() => {

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -62,14 +62,22 @@ interface UserHookResponse {
 export const useUser = ({
   id,
   initialData,
-}: { id?: number; initialData?: User } = {}): UserHookResponse => {
+  disableAutoRevalidation,
+}: {
+  id?: number;
+  initialData?: User;
+  disableAutoRevalidation?: boolean;
+} = {}): UserHookResponse => {
   const {
     data,
     error,
     mutate: revalidate,
   } = useSWR<User>(id ? `/api/v1/user/${id}` : `/api/v1/auth/me`, {
     fallbackData: initialData,
-    refreshInterval: 30000,
+    refreshInterval: !disableAutoRevalidation ? 30000 : 0,
+    revalidateOnFocus: !disableAutoRevalidation,
+    revalidateOnMount: !disableAutoRevalidation,
+    revalidateOnReconnect: !disableAutoRevalidation,
     errorRetryInterval: 30000,
     shouldRetryOnError: false,
   });


### PR DESCRIPTION
## Description

- Disables automatic SWR revalidation on auth pages (`/signin`, `/signup`, `/setup`, `/resetpassword`)
- Reduces unnecessary `/api/v1/auth/me` polling during authentication flows
- Adds pathname detection with `usePathname()` hook
- Sets `refreshInterval: 0`, `revalidateOnFocus: false`, `revalidateOnMount: false`, `revalidateOnReconnect: false` on auth pages

## Has This Been Tested?

Yes, verified Plex authentication flow completes successfully and user redirects to `/watch` after login.

## Screenshots (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)