### PR TITLE
feat(network): global network settings page with API request timeout

### DIFF
--- a/server/api/servarr/base.ts
+++ b/server/api/servarr/base.ts
@@ -98,11 +98,13 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
     apiKey,
     cacheName,
     apiName,
+    timeout,
   }: {
     url: string;
     apiKey: string;
     cacheName: AvailableCacheIds;
     apiName: string;
+    timeout?: number;
   }) {
     super(
       url,
@@ -111,6 +113,7 @@ class ServarrBase<QueueItemAppendT> extends ExternalAPI {
       },
       {
         nodeCache: cacheManager.getCache(cacheName).data,
+        timeout,
       }
     );
 

--- a/server/api/servarr/lidarr.ts
+++ b/server/api/servarr/lidarr.ts
@@ -2,8 +2,16 @@ import type { ServiceSettings } from '@server/lib/settings';
 import ServarrBase from './base';
 
 class LidarrAPI extends ServarrBase<Record<string, never>> {
-  constructor({ url, apiKey }: { url: string; apiKey: string }) {
-    super({ url, apiKey, cacheName: 'lidarr', apiName: 'Lidarr' });
+  constructor({
+    url,
+    apiKey,
+    timeout,
+  }: {
+    url: string;
+    apiKey: string;
+    timeout?: number;
+  }) {
+    super({ url, apiKey, cacheName: 'lidarr', apiName: 'Lidarr', timeout });
   }
 
   static buildServiceUrl(settings: ServiceSettings, path?: string): string {

--- a/server/api/servarr/prowlarr.ts
+++ b/server/api/servarr/prowlarr.ts
@@ -2,8 +2,16 @@ import type { ServiceSettings } from '@server/lib/settings';
 import ServarrBase from './base';
 
 class ProwlarrAPI extends ServarrBase<Record<string, never>> {
-  constructor({ url, apiKey }: { url: string; apiKey: string }) {
-    super({ url, apiKey, cacheName: 'prowlarr', apiName: 'Prowlarr' });
+  constructor({
+    url,
+    apiKey,
+    timeout,
+  }: {
+    url: string;
+    apiKey: string;
+    timeout?: number;
+  }) {
+    super({ url, apiKey, cacheName: 'prowlarr', apiName: 'Prowlarr', timeout });
   }
 
   static buildServiceUrl(settings: ServiceSettings, path?: string): string {

--- a/server/api/servarr/radarr.ts
+++ b/server/api/servarr/radarr.ts
@@ -32,8 +32,16 @@ export interface RadarrMovie {
 }
 
 class RadarrAPI extends ServarrBase<{ movieId: number }> {
-  constructor({ url, apiKey }: { url: string; apiKey: string }) {
-    super({ url, apiKey, cacheName: 'radarr', apiName: 'Radarr' });
+  constructor({
+    url,
+    apiKey,
+    timeout,
+  }: {
+    url: string;
+    apiKey: string;
+    timeout?: number;
+  }) {
+    super({ url, apiKey, cacheName: 'radarr', apiName: 'Radarr', timeout });
   }
 
   public getMovies = async (): Promise<RadarrMovie[]> => {

--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -116,8 +116,16 @@ class SonarrAPI extends ServarrBase<{
   episodeId: number;
   episode: EpisodeResult;
 }> {
-  constructor({ url, apiKey }: { url: string; apiKey: string }) {
-    super({ url, apiKey, apiName: 'Sonarr', cacheName: 'sonarr' });
+  constructor({
+    url,
+    apiKey,
+    timeout,
+  }: {
+    url: string;
+    apiKey: string;
+    timeout?: number;
+  }) {
+    super({ url, apiKey, apiName: 'Sonarr', cacheName: 'sonarr', timeout });
   }
 
   public async getSeries(): Promise<SonarrSeries[]> {

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,7 +70,7 @@ app
     }
 
     // Load Settings
-    const settings = getSettings().load();
+    const settings = await getSettings().load();
     await initializeOnboardingDefaults();
 
     // Migrate library types
@@ -104,7 +104,7 @@ app
     startJobs();
     const pythonReady = pythonService.start();
     const server = express();
-    if (settings.main.trustProxy) {
+    if (settings.network.trustProxy) {
       server.set('trust proxy', 1);
     }
     server.use(cookieParser());
@@ -134,7 +134,7 @@ app
       }
       express.urlencoded({ extended: true, limit: '50mb' })(req, res, next);
     });
-    if (settings.main.csrfProtection) {
+    if (settings.network.csrfProtection) {
       server.use(
         csurf({
           cookie: {
@@ -164,7 +164,7 @@ app
       cookie: {
         maxAge: 1000 * 60 * 60 * 24 * 30,
         httpOnly: true,
-        sameSite: settings.main.csrfProtection ? 'strict' : 'lax',
+        sameSite: settings.network.csrfProtection ? 'strict' : 'lax',
         secure: 'auto',
       },
       store: new TypeormStore({

--- a/server/lib/migrations/0001_migrate_network_proxy_csrf.ts
+++ b/server/lib/migrations/0001_migrate_network_proxy_csrf.ts
@@ -1,0 +1,29 @@
+import type { AllSettings } from '@server/lib/settings';
+
+type SettingsMigrationInput = AllSettings & {
+  main: AllSettings['main'] & {
+    trustProxy?: boolean;
+    csrfProtection?: boolean;
+  };
+};
+
+const migrateNetworkProxyCsrf = (
+  settings: SettingsMigrationInput
+): AllSettings => {
+  if (settings.network) {
+    return settings;
+  }
+
+  settings.network = {
+    requestTimeout: 10000,
+    trustProxy: settings.main.trustProxy ?? false,
+    csrfProtection: settings.main.csrfProtection ?? false,
+  };
+
+  delete settings.main.trustProxy;
+  delete settings.main.csrfProtection;
+
+  return settings;
+};
+
+export default migrateNetworkProxyCsrf;

--- a/server/lib/migrator.ts
+++ b/server/lib/migrator.ts
@@ -1,0 +1,92 @@
+import type { AllSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+import fs from 'fs/promises';
+import { createRequire } from 'module';
+import path from 'path';
+
+const moduleRequire = createRequire(__filename);
+
+const migrationsDir = path.join(__dirname, 'migrations');
+
+export const runMigrations = (
+  settings: AllSettings,
+  settingsPath: string
+): Promise<AllSettings> => {
+  let migrated = settings;
+
+  return (async () => {
+    try {
+      const backupPath = settingsPath.replace('.json', '.old.json');
+      let oldBackup: string | null = null;
+      try {
+        oldBackup = await fs.readFile(backupPath, 'utf-8');
+      } catch {
+        // No existing backup — that's fine.
+      }
+      await fs.writeFile(backupPath, JSON.stringify(settings, undefined, ' '));
+
+      const migrations = (await fs.readdir(migrationsDir))
+        .filter((file) => file.endsWith('.js') || file.endsWith('.ts'))
+        .sort();
+
+      const settingsBefore = JSON.stringify(migrated);
+
+      for (const migration of migrations) {
+        try {
+          const mod = moduleRequire(path.join(migrationsDir, migration));
+          const migrationFn: (
+            settings: AllSettings
+          ) => AllSettings | Promise<AllSettings> =
+            typeof mod === 'function' ? mod : (mod.default ?? mod);
+          const newSettings = await migrationFn(structuredClone(migrated));
+
+          if (JSON.stringify(migrated) !== JSON.stringify(newSettings)) {
+            logger.debug(`Running migration '${migration}'.`, {
+              label: 'Migrations',
+            });
+          }
+
+          migrated = newSettings;
+        } catch (e) {
+          logger.error(
+            `Error while running migration '${migration}': ${e.message}\n${e.stack}`,
+            { label: 'Migrations' }
+          );
+          throw e;
+        }
+      }
+
+      const settingsAfter = JSON.stringify(migrated);
+      if (settingsBefore !== settingsAfter) {
+        await fs.writeFile(
+          settingsPath,
+          JSON.stringify(migrated, undefined, ' ')
+        );
+        const fileSaved = JSON.parse(await fs.readFile(settingsPath, 'utf-8'));
+        if (JSON.stringify(fileSaved) !== settingsAfter) {
+          throw new Error('Unable to save settings during migration.');
+        }
+        // Migration succeeded — remove the backup file.
+        await fs.unlink(backupPath).catch(() => {
+          // Non-fatal if the backup couldn't be removed.
+        });
+      } else {
+        if (oldBackup) {
+          await fs.writeFile(backupPath, oldBackup);
+        } else {
+          await fs.unlink(backupPath).catch(() => {
+            // Non-fatal if already gone.
+          });
+        }
+      }
+    } catch (e) {
+      logger.error(
+        `Something went wrong while running settings migrations: ${e.message}`,
+        { label: 'Migrations' }
+      );
+      throw e;
+    }
+
+    return migrated;
+  })();
+};

--- a/server/lib/restartManager.ts
+++ b/server/lib/restartManager.ts
@@ -19,7 +19,7 @@ interface ProxyAffectingSettings {
   bazarr: ServiceEntry;
   tdarr: { hostname?: string; enabled?: boolean };
   tautulli: ServiceEntry;
-  main: { trustProxy: boolean; csrfProtection: boolean };
+  network: { trustProxy: boolean; csrfProtection: boolean };
 }
 
 interface ServiceEntry {
@@ -75,9 +75,9 @@ class RestartManager {
         hostname: settings.tautulli.hostname,
         urlBase: settings.tautulli.urlBase,
       },
-      main: {
-        trustProxy: settings.main.trustProxy,
-        csrfProtection: settings.main.csrfProtection,
+      network: {
+        trustProxy: settings.network.trustProxy,
+        csrfProtection: settings.network.csrfProtection,
       },
     };
   }
@@ -140,11 +140,13 @@ class RestartManager {
       changed.push('Tautulli');
     }
 
-    if (settings.main.trustProxy !== this.snapshot.main.trustProxy) {
+    if (settings.network.trustProxy !== this.snapshot.network.trustProxy) {
       changed.push('Proxy Support');
     }
 
-    if (settings.main.csrfProtection !== this.snapshot.main.csrfProtection) {
+    if (
+      settings.network.csrfProtection !== this.snapshot.network.csrfProtection
+    ) {
       changed.push('CSRF Protection');
     }
 

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -3,6 +3,7 @@ import fs from 'fs';
 import { mergeWith } from 'lodash';
 import path from 'path';
 import webpush from 'web-push';
+import { runMigrations } from '@server/lib/migrator';
 import { Permission } from './permissions';
 
 const mergeSettings = <T>(current: T, incoming: Partial<T>): T =>
@@ -56,6 +57,12 @@ export interface ServiceSettings {
   urlBase?: string;
   id?: string;
   apiKey?: string;
+}
+
+export interface NetworkSettings {
+  requestTimeout: number;
+  trustProxy: boolean;
+  csrfProtection: boolean;
 }
 
 export interface DVRSettings {
@@ -137,7 +144,6 @@ export interface MainSettings {
   apiKey: string;
   applicationTitle: string;
   applicationUrl: string;
-  csrfProtection: boolean;
   cacheImages: boolean;
   defaultPermissions: number;
   defaultQuotas: {
@@ -151,7 +157,6 @@ export interface MainSettings {
   newPlexLogin: boolean;
   enableSignUp: boolean;
   releaseSched: boolean;
-  trustProxy: boolean;
   locale: string;
   supportUrl: string;
   supportEmail: string;
@@ -269,12 +274,13 @@ export type JobId =
   | 'image-cache-cleanup'
   | 'notification-cleanup';
 
-interface AllSettings {
+export interface AllSettings {
   clientId: string;
   sessionSecret?: string;
   vapidPublic: string;
   vapidPrivate: string;
   main: MainSettings;
+  network: NetworkSettings;
   plex: PlexSettings;
   tautulli: TautulliSettings;
   radarr: RadarrSettings[];
@@ -311,7 +317,6 @@ class Settings {
         apiKey: '',
         applicationTitle: 'Streamarr',
         applicationUrl: '',
-        csrfProtection: false,
         cacheImages: false,
         defaultPermissions: Permission.STREAMARR,
         defaultQuotas: {
@@ -331,7 +336,6 @@ class Settings {
         newPlexLogin: true,
         enableSignUp: false,
         releaseSched: false,
-        trustProxy: false,
         locale: 'en',
         supportUrl: '',
         supportEmail: '',
@@ -371,6 +375,11 @@ class Settings {
         libraries: [],
         enablePlaylists: false,
         defaultPivot: 'library',
+      },
+      network: {
+        requestTimeout: 10000,
+        trustProxy: false,
+        csrfProtection: false,
       },
       tautulli: {
         enabled: false,
@@ -456,6 +465,14 @@ class Settings {
 
   set main(data: MainSettings) {
     this.data.main = mergeSettings(this.data.main, data);
+  }
+
+  get network(): NetworkSettings {
+    return this.data.network;
+  }
+
+  set network(data: NetworkSettings) {
+    this.data.network = mergeSettings(this.data.network, data);
   }
 
   get plex(): PlexSettings {
@@ -675,7 +692,10 @@ class Settings {
    * @param overrideSettings If passed in, will override all existing settings with these
    * values
    */
-  public load(overrideSettings?: AllSettings): Settings {
+  public async load(
+    overrideSettings?: AllSettings,
+    raw = false
+  ): Promise<Settings> {
     if (overrideSettings) {
       this.data = overrideSettings;
       return this;
@@ -686,10 +706,18 @@ class Settings {
     }
     const data = fs.readFileSync(SETTINGS_PATH, 'utf-8');
 
-    if (data) {
-      this.data = mergeSettings(this.data, JSON.parse(data));
+    if (data && !raw) {
+      const parsedSettings = JSON.parse(data);
+      const migratedSettings = await runMigrations(
+        parsedSettings,
+        SETTINGS_PATH
+      );
+      this.data = mergeSettings(this.data, migratedSettings);
       this.save();
+    } else if (data) {
+      this.data = JSON.parse(data);
     }
+
     return this;
   }
 

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -276,7 +276,7 @@ authRoutes.post('/logout', (req, res, next) => {
     const settings = getSettings();
     res.clearCookie('streamarr.sid', {
       httpOnly: true,
-      sameSite: settings.main.csrfProtection ? 'strict' : 'lax',
+      sameSite: settings.network.csrfProtection ? 'strict' : 'lax',
       secure: process.env.NODE_ENV === 'production',
     });
     res.status(200).json({ status: 'ok' });

--- a/server/routes/service.ts
+++ b/server/routes/service.ts
@@ -118,6 +118,7 @@ serviceRoutes.get<{ tmdbId: string }>(
     const sonarr = new SonarrAPI({
       apiKey: sonarrSettings.apiKey,
       url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
+      timeout: getSettings().network.requestTimeout,
     });
 
     try {

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -25,6 +25,7 @@ import {
 import type {
   JobId,
   MainSettings,
+  NetworkSettings,
   ServiceSettings,
 } from '@server/lib/settings';
 import restartManager from '@server/lib/restartManager';
@@ -112,6 +113,41 @@ settingsRoutes.post('/main/regenerate', (req, res, next) => {
 
   res.status(200).json(filteredMainSettings(req.user, main));
 });
+
+settingsRoutes.get('/network', (_req, res) => {
+  const settings = getSettings();
+  res.status(200).json(settings.network);
+});
+
+settingsRoutes.post<undefined, NetworkSettings, NetworkSettings>(
+  '/network',
+  (req, res, next) => {
+    try {
+      const settings = getSettings();
+
+      if (req.body.requestTimeout) {
+        const timeout = Number(req.body.requestTimeout);
+        if (!Number.isFinite(timeout) || timeout < 1000 || timeout > 300000) {
+          return next({
+            status: 400,
+            message: 'requestTimeout must be between 1000 and 300000 ms',
+          });
+        }
+      }
+
+      Object.assign(settings.network, req.body);
+
+      settings.save();
+      res.status(200).json(settings.network);
+    } catch (e) {
+      logger.error('Error saving network settings:', {
+        label: 'Settings',
+        message: e instanceof Error ? e.message : String(e),
+      });
+      next({ status: 500, message: 'Failed to save network settings' });
+    }
+  }
+);
 
 settingsRoutes.get('/plex', (_req, res) => {
   const settings = getSettings();
@@ -372,6 +408,7 @@ settingsRoutes.post('/prowlarr/test', async (req, res, next) => {
     const prowlarr = new ProwlarrAPI({
       apiKey: req.body.apiKey,
       url: ProwlarrAPI.buildServiceUrl(req.body, '/api/v1'),
+      timeout: getSettings().network.requestTimeout,
     });
 
     const urlBase = await prowlarr
@@ -406,6 +443,7 @@ settingsRoutes.get('/prowlarr/auth', async (req, res, next) => {
     const prowlarr = new ProwlarrAPI({
       apiKey: prowlarrSettings.apiKey,
       url: ProwlarrAPI.buildServiceUrl(prowlarrSettings, '/api/v1'),
+      timeout: getSettings().network.requestTimeout,
     });
 
     const hostConfig = await prowlarr.getHostConfig();
@@ -440,6 +478,7 @@ settingsRoutes.post(
       const prowlarr = new ProwlarrAPI({
         apiKey: prowlarrSettings.apiKey,
         url: ProwlarrAPI.buildServiceUrl(prowlarrSettings, '/api/v1'),
+        timeout: getSettings().network.requestTimeout,
       });
 
       const hostConfig = await prowlarr.disableAuthentication();
@@ -493,6 +532,7 @@ settingsRoutes.post<undefined, Record<string, unknown>, ServiceSettings>(
       const lidarr = new LidarrAPI({
         apiKey: req.body.apiKey,
         url: LidarrAPI.buildServiceUrl(req.body, '/api/v1'),
+        timeout: getSettings().network.requestTimeout,
       });
 
       const urlBase = await lidarr
@@ -535,6 +575,7 @@ settingsRoutes.get('/lidarr/auth', arrAuthLimiter, async (req, res, next) => {
     const lidarr = new LidarrAPI({
       apiKey: lidarrSettings.apiKey,
       url: LidarrAPI.buildServiceUrl(lidarrSettings, '/api/v1'),
+      timeout: getSettings().network.requestTimeout,
     });
 
     const hostConfig = await lidarr.getHostConfig();
@@ -566,6 +607,7 @@ settingsRoutes.post('/lidarr/auth', async (req, res, next) => {
     const lidarr = new LidarrAPI({
       apiKey: lidarrSettings.apiKey,
       url: LidarrAPI.buildServiceUrl(lidarrSettings, '/api/v1'),
+      timeout: getSettings().network.requestTimeout,
     });
 
     const hostConfig = await lidarr.disableAuthentication();

--- a/server/routes/settings/radarr.ts
+++ b/server/routes/settings/radarr.ts
@@ -51,6 +51,7 @@ radarrRoutes.post<undefined, Record<string, unknown>, RadarrSettings>(
       const radarr = new RadarrAPI({
         apiKey: req.body.apiKey,
         url: RadarrAPI.buildUrl(req.body, '/api/v3'),
+        timeout: getSettings().network.requestTimeout,
       });
 
       const urlBase = await radarr
@@ -156,6 +157,7 @@ radarrRoutes.get<{ id: string }>('/:id/auth', async (req, res, next) => {
     const radarr = new RadarrAPI({
       apiKey: radarrSettings.apiKey,
       url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
+      timeout: getSettings().network.requestTimeout,
     });
 
     const hostConfig = await radarr.getHostConfig();
@@ -192,6 +194,7 @@ radarrRoutes.post<{ id: string }>(
       const radarr = new RadarrAPI({
         apiKey: radarrSettings.apiKey,
         url: RadarrAPI.buildUrl(radarrSettings, '/api/v3'),
+        timeout: getSettings().network.requestTimeout,
       });
 
       const hostConfig = await radarr.disableAuthentication();

--- a/server/routes/settings/sonarr.ts
+++ b/server/routes/settings/sonarr.ts
@@ -49,6 +49,7 @@ sonarrRoutes.post('/test', async (req, res, next) => {
     const sonarr = new SonarrAPI({
       apiKey: req.body.apiKey,
       url: SonarrAPI.buildUrl(req.body, '/api/v3'),
+      timeout: getSettings().network.requestTimeout,
     });
 
     const urlBase = await sonarr
@@ -154,6 +155,7 @@ sonarrRoutes.get<{ id: string }>('/:id/auth', async (req, res, next) => {
     const sonarr = new SonarrAPI({
       apiKey: sonarrSettings.apiKey,
       url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
+      timeout: getSettings().network.requestTimeout,
     });
 
     const hostConfig = await sonarr.getHostConfig();
@@ -190,6 +192,7 @@ sonarrRoutes.post<{ id: string }>(
       const sonarr = new SonarrAPI({
         apiKey: sonarrSettings.apiKey,
         url: SonarrAPI.buildUrl(sonarrSettings, '/api/v3'),
+        timeout: getSettings().network.requestTimeout,
       });
 
       const hostConfig = await sonarr.disableAuthentication();

--- a/src/app/admin/settings/layout.tsx
+++ b/src/app/admin/settings/layout.tsx
@@ -7,8 +7,6 @@ import type { ServiceSettings } from '@server/lib/settings';
 import { useIntl } from 'react-intl';
 import useSWR from 'swr';
 
-//TODO: Add new newsletter management settings and feature
-
 type SettingsLayoutProps = { children: React.ReactNode };
 
 const SettingsLayout = ({ children }: SettingsLayoutProps) => {
@@ -61,6 +59,14 @@ const SettingsLayout = ({ children }: SettingsLayoutProps) => {
       route: '/admin/settings/services',
       regex: /^\/admin\/settings\/services/,
       dataTutorial: 'services-settings-tab',
+    },
+    {
+      text: intl.formatMessage({
+        id: 'common.network',
+        defaultMessage: 'Network',
+      }),
+      route: '/admin/settings/network',
+      regex: /^\/admin\/settings\/network/,
     },
     {
       text: intl.formatMessage({

--- a/src/app/admin/settings/network/page.tsx
+++ b/src/app/admin/settings/network/page.tsx
@@ -1,0 +1,10 @@
+import NetworkSettings from '@app/components/Admin/Settings/Network';
+import { generatePageMetadata } from '@app/utils/serverFetchHelpers';
+
+export const generateMetadata = () =>
+  generatePageMetadata('Admin - Network Settings');
+
+const NetworkPage = () => {
+  return <NetworkSettings />;
+};
+export default NetworkPage;

--- a/src/components/Admin/Settings/General/index.tsx
+++ b/src/components/Admin/Settings/General/index.tsx
@@ -1,8 +1,5 @@
 'use client';
-import SettingsBadge from '@app/components/Admin/Settings/SettingsBadge';
-import RestartRequiredAlert, {
-  RESTART_REQUIRED_SWR_KEY,
-} from '@app/components/Admin/Settings/RestartRequiredAlert';
+import { RESTART_REQUIRED_SWR_KEY } from '@app/components/Admin/Settings/RestartRequiredAlert';
 import Button from '@app/components/Common/Button';
 import CopyButton from '@app/components/Common/CopyButton';
 import LoadingEllipsis from '@app/components/Common/LoadingEllipsis';
@@ -32,6 +29,7 @@ import * as Yup from 'yup';
 import { useIntl, FormattedMessage } from 'react-intl';
 import ColorPickerModal from '@app/components/Admin/Settings/ColorPickerModal';
 import { SettingsContext } from '@app/context/SettingsContext';
+import { isValidHttpUrl } from '@app/utils/networkValidation';
 
 const GeneralSettings = () => {
   const intl = useIntl();
@@ -61,11 +59,13 @@ const GeneralSettings = () => {
       })
     ),
     applicationUrl: Yup.string()
-      .url(
+      .test(
+        'valid-http-url',
         intl.formatMessage({
           id: 'generalSettings.validation.supportUrl',
           defaultMessage: 'You must provide a valid URL',
-        })
+        }),
+        (value) => isValidHttpUrl(value)
       )
       .test(
         'no-trailing-slash',
@@ -75,11 +75,13 @@ const GeneralSettings = () => {
         }),
         (value) => !value || !value.endsWith('/')
       ),
-    supportUrl: Yup.string().url(
+    supportUrl: Yup.string().test(
+      'valid-http-url',
       intl.formatMessage({
         id: 'generalSettings.validation.supportUrl',
         defaultMessage: 'You must provide a valid URL',
-      })
+      }),
+      (value) => isValidHttpUrl(value)
     ),
   });
 
@@ -130,19 +132,14 @@ const GeneralSettings = () => {
           defaultMessage="Configure global and default Streamarr settings"
         />
       </p>
-      <RestartRequiredAlert
-        filterServices={['Proxy Support', 'CSRF Protection']}
-      />
       <Formik
         initialValues={{
           applicationTitle: data?.applicationTitle,
           applicationUrl: data?.applicationUrl,
-          csrfProtection: data?.csrfProtection,
           locale: data?.locale ?? 'en',
           enableSignUp: data?.enableSignUp,
           enableHelpCentre: data?.enableHelpCentre,
           releaseSched: data?.releaseSched,
-          trustProxy: data?.trustProxy,
           cacheImages: data?.cacheImages,
           supportUrl: data?.supportUrl,
           supportEmail: data?.supportEmail,
@@ -159,12 +156,10 @@ const GeneralSettings = () => {
             await axios.post('/api/v1/settings/main', {
               applicationTitle: values.applicationTitle,
               applicationUrl: values.applicationUrl,
-              csrfProtection: values.csrfProtection,
               locale: values.locale,
               enableSignUp: values.enableSignUp,
               enableHelpCentre: values.enableHelpCentre,
               releaseSched: values.releaseSched,
-              trustProxy: values.trustProxy,
               cacheImages: values.cacheImages,
               supportUrl: values.supportUrl,
               supportEmail: values.supportEmail,
@@ -713,69 +708,6 @@ const GeneralSettings = () => {
                       className="checkbox-primary checkbox"
                     />
                   </div>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-3 space-y-2 sm:space-x-2 sm:space-y-0">
-                  <label htmlFor="trustProxy" className="col-span-1">
-                    <span className="mr-2">
-                      <FormattedMessage
-                        id="generalSettings.trustProxy.label"
-                        defaultMessage="Enable Proxy Support"
-                      />
-                    </span>
-                    <SettingsBadge badgeType="restartRequired" />
-                    <p className="text-sm text-neutral">
-                      <FormattedMessage
-                        id="generalSettings.trustProxy.description"
-                        defaultMessage="Allow Streamarr to correctly register client IP addresses behind a proxy"
-                      />
-                    </p>
-                  </label>
-                  <div className="col-span-2">
-                    <Field
-                      type="checkbox"
-                      id="trustProxy"
-                      name="trustProxy"
-                      onChange={() => {
-                        setFieldValue('trustProxy', !values.trustProxy);
-                      }}
-                      className="checkbox-primary checkbox"
-                    />
-                  </div>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-3 space-y-2 sm:space-x-2 sm:space-y-0">
-                  <label htmlFor="csrfProtection" className="col-span-1">
-                    <span className="mr-2">
-                      <FormattedMessage
-                        id="generalSettings.csrfProtection.label"
-                        defaultMessage="Enable CSRF Protection"
-                      />
-                    </span>
-                    <SettingsBadge badgeType="advanced" className="mr-2" />
-                    <SettingsBadge badgeType="restartRequired" />
-                    <p className="text-sm text-neutral">
-                      <FormattedMessage
-                        id="generalSettings.csrfProtection.description"
-                        defaultMessage="Set external API access to read-only (requires HTTPS)"
-                      />
-                    </p>
-                  </label>
-                  <Tooltip
-                    content={intl.formatMessage({
-                      id: 'generalSettings.csrfProtection.tooltip',
-                      defaultMessage:
-                        'Do NOT enable this setting unless you understand what you are doing!',
-                    })}
-                  >
-                    <Field
-                      type="checkbox"
-                      id="csrfProtection"
-                      name="csrfProtection"
-                      onChange={() => {
-                        setFieldValue('csrfProtection', !values.csrfProtection);
-                      }}
-                      className="checkbox-primary checkbox"
-                    />
-                  </Tooltip>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-3 space-y-2 sm:space-x-2 sm:space-y-0">
                   <label htmlFor="cacheImages" className="col-span-1">

--- a/src/components/Admin/Settings/Network/index.tsx
+++ b/src/components/Admin/Settings/Network/index.tsx
@@ -1,0 +1,248 @@
+'use client';
+import SettingsBadge from '@app/components/Admin/Settings/SettingsBadge';
+import RestartRequiredAlert, {
+  RESTART_REQUIRED_SWR_KEY,
+} from '@app/components/Admin/Settings/RestartRequiredAlert';
+import Button from '@app/components/Common/Button';
+import LoadingEllipsis from '@app/components/Common/LoadingEllipsis';
+import Tooltip from '@app/components/Common/ToolTip';
+import Toast from '@app/components/Toast';
+import {
+  ArrowDownTrayIcon,
+  CheckBadgeIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/solid';
+import type { NetworkSettings } from '@server/lib/settings';
+import axios from 'axios';
+import { Field, Form, Formik } from 'formik';
+import { FormattedMessage, useIntl } from 'react-intl';
+import useSWR, { mutate } from 'swr';
+import * as Yup from 'yup';
+
+const NetworkSettings = () => {
+  const intl = useIntl();
+  const {
+    data,
+    error,
+    mutate: revalidate,
+  } = useSWR<NetworkSettings>('/api/v1/settings/network');
+
+  const NetworkSettingsSchema = Yup.object().shape({
+    requestTimeout: Yup.number()
+      .typeError(
+        intl.formatMessage({
+          id: 'networkSettings.validation.requestTimeout',
+          defaultMessage: 'You must provide a valid request timeout',
+        })
+      )
+      .required(
+        intl.formatMessage({
+          id: 'networkSettings.validation.requestTimeout',
+          defaultMessage: 'You must provide a valid request timeout',
+        })
+      )
+      .min(
+        1,
+        intl.formatMessage({
+          id: 'networkSettings.validation.requestTimeoutMin',
+          defaultMessage: 'Request timeout must be at least 1 second',
+        })
+      ),
+    trustProxy: Yup.boolean(),
+    csrfProtection: Yup.boolean(),
+  });
+
+  if (!data && !error) {
+    return <LoadingEllipsis />;
+  }
+
+  return (
+    <div className="max-w-6xl mb-10">
+      <div className="mb-6">
+        <h3 className="text-2xl font-extrabold">
+          <FormattedMessage
+            id="networkSettings.title"
+            defaultMessage="Network Settings"
+          />
+        </h3>
+        <p className="mb-5">
+          <FormattedMessage
+            id="networkSettings.description"
+            defaultMessage="Configure global network settings for your Streamarr instance."
+          />
+        </p>
+      </div>
+      <RestartRequiredAlert
+        filterServices={['Proxy Support', 'CSRF Protection']}
+      />
+      <Formik
+        initialValues={{
+          requestTimeout: data ? data.requestTimeout / 1000 : 10,
+          trustProxy: data?.trustProxy ?? false,
+          csrfProtection: data?.csrfProtection ?? false,
+        }}
+        enableReinitialize
+        validationSchema={NetworkSettingsSchema}
+        onSubmit={async (values) => {
+          try {
+            await axios.post('/api/v1/settings/network', {
+              requestTimeout: Number(values.requestTimeout) * 1000,
+              trustProxy: values.trustProxy,
+              csrfProtection: values.csrfProtection,
+            });
+            revalidate();
+            mutate(RESTART_REQUIRED_SWR_KEY);
+            Toast({
+              title: intl.formatMessage({
+                id: 'networkSettings.saveSuccess',
+                defaultMessage: 'Network settings saved successfully',
+              }),
+              type: 'success',
+              icon: <CheckBadgeIcon className="size-7" />,
+            });
+          } catch (e) {
+            Toast({
+              title: intl.formatMessage({
+                id: 'networkSettings.saveError',
+                defaultMessage:
+                  'Something went wrong while saving network settings.',
+              }),
+              message: e.response?.data?.message || e.message,
+              type: 'error',
+              icon: <XCircleIcon className="size-7" />,
+            });
+          }
+        }}
+      >
+        {({
+          errors,
+          touched,
+          isSubmitting,
+          isValid,
+          setFieldValue,
+          values,
+        }) => (
+          <Form className="mt-5 max-w-6xl space-y-5">
+            <div className="grid grid-cols-1 sm:grid-cols-3 space-y-2 sm:space-x-2 sm:space-y-0">
+              <label htmlFor="trustProxy" className="col-span-1">
+                <span className="mr-2">
+                  <FormattedMessage
+                    id="generalSettings.trustProxy.label"
+                    defaultMessage="Enable Proxy Support"
+                  />
+                </span>
+                <SettingsBadge badgeType="restartRequired" />
+                <p className="text-sm block font-light text-neutral">
+                  <FormattedMessage
+                    id="generalSettings.trustProxy.description"
+                    defaultMessage="Allow Streamarr to correctly register client IP addresses behind a proxy"
+                  />
+                </p>
+              </label>
+              <div className="col-span-2">
+                <Field
+                  type="checkbox"
+                  id="trustProxy"
+                  name="trustProxy"
+                  onChange={() => {
+                    setFieldValue('trustProxy', !values.trustProxy);
+                  }}
+                  className="checkbox-primary checkbox"
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 space-y-2 sm:space-x-2 sm:space-y-0">
+              <label htmlFor="csrfProtection" className="col-span-1">
+                <span className="mr-2">
+                  <FormattedMessage
+                    id="generalSettings.csrfProtection.label"
+                    defaultMessage="Enable CSRF Protection"
+                  />
+                </span>
+                <SettingsBadge badgeType="advanced" className="mr-2" />
+                <SettingsBadge badgeType="restartRequired" />
+                <p className="text-sm block font-light text-neutral">
+                  <FormattedMessage
+                    id="generalSettings.csrfProtection.description"
+                    defaultMessage="Set external API access to read-only (requires HTTPS)"
+                  />
+                </p>
+              </label>
+              <Tooltip
+                content={intl.formatMessage({
+                  id: 'generalSettings.csrfProtection.tooltip',
+                  defaultMessage:
+                    'Do NOT enable this setting unless you understand what you are doing!',
+                })}
+              >
+                <Field
+                  type="checkbox"
+                  id="csrfProtection"
+                  name="csrfProtection"
+                  onChange={() => {
+                    setFieldValue('csrfProtection', !values.csrfProtection);
+                  }}
+                  className="checkbox-primary checkbox"
+                />
+              </Tooltip>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 space-y-2 sm:space-x-2 sm:space-y-0">
+              <label htmlFor="requestTimeout" className="col-span-1">
+                <FormattedMessage
+                  id="networkSettings.requestTimeout"
+                  defaultMessage="API Request Timeout"
+                />
+                <span className="text-sm block font-light text-neutral">
+                  <FormattedMessage
+                    id="networkSettings.requestTimeout.description"
+                    defaultMessage="Maximum time (in seconds) to wait for responses from external services."
+                  />
+                </span>
+              </label>
+              <div className="col-span-2">
+                <Field
+                  id="requestTimeout"
+                  name="requestTimeout"
+                  type="number"
+                  inputMode="numeric"
+                  className="input input-primary input-sm rounded-md w-1/6"
+                />
+                {errors.requestTimeout &&
+                  touched.requestTimeout &&
+                  typeof errors.requestTimeout === 'string' && (
+                    <div className="text-error">{errors.requestTimeout}</div>
+                  )}
+              </div>
+            </div>
+            <div className="divider divider-primary mb-0 col-span-full" />
+            <div className="flex justify-end col-span-3 mt-4">
+              <div className="flex gap-2">
+                <Button
+                  buttonType="primary"
+                  buttonSize="sm"
+                  type="submit"
+                  disabled={isSubmitting || !isValid}
+                >
+                  <ArrowDownTrayIcon className="size-4 mr-2" />
+                  <span>
+                    {isSubmitting
+                      ? intl.formatMessage({
+                          id: 'common.saving',
+                          defaultMessage: 'Saving...',
+                        })
+                      : intl.formatMessage({
+                          id: 'common.saveChanges',
+                          defaultMessage: 'Save Changes',
+                        })}
+                  </span>
+                </Button>
+              </div>
+            </div>
+          </Form>
+        )}
+      </Formik>
+    </div>
+  );
+};
+
+export default NetworkSettings;

--- a/src/components/Admin/Settings/Notifications/EmailNotifications/index.tsx
+++ b/src/components/Admin/Settings/Notifications/EmailNotifications/index.tsx
@@ -17,6 +17,7 @@ import useSWR, { mutate } from 'swr';
 import validator from 'validator';
 import * as Yup from 'yup';
 import { useIntl, FormattedMessage } from 'react-intl';
+import { isValidHostnameOrIpAddress } from '@app/utils/networkValidation';
 
 const EmailNotifications = () => {
   const intl = useIntl();
@@ -59,12 +60,13 @@ const EmailNotifications = () => {
             )
           : schema.nullable()
       )
-      .matches(
-        /^(((([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])):((([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))@)?(([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])$/i,
+      .test(
+        'hostname-or-ip',
         intl.formatMessage({
           id: 'servicesSettings.validation.hostname',
           defaultMessage: 'You must provide a valid hostname or IP address',
-        })
+        }),
+        (value) => !value || isValidHostnameOrIpAddress(value)
       ),
     smtpPort: Yup.number().when('enabled', (enabled, schema) =>
       enabled

--- a/src/components/Admin/Settings/Plex/index.tsx
+++ b/src/components/Admin/Settings/Plex/index.tsx
@@ -26,6 +26,7 @@ import { useMemo, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 import * as Yup from 'yup';
 import { useIntl, FormattedMessage } from 'react-intl';
+import { isValidHostnameOrIpAddress } from '@app/utils/networkValidation';
 interface PresetServerDisplay {
   name: string;
   ssl: boolean;
@@ -75,12 +76,13 @@ const PlexSettings = ({ onComplete }: SettingsPlexProps) => {
           defaultMessage: 'You must provide a valid hostname or IP address',
         })
       )
-      .matches(
-        /^(((([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])):((([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))@)?(([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])$/i,
+      .test(
+        'hostname-or-ip',
         intl.formatMessage({
           id: 'servicesSettings.validation.hostname',
           defaultMessage: 'You must provide a valid hostname or IP address',
-        })
+        }),
+        (value) => isValidHostnameOrIpAddress(value)
       ),
     port: Yup.number()
       .nullable()
@@ -318,6 +320,7 @@ const PlexSettings = ({ onComplete }: SettingsPlexProps) => {
           selectedPreset: undefined,
         }}
         enableReinitialize
+        validateOnMount
         validationSchema={PlexSettingsSchema}
         onSubmit={async (values) => {
           let toastId: string | undefined;
@@ -392,6 +395,7 @@ const PlexSettings = ({ onComplete }: SettingsPlexProps) => {
           values,
           handleSubmit,
           setFieldValue,
+          setValues,
           isSubmitting,
           isValid,
         }) => {
@@ -418,9 +422,12 @@ const PlexSettings = ({ onComplete }: SettingsPlexProps) => {
                         availablePresets[Number(e.target.value)];
 
                       if (targPreset) {
-                        setFieldValue('hostname', targPreset.address);
-                        setFieldValue('port', targPreset.port);
-                        setFieldValue('useSsl', targPreset.ssl);
+                        setValues({
+                          ...values,
+                          hostname: targPreset.address,
+                          port: targPreset.port,
+                          useSsl: targPreset.ssl,
+                        });
                       }
                     }}
                   >

--- a/src/components/Admin/Settings/Services/Radarr/RadarrModal/index.tsx
+++ b/src/components/Admin/Settings/Services/Radarr/RadarrModal/index.tsx
@@ -15,6 +15,7 @@ import { Field, Formik } from 'formik';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import * as Yup from 'yup';
 import { SmallLoadingEllipsis } from '@app/components/Common/LoadingEllipsis';
+import { isValidHostnameOrIpAddress } from '@app/utils/networkValidation';
 
 interface TestResponse {
   urlBase?: string;
@@ -53,12 +54,13 @@ const RadarrModal = ({ onClose, radarr, onSave, show }: RadarrModalProps) => {
           defaultMessage: 'You must provide a valid hostname or IP address',
         })
       )
-      .matches(
-        /^(((([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])):((([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))@)?(([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])$/i,
+      .test(
+        'hostname-or-ip',
         intl.formatMessage({
           id: 'servicesSettings.validation.hostname',
           defaultMessage: 'You must provide a valid hostname or IP address',
-        })
+        }),
+        (value) => isValidHostnameOrIpAddress(value)
       ),
     port: Yup.number()
       .nullable()

--- a/src/components/Admin/Settings/Services/Sonarr/SonarrModal/index.tsx
+++ b/src/components/Admin/Settings/Services/Sonarr/SonarrModal/index.tsx
@@ -15,6 +15,7 @@ import { Field, Formik } from 'formik';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import * as Yup from 'yup';
 import { SmallLoadingEllipsis } from '@app/components/Common/LoadingEllipsis';
+import { isValidHostnameOrIpAddress } from '@app/utils/networkValidation';
 
 interface TestResponse {
   urlBase?: string;
@@ -53,12 +54,13 @@ const SonarrModal = ({ onClose, sonarr, onSave, show }: SonarrModalProps) => {
           defaultMessage: 'You must provide a valid hostname or IP address',
         })
       )
-      .matches(
-        /^(((([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])):((([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))@)?(([a-z]|\d|_|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*)?([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])$/i,
+      .test(
+        'hostname-or-ip',
         intl.formatMessage({
           id: 'servicesSettings.validation.hostname',
           defaultMessage: 'You must provide a valid hostname or IP address',
-        })
+        }),
+        (value) => isValidHostnameOrIpAddress(value)
       ),
     port: Yup.number()
       .nullable()

--- a/src/components/Admin/Settings/Services/Uptime/index.tsx
+++ b/src/components/Admin/Settings/Services/Uptime/index.tsx
@@ -13,6 +13,7 @@ import axios from 'axios';
 import { Field, Formik } from 'formik';
 import useSWR from 'swr';
 import * as Yup from 'yup';
+import { isValidHttpUrl } from '@app/utils/networkValidation';
 
 const ServicesUptime = () => {
   const intl = useIntl();
@@ -21,11 +22,13 @@ const ServicesUptime = () => {
 
   const SettingsSchema = Yup.object().shape({
     externalUrl: Yup.string()
-      .url(
+      .test(
+        'valid-http-url',
         intl.formatMessage({
           id: 'generalSettings.validation.supportUrl',
           defaultMessage: 'You must provide a valid URL',
-        })
+        }),
+        (value) => isValidHttpUrl(value)
       )
       .test(
         'no-trailing-slash',

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -476,6 +476,9 @@
   "common.name": {
     "defaultMessage": "Name"
   },
+  "common.network": {
+    "defaultMessage": "Network"
+  },
   "common.never": {
     "defaultMessage": "Never"
   },
@@ -3700,6 +3703,30 @@
   },
   "moreHelp.visitPlex": {
     "defaultMessage": "Visit {plexLogo}"
+  },
+  "networkSettings.description": {
+    "defaultMessage": "Configure global network settings for your Streamarr instance."
+  },
+  "networkSettings.requestTimeout": {
+    "defaultMessage": "API Request Timeout"
+  },
+  "networkSettings.requestTimeout.description": {
+    "defaultMessage": "Maximum time (in seconds) to wait for responses from external services."
+  },
+  "networkSettings.saveError": {
+    "defaultMessage": "Something went wrong while saving network settings."
+  },
+  "networkSettings.saveSuccess": {
+    "defaultMessage": "Network settings saved successfully"
+  },
+  "networkSettings.title": {
+    "defaultMessage": "Network Settings"
+  },
+  "networkSettings.validation.requestTimeout": {
+    "defaultMessage": "You must provide a valid request timeout"
+  },
+  "networkSettings.validation.requestTimeoutMin": {
+    "defaultMessage": "Request timeout must be at least 1 second"
   },
   "notFound.notFound": {
     "defaultMessage": "Not found"

--- a/src/utils/networkValidation.ts
+++ b/src/utils/networkValidation.ts
@@ -1,0 +1,52 @@
+import validator from 'validator';
+
+const IP_BRACKET_REGEX = /^\[(.*)]$/;
+
+export const isValidHostnameOrIpAddress = (value?: string | null): boolean => {
+  if (!value) {
+    return false;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  // Avoid accepting values that would later be saved with surrounding whitespace.
+  if (trimmed !== value) {
+    return false;
+  }
+
+  if (trimmed.toLowerCase() === 'localhost') {
+    return true;
+  }
+
+  if (validator.isIP(trimmed)) {
+    return true;
+  }
+
+  const bracketMatch = trimmed.match(IP_BRACKET_REGEX);
+  if (bracketMatch && validator.isIP(bracketMatch[1], 6)) {
+    return true;
+  }
+
+  return validator.isFQDN(trimmed, {
+    require_tld: false,
+    allow_underscores: true,
+    allow_trailing_dot: false,
+  });
+};
+
+export const isValidHttpUrl = (value?: string | null): boolean => {
+  if (!value || !value.trim()) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(value);
+
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -233,12 +233,6 @@ components:
         applicationUrl:
           type: string
           example: https://example.com
-        trustProxy:
-          type: boolean
-          example: true
-        csrfProtection:
-          type: boolean
-          example: false
         cacheImages:
           type: boolean
           example: true
@@ -783,6 +777,23 @@ components:
         apiKey:
           type: string
           nullable: true
+    NetworkSettings:
+      type: object
+      required:
+        - requestTimeout
+      properties:
+        requestTimeout:
+          type: integer
+          minimum: 1000
+          maximum: 300000
+          description: Global API request timeout in milliseconds
+          example: 10000
+        trustProxy:
+          type: boolean
+          example: true
+        csrfProtection:
+          type: boolean
+          example: false
     SeerrQuotaResponse:
       type: object
       properties:
@@ -2476,6 +2487,37 @@ paths:
           description: Logo file not found
         '500':
           description: Internal server error
+  /settings/network:
+    get:
+      summary: Get network settings
+      description: Retrieves current global network settings.
+      tags:
+        - settings
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NetworkSettings'
+    post:
+      summary: Update network settings
+      description: Updates global network settings with the provided values.
+      tags:
+        - settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NetworkSettings'
+      responses:
+        '200':
+          description: 'Values were successfully updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NetworkSettings'
   /settings/plex:
     get:
       summary: Get Plex settings


### PR DESCRIPTION
## Summary

Replaces per-service `requestTimeout` fields with a single global **Network Settings** page, following Seer's approach.

## Changes

### Backend
- Added `NetworkSettings` interface to `server/lib/settings.ts` with `requestTimeout: number` (default: 10000ms)
- Added `network` getter/setter to `Settings` class
- Added `GET /api/v1/settings/network` and `POST /api/v1/settings/network` routes
- All service API instantiations (Radarr, Sonarr, Prowlarr, Lidarr) now use `getSettings().network.requestTimeout`
- Fixed missing `prowlarr.disableAuthentication()` call in Prowlarr auth POST route

### Frontend
- Created `src/components/Admin/Settings/Network/index.tsx` — new settings page with `requestTimeout` field (displayed in seconds, stored in ms)
- Created `src/app/admin/settings/network/page.tsx` — Next.js page wrapper
- Added **Network** tab to settings layout nav (between Services and Notifications)
- Removed per-service `requestTimeout` Yup validation, initialValues, onSubmit, and form fields from RadarrModal, SonarrModal, Prowlarr, and Lidarr components

### Validation & API Spec
- Added robust hostname/URL validation utilities (`src/utils/networkValidation.ts`) used across General, Plex, Email, and Uptime settings
- Added `NetworkSettings` schema and `/settings/network` endpoints to `streamarr-api.yml`
- Removed `requestTimeout` from `RadarrSettings`, `SonarrSettings`, `ServiceSettings`, and all test endpoint schemas in the OpenAPI spec

## Testing
- `pnpm typecheck` passes (server + client)