### PR TITLE
fix(webpush): add dataDevices to verifyWebPush useEffect deps

### DIFF
--- a/src/components/UserProfile/UserSettings/UserSettingsNotifications/UserNotificationsWebpush.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsNotifications/UserNotificationsWebpush.tsx
@@ -173,7 +173,7 @@ const UserWebPushSettings = () => {
     if (user?.id) {
       verifyWebPush();
     }
-  }, [user?.id, currentSettings]);
+  }, [user?.id, currentSettings, dataDevices]);
 
   useEffect(() => {
     const getSubscriptionEndpoint = async () => {


### PR DESCRIPTION
## Description

In `UserNotificationsWebpush`, the `verifyWebPush` function checks whether the current browser's push subscription is already registered among the user's devices. The `useEffect` that calls it was missing `dataDevices` (the SWR result for the device list) from its dependency array:

```ts
// Before
}, [user?.id, currentSettings]);

// After
}, [user?.id, currentSettings, dataDevices]);
```

Without `dataDevices` in the deps, the effect would not re-run when the device list changed (e.g. after a device is added or removed elsewhere). This caused push subscription status to go stale — the UI could show an incorrect registration state until a full page reload.

## Has This Been Tested?

- `pnpm typecheck:client` passes

## Screenshots (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
