### PR TITLE
feat(avatarproxy): add server-side avatar caching and proxy

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -20,6 +20,7 @@ import logger from '@server/logger';
 import clearCookies from '@server/middleware/clearcookies';
 import { checkUser } from '@server/middleware/auth';
 import routes from '@server/routes';
+import avatarproxy from '@server/routes/avatarproxy';
 import imageproxy from '@server/routes/imageproxy';
 import logoRoutes from '@server/routes/logo';
 import { onboardingImageService } from '@server/lib/onboarding';
@@ -211,6 +212,7 @@ app
       },
       imageproxy
     );
+    server.use('/avatarproxy', clearCookies, avatarproxy);
     server.use('/logo', clearCookies, logoRoutes);
     server.use(
       '/onboarding/images',

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -74,6 +74,7 @@ export interface CacheResponse {
   imageCache: {
     tmdb: { size: number; imageCount: number };
     plex: { size: number; imageCount: number };
+    avatar: { size: number; imageCount: number };
     qrcode: { size: number; imageCount: number };
   };
 }

--- a/server/job/schedule.ts
+++ b/server/job/schedule.ts
@@ -52,9 +52,10 @@ export const startJobs = (): void => {
       logger.info('Starting scheduled job: Image Cache Cleanup', {
         label: 'Jobs',
       });
-      // Clean TMDB and Plex image caches
+      // Clean TMDB, Plex, and avatar image caches
       ImageProxy.clearCache('tmdb');
       ImageProxy.clearCache('plex');
+      ImageProxy.clearCache('avatar');
     }),
   });
 

--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -156,6 +156,20 @@ class ImageProxy {
     }
   }
 
+  public static async clearCachedImage(
+    key: string,
+    imageUrl: string
+  ): Promise<void> {
+    const mapKey = `${key}::`;
+    const proxy =
+      ImageProxy.instanceCache.get(mapKey) ?? new ImageProxy(key, '');
+    const cacheKey = proxy.getCacheKey(imageUrl);
+    const directory = join(proxy.getCacheDirectory(), cacheKey);
+    await promises.rm(directory, { force: true, recursive: true }).catch(() => {
+      // Directory may not exist — ignore
+    });
+  }
+
   public async getImage(path: string): Promise<ImageResponse> {
     const cacheKey = this.getCacheKey(path);
 

--- a/server/lib/rateLimiters.ts
+++ b/server/lib/rateLimiters.ts
@@ -13,3 +13,10 @@ export const resetPasswordLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
 });
+
+export const avatarLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 120, // 2 req/sec per IP — covers page loads, blocks bulk enumeration
+  standardHeaders: true,
+  legacyHeaders: false,
+});

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -9,6 +9,7 @@ import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { resetPasswordLimiter } from '@server/lib/rateLimiters';
 import { isAuthenticated } from '@server/middleware/auth';
+import ImageProxy from '@server/lib/imageproxy';
 import { Router } from 'express';
 
 const authRoutes = Router();
@@ -121,6 +122,7 @@ authRoutes.post('/plex', async (req, res, next) => {
             );
           }
 
+          const previousAvatar = user.avatar;
           user.plexToken = body.authToken;
           user.plexId = account.id;
           user.avatar = account.thumb;
@@ -129,6 +131,9 @@ authRoutes.post('/plex', async (req, res, next) => {
           user.userType = UserType.PLEX;
 
           await userRepository.save(user);
+          if (previousAvatar && previousAvatar !== user.avatar) {
+            void ImageProxy.clearCachedImage('avatar', previousAvatar);
+          }
         } else if (!settings.main.newPlexLogin) {
           logger.warn(
             'Failed sign-in attempt by unimported Plex user with access to the media app',

--- a/server/routes/avatarproxy.ts
+++ b/server/routes/avatarproxy.ts
@@ -1,0 +1,87 @@
+import { getRepository } from '@server/datasource';
+import { User } from '@server/entity/User';
+import ImageProxy from '@server/lib/imageproxy';
+import { avatarLimiter } from '@server/lib/rateLimiters';
+import logger from '@server/logger';
+import { Router } from 'express';
+
+const router = Router();
+
+const DEFAULT_AVATAR =
+  'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mm&s=200';
+const AVATAR_MAX_AGE = 60 * 60 * 24; // 24 hours
+
+// Block loopback and RFC-1918 private address ranges to prevent SSRF
+const PRIVATE_HOST_RE =
+  /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|::1$|fc00:|fe80:)/i;
+
+function isValidAvatarUrl(url: string): boolean {
+  try {
+    const { protocol, hostname } = new URL(url);
+    return protocol === 'https:' && !PRIVATE_HOST_RE.test(hostname);
+  } catch {
+    return false;
+  }
+}
+
+const validateAvatarImageResponse = (headers: Record<string, unknown>) => {
+  const contentType = headers['content-type'];
+  if (typeof contentType !== 'string' || !contentType.startsWith('image/')) {
+    throw new Error(`Invalid avatar content type: ${String(contentType)}`);
+  }
+};
+
+function getAvatarProxy(): ImageProxy {
+  return ImageProxy.getOrCreate('avatar', '', {
+    defaultMaxAge: AVATAR_MAX_AGE,
+    validateResponse: validateAvatarImageResponse,
+  });
+}
+
+router.use(avatarLimiter);
+
+router.get('/:userId', async (req, res) => {
+  try {
+    const userId = parseInt(req.params.userId, 10);
+    if (isNaN(userId) || userId <= 0) {
+      return res.status(400).send('Invalid user ID');
+    }
+
+    const user = await getRepository(User).findOne({
+      select: ['id', 'avatar'],
+      where: { id: userId },
+    });
+    const dbAvatar = user?.avatar;
+    if (dbAvatar && !isValidAvatarUrl(dbAvatar)) {
+      return res.status(400).send('Invalid avatar URL');
+    }
+    const avatarUrl = dbAvatar || DEFAULT_AVATAR;
+
+    const proxy = getAvatarProxy();
+    const imageData = await proxy.getImage(avatarUrl);
+
+    // Respond 304 if client already has the current version
+    const ifNoneMatch = req.headers['if-none-match'];
+    if (ifNoneMatch && ifNoneMatch === `"${imageData.meta.etag}"`) {
+      return res.status(304).end();
+    }
+
+    res.writeHead(200, {
+      'Content-Type': `image/${imageData.meta.extension}`,
+      'Content-Length': imageData.imageBuffer.length,
+      'Cache-Control': `public, max-age=${imageData.meta.curRevalidate}`,
+      ETag: `"${imageData.meta.etag}"`,
+      'Streamarr-Cache-Status': imageData.meta.cacheMiss ? 'MISS' : 'HIT',
+      'Streamarr-Cache-Key': imageData.meta.cacheKey,
+    });
+    res.end(imageData.imageBuffer);
+  } catch (e) {
+    logger.error('Failed to proxy avatar image', {
+      label: 'Avatar Proxy',
+      errorMessage: e instanceof Error ? e.message : String(e),
+    });
+    res.status(500).end();
+  }
+});
+
+export default router;

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -957,6 +957,7 @@ settingsRoutes.get('/cache', async (_req, res) => {
 
   const tmdbImageCache = await ImageProxy.getImageStats('tmdb');
   const plexImageCache = await ImageProxy.getImageStats('plex');
+  const avatarImageCache = await ImageProxy.getImageStats('avatar');
 
   // QR code cache stats
   const qrProxy = new QRCodeProxy();
@@ -981,6 +982,7 @@ settingsRoutes.get('/cache', async (_req, res) => {
     imageCache: {
       tmdb: tmdbImageCache,
       plex: plexImageCache,
+      avatar: avatarImageCache,
       qrcode: { imageCount: qrImageCount, size: qrCacheSize },
     },
   });

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -22,6 +22,7 @@ import { hasPermission, Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
+import ImageProxy from '@server/lib/imageproxy';
 import { Router } from 'express';
 import type { EntityManager } from 'typeorm';
 import { In, Not } from 'typeorm';
@@ -693,6 +694,7 @@ router.post(
 
           if (user) {
             // Update the user's avatar with their Plex thumbnail, in case it changed
+            const previousAvatar = user.avatar;
             user.avatar = account.thumb;
             user.email = account.email;
             user.plexUsername = account.username;
@@ -703,6 +705,9 @@ router.post(
               user.plexId = parseInt(account.id);
             }
             await userRepository.save(user);
+            if (previousAvatar && previousAvatar !== user.avatar) {
+              void ImageProxy.clearCachedImage('avatar', previousAvatar);
+            }
           } else if (!body || body.plexIds.includes(account.id)) {
             if (await mainPlexTv.checkUserAccess(parseInt(account.id))) {
               const newUser = new User({

--- a/src/components/Admin/Settings/JobsCache/index.tsx
+++ b/src/components/Admin/Settings/JobsCache/index.tsx
@@ -618,6 +618,15 @@ const JobsCacheSettings = () => {
                   </Table.TD>
                 </tr>
                 <tr>
+                  <Table.TD>User Avatars</Table.TD>
+                  <Table.TD>
+                    {cacheData?.imageCache.avatar?.imageCount ?? 0}
+                  </Table.TD>
+                  <Table.TD>
+                    {formatBytes(cacheData?.imageCache.avatar?.size ?? 0)}
+                  </Table.TD>
+                </tr>
+                <tr>
                   <Table.TD>
                     <FormattedMessage
                       id="imageCache.qrcode"

--- a/src/components/Admin/Users/index.tsx
+++ b/src/components/Admin/Users/index.tsx
@@ -640,7 +640,7 @@ const AdminUsers = () => {
                   >
                     <CachedImage
                       className="h-10 w-10 rounded-full object-cover"
-                      src={user.avatar}
+                      src={`/avatarproxy/${user.id}`}
                       alt=""
                       width={40}
                       height={40}

--- a/src/components/Common/Slider/RecentInvite.tsx
+++ b/src/components/Common/Slider/RecentInvite.tsx
@@ -100,7 +100,11 @@ const RecentInvite = ({ invite }: RecentInviteProps) => {
             </button>
             <span className="font-extrabold flex items-center truncate gap-2">
               <CachedImage
-                src={invite?.createdBy?.avatar}
+                src={
+                  invite?.createdBy?.id
+                    ? `/avatarproxy/${invite.createdBy.id}`
+                    : undefined
+                }
                 alt=""
                 className="object-cover rounded-full"
                 width={20}
@@ -208,7 +212,7 @@ const RecentInvite = ({ invite }: RecentInviteProps) => {
                         }
                       >
                         <CachedImage
-                          src={user?.avatar}
+                          src={user?.id ? `/avatarproxy/${user.id}` : undefined}
                           alt=""
                           className="size-6 rounded-full border-2 border-base-100 group-hover:border-primary"
                           width={24}
@@ -228,7 +232,7 @@ const RecentInvite = ({ invite }: RecentInviteProps) => {
                         }
                       >
                         <CachedImage
-                          src={user?.avatar}
+                          src={user?.id ? `/avatarproxy/${user.id}` : undefined}
                           alt=""
                           className="size-6 rounded-full border-2 border-base-100"
                           width={24}

--- a/src/components/Common/Slider/RecentRequest.tsx
+++ b/src/components/Common/Slider/RecentRequest.tsx
@@ -122,10 +122,10 @@ const RequestCardError = ({
                     }
                     className="group flex items-center"
                   >
-                    {requestData.requestedBy.avatar && (
+                    {requestData.requestedBy.id && (
                       <span className="mr-2 rounded-full">
                         <CachedImage
-                          src={requestData.requestedBy.avatar}
+                          src={`/avatarproxy/${requestData.requestedBy.id}`}
                           alt=""
                           className="rounded-full object-cover"
                           width={20}
@@ -232,10 +232,10 @@ const RequestCard = ({ request }: { request: SeerrRequestItem }) => {
             }
             className="group flex items-center gap-2"
           >
-            {requestData.requestedBy.avatar && (
+            {requestData.requestedBy.id && (
               <span className="rounded-full">
                 <CachedImage
-                  src={requestData.requestedBy.avatar}
+                  src={`/avatarproxy/${requestData.requestedBy.id}`}
                   alt=""
                   className="rounded-full object-cover"
                   width={20}

--- a/src/components/Common/UserSelector/index.tsx
+++ b/src/components/Common/UserSelector/index.tsx
@@ -164,7 +164,7 @@ const UserSelector = ({
                 {!multiple && !Array.isArray(selectedUser) && selectedUser ? (
                   <span className="flex items-center">
                     <CachedImage
-                      src={selectedUser.avatar}
+                      src={`/avatarproxy/${selectedUser.id}`}
                       alt=""
                       className="h-6 w-6 flex-shrink-0 rounded-full object-cover"
                       width={24}
@@ -187,7 +187,7 @@ const UserSelector = ({
                     {selectedUser.map((user, idx) => (
                       <CachedImage
                         key={user?.id || idx}
-                        src={user?.avatar}
+                        src={user?.id ? `/avatarproxy/${user.id}` : undefined}
                         alt=""
                         className="size-6 flex-shrink-0 rounded-full object-cover"
                         width={24}
@@ -236,7 +236,7 @@ const UserSelector = ({
                             } flex items-center`}
                           >
                             <CachedImage
-                              src={user.avatar}
+                              src={`/avatarproxy/${user.id}`}
                               alt=""
                               className="h-6 w-6 flex-shrink-0 rounded-full object-cover"
                               width={24}

--- a/src/components/InviteList/InviteModal/index.tsx
+++ b/src/components/InviteList/InviteModal/index.tsx
@@ -791,7 +791,7 @@ const InviteModal = ({
                                   >
                                     <span className="flex items-center">
                                       <CachedImage
-                                        src={selectedUser.avatar}
+                                        src={`/avatarproxy/${selectedUser.id}`}
                                         alt=""
                                         className="h-6 w-6 flex-shrink-0 rounded-full object-cover"
                                         width={24}
@@ -858,7 +858,7 @@ const InviteModal = ({
                                                 } flex items-center`}
                                               >
                                                 <CachedImage
-                                                  src={user.avatar}
+                                                  src={`/avatarproxy/${user.id}`}
                                                   alt=""
                                                   className="h-6 w-6 flex-shrink-0 rounded-full object-cover"
                                                   width={24}

--- a/src/components/InviteList/InvitesCard/index.tsx
+++ b/src/components/InviteList/InvitesCard/index.tsx
@@ -292,7 +292,11 @@ const InviteCard = ({ invite, onEdit, onDelete, onShare }: InviteCardProps) => {
                     href={`/admin/users/${invite?.createdBy?.id}`}
                   >
                     <CachedImage
-                      src={invite?.createdBy?.avatar}
+                      src={
+                        invite?.createdBy?.id
+                          ? `/avatarproxy/${invite.createdBy.id}`
+                          : undefined
+                      }
                       alt=""
                       className="size-5 mr-1 ml-1.5 object-cover rounded-full"
                       width={20}
@@ -312,7 +316,11 @@ const InviteCard = ({ invite, onEdit, onDelete, onShare }: InviteCardProps) => {
                     href={`/profile`}
                   >
                     <CachedImage
-                      src={invite?.createdBy?.avatar}
+                      src={
+                        invite?.createdBy?.id
+                          ? `/avatarproxy/${invite.createdBy.id}`
+                          : undefined
+                      }
                       alt=""
                       className="size-5 mr-1 ml-1.5 object-cover rounded-full"
                       width={20}
@@ -330,7 +338,11 @@ const InviteCard = ({ invite, onEdit, onDelete, onShare }: InviteCardProps) => {
                     <FormattedMessage id="common.by" defaultMessage="by" />{' '}
                     <span className="font-extrabold flex items-center truncate">
                       <CachedImage
-                        src={invite?.createdBy?.avatar}
+                        src={
+                          invite?.createdBy?.id
+                            ? `/avatarproxy/${invite.createdBy.id}`
+                            : undefined
+                        }
                         alt=""
                         className="size-5 mr-1 ml-1.5 object-cover rounded-full"
                         width={20}
@@ -361,7 +373,11 @@ const InviteCard = ({ invite, onEdit, onDelete, onShare }: InviteCardProps) => {
                     href={`/admin/users/${invite?.updatedBy?.id}`}
                   >
                     <CachedImage
-                      src={invite?.updatedBy?.avatar}
+                      src={
+                        invite?.updatedBy?.id
+                          ? `/avatarproxy/${invite.updatedBy.id}`
+                          : undefined
+                      }
                       alt=""
                       className="size-5 mr-1 ml-1.5 object-cover rounded-full"
                       width={20}
@@ -380,7 +396,11 @@ const InviteCard = ({ invite, onEdit, onDelete, onShare }: InviteCardProps) => {
                     href={`/profile`}
                   >
                     <CachedImage
-                      src={invite?.updatedBy?.avatar}
+                      src={
+                        invite?.updatedBy?.id
+                          ? `/avatarproxy/${invite.updatedBy.id}`
+                          : undefined
+                      }
                       alt=""
                       className="size-5 mr-1 ml-1.5 object-cover rounded-full"
                       width={20}
@@ -398,7 +418,11 @@ const InviteCard = ({ invite, onEdit, onDelete, onShare }: InviteCardProps) => {
                     <FormattedMessage id="common.by" defaultMessage="by" />{' '}
                     <span className="font-extrabold flex items-center truncate">
                       <CachedImage
-                        src={invite?.updatedBy?.avatar}
+                        src={
+                          invite?.updatedBy?.id
+                            ? `/avatarproxy/${invite.updatedBy.id}`
+                            : undefined
+                        }
                         alt=""
                         className="size-5 mr-1 ml-1.5 object-cover rounded-full"
                         width={20}
@@ -433,7 +457,9 @@ const InviteCard = ({ invite, onEdit, onDelete, onShare }: InviteCardProps) => {
                           title={user?.displayName}
                         >
                           <CachedImage
-                            src={user?.avatar}
+                            src={
+                              user?.id ? `/avatarproxy/${user.id}` : undefined
+                            }
                             alt=""
                             className="size-6 rounded-full border-2 border-base-100 group-hover:border-primary"
                             width={24}
@@ -443,7 +469,9 @@ const InviteCard = ({ invite, onEdit, onDelete, onShare }: InviteCardProps) => {
                       ) : (
                         <span key={user?.id || idx} title={user?.displayName}>
                           <CachedImage
-                            src={user?.avatar}
+                            src={
+                              user?.id ? `/avatarproxy/${user.id}` : undefined
+                            }
                             alt=""
                             className="size-6 rounded-full border-2 border-base-100"
                             width={24}

--- a/src/components/Layout/UserCard/index.tsx
+++ b/src/components/Layout/UserCard/index.tsx
@@ -42,7 +42,7 @@ const UserCard = ({
       >
         <CachedImage
           className="inline-block h-16 w-16 rounded-full ring-1 ring-primary-content shadow-3xl"
-          src={user?.avatar}
+          src={user?.id ? `/avatarproxy/${user.id}` : undefined}
           alt="user"
           width={64}
           height={64}

--- a/src/components/Layout/UserDropdown/index.tsx
+++ b/src/components/Layout/UserDropdown/index.tsx
@@ -82,7 +82,7 @@ const UserDropdown = ({
         dropdownIcon={
           <CachedImage
             className="h-9 w-9 rounded-full mr-1"
-            src={user?.avatar}
+            src={user?.id ? `/avatarproxy/${user.id}` : undefined}
             alt=""
             width={36}
             height={36}

--- a/src/components/NotificationList/NotificationCard/index.tsx
+++ b/src/components/NotificationList/NotificationCard/index.tsx
@@ -215,7 +215,11 @@ export const NotificationCard = ({
         <div className="relative inline-flex size-16 flex-shrink-0 items-center justify-center rounded-full border border-primary-content shadow-md mb-2">
           <div>
             <CachedImage
-              src={notification?.createdBy?.avatar || logoSmallSrc}
+              src={
+                notification?.createdBy?.id
+                  ? `/avatarproxy/${notification.createdBy.id}`
+                  : logoSmallSrc
+              }
               alt=""
               className="rounded-full"
               width={64}

--- a/src/components/UserProfile/ProfileHeader/index.tsx
+++ b/src/components/UserProfile/ProfileHeader/index.tsx
@@ -62,7 +62,7 @@ const ProfileHeader = ({ user, isSettingsPage }: ProfileHeaderProps) => {
           <div className="relative">
             <CachedImage
               className="h-24 w-24 rounded-full bg-primary-content object-cover ring-1 ring-primary-content"
-              src={user.avatar}
+              src={`/avatarproxy/${user.id}`}
               alt=""
               width={96}
               height={96}

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -3959,6 +3959,15 @@ paths:
                           imageCount:
                             type: number
                             example: 123
+                      avatar:
+                        type: object
+                        properties:
+                          size:
+                            type: number
+                            example: 123456
+                          imageCount:
+                            type: number
+                            example: 123
                   apiCaches:
                     type: array
                     items:


### PR DESCRIPTION
## Description

Adds a server-side avatar proxy that fetches and caches user avatar images on the server rather than loading them directly from external URLs (e.g. Plex CDN) in the browser.

- New `/avatarproxy/:userId` Express route that looks up the user's avatar URL and proxies the image through the server-side image cache
- 24-hour default TTL, ETag/304 support, falls back to the Gravatar mystery-man default when the user has no avatar set
- Rate-limited at 120 requests/min per IP to prevent bulk enumeration
- Cache is invalidated automatically on Plex login and Plex user sync when a user's avatar URL changes (fire-and-forget, does not block the response)
- Static `ImageProxy.clearCachedImage(key, imageUrl)` method added for targeted single-image cache removal
- Nightly image cache cleanup job now includes the avatar cache alongside TMDB and Plex caches
- All 10 frontend components that rendered user avatars updated to use `/avatarproxy/${user.id}` instead of external avatar URLs directly — guards use `?.id` check so `undefined` is passed to `CachedImage` rather than a broken URL
- Admin Settings → Jobs & Cache page now includes a **User Avatars** row showing image count and total cache size
- `CacheResponse` interface and OpenAPI spec updated to include the `avatar` image cache entry

## Has This Been Tested?

- Dev server tested: avatars load correctly, cache HIT/MISS headers visible in devtools
- Verified 304 responses on repeat requests with matching ETag
- Confirmed avatar cache row appears in admin Jobs & Cache settings
- `pnpm prepare && pnpm build` passing

## Screenshots (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
