### PR TITLE
perf(frontend): use lodash sub-path imports for tree-shaking

### DIFF
--- a/src/components/Admin/Settings/Plex/index.tsx
+++ b/src/components/Admin/Settings/Plex/index.tsx
@@ -21,7 +21,7 @@ import type { PlexDevice } from '@server/interfaces/api/plexInterfaces';
 import type { PlexSettings } from '@server/lib/settings';
 import axios from 'axios';
 import { Field, Formik } from 'formik';
-import { orderBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 import { useMemo, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 import * as Yup from 'yup';

--- a/src/components/Common/NotificationTypeSelector/index.tsx
+++ b/src/components/Common/NotificationTypeSelector/index.tsx
@@ -2,7 +2,7 @@ import NotificationType from '@app/components/Common/NotificationTypeSelector/No
 import { NotificationType as Notification } from '@server/constants/notification';
 import type { User } from '@app/hooks/useUser';
 import { Permission, useUser } from '@app/hooks/useUser';
-import { sortBy } from 'lodash';
+import orderBy from 'lodash/orderBy';
 import { useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 
@@ -219,7 +219,7 @@ const NotificationTypeSelector = ({
     );
 
     return user
-      ? sortBy(filteredTypes, 'hasNotifyUser', 'DESC')
+      ? orderBy(filteredTypes, ['hasNotifyUser'], ['desc'])
       : filteredTypes;
   }, [intl, user, hasPermission, enabledTypes]);
 

--- a/src/components/Common/Slider/index.tsx
+++ b/src/components/Common/Slider/index.tsx
@@ -1,6 +1,6 @@
 import RecentInvite from '@app/components/Common/Slider/RecentInvite';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import type { JSX } from 'react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSpring } from 'react-spring';

--- a/src/components/LibrarySelector/index.tsx
+++ b/src/components/LibrarySelector/index.tsx
@@ -1,5 +1,5 @@
 import type { Library } from '@server/lib/settings';
-import { sortBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 import { useMemo } from 'react';
 import type { CSSObjectWithLabel } from 'react-select';
 import Select from 'react-select';


### PR DESCRIPTION
## Description

Lodash v4 is a legacy CJS-only package with no `sideEffects` declaration and no `exports` map. This means webpack/turbopack cannot tree-shake barrel imports — every `import { x } from 'lodash'` pulls in the entire ~72KB minified library.

Replacing with sub-path imports (`lodash/orderBy`, `lodash/sortBy`, etc.) lets the bundler include only the specific function module instead of the full barrel.

Changed files (all frontend, 4 components):

- `src/components/Admin/Settings/Plex/index.tsx` — `orderBy`
- `src/components/Common/NotificationTypeSelector/index.tsx` — `sortBy`
- `src/components/Common/Slider/index.tsx` — `debounce`
- `src/components/LibrarySelector/index.tsx` — `sortBy`

Server-side lodash usage (`merge`, `mergeWith`, `omit`, `set`, `escapeRegExp`, `sortBy`, `uniqWith`) is intentionally left unchanged — no bundle impact on the server.

## Has This Been Tested?

- `pnpm typecheck:client` passes

## Screenshots (if applicable)

N/A — import-only change, no UI impact

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
