### PR TITLE
fix(auth): handle local login boundary whitespace safely

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -204,26 +204,28 @@ authRoutes.post('/local', async (req, res, next) => {
   const settings = getSettings();
   const userRepository = getRepository(User);
   const body = req.body as { email?: string; password?: string };
+  const normalizedEmail = body.email?.trim().toLowerCase();
 
   if (!settings.main.localLogin) {
-    res.status(500).json({ error: 'Password sign-in is disabled.' });
-  } else if (!body.email || !body.password) {
-    res.status(500).json({
-      error: 'You must provide both an email address and a password.',
+    return next({ status: 403, message: 'Password sign-in is disabled.' });
+  } else if (!normalizedEmail || !body.password) {
+    return next({
+      status: 400,
+      message: 'You must provide both an email address and a password.',
     });
   }
   try {
     const user = await userRepository
       .createQueryBuilder('user')
       .select(['user.id', 'user.email', 'user.password', 'user.plexId'])
-      .where('user.email = :email', { email: body.email.toLowerCase() })
+      .where('user.email = :email', { email: normalizedEmail })
       .getOne();
 
     if (!user || !(await user.passwordMatch(body.password))) {
       logger.warn('Failed sign-in attempt using invalid Streamarr password', {
         label: 'API',
         ip: req.ip,
-        email: body.email,
+        email: normalizedEmail,
         userId: user?.id,
       });
       return next({ status: 403, message: 'Access denied.' });
@@ -246,7 +248,7 @@ authRoutes.post('/local', async (req, res, next) => {
           label: 'API',
           account: {
             ip: req.ip,
-            email: body.email,
+            email: normalizedEmail,
             userId: user.id,
             plexId: user.plexId,
           },
@@ -264,7 +266,12 @@ authRoutes.post('/local', async (req, res, next) => {
   } catch (e) {
     logger.error(
       'Something went wrong authenticating with Streamarr password',
-      { label: 'API', errorMessage: e.message, ip: req.ip, email: body.email }
+      {
+        label: 'API',
+        errorMessage: e.message,
+        ip: req.ip,
+        email: normalizedEmail,
+      }
     );
     return next({ status: 500, message: 'Unable to authenticate.' });
   }

--- a/src/components/SignIn/LocalSignIn.tsx
+++ b/src/components/SignIn/LocalSignIn.tsx
@@ -20,6 +20,7 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
 
   const LoginSchema = Yup.object().shape({
     email: Yup.string()
+      .transform((value) => value?.trim() ?? value)
       .test(
         'email',
         intl.formatMessage({
@@ -54,9 +55,10 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
       }}
       validationSchema={LoginSchema}
       onSubmit={async (values) => {
+        setLoginError(null);
         try {
           await axios.post('/api/v1/auth/local', {
-            email: values.email,
+            email: values.email.trim(),
             password: values.password,
           });
         } catch {
@@ -71,7 +73,11 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
         }
       }}
     >
-      {({ errors, touched, isSubmitting, isValid }) => {
+      {({ errors, touched, isSubmitting, isValid, values }) => {
+        const hasBoundaryWhitespace =
+          values.email !== values.email.trim() ||
+          values.password !== values.password.trim();
+
         return (
           <div className="p-4 place-content-center bg-secondary/50 border border-secondary rounded-b-lg">
             <Form className="mt-4">
@@ -137,6 +143,14 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
                       {errors.password}
                     </div>
                   )}
+                {hasBoundaryWhitespace && (
+                  <div className="text-center text-warning text-sm my-2">
+                    <FormattedMessage
+                      id="signIn.whitespaceWarning"
+                      defaultMessage="Leading or trailing spaces in your email or password can cause issues signing in."
+                    />
+                  </div>
+                )}
                 <div className="form-control my-4">
                   <label className="flex cursor-pointer place-items-center">
                     <input

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -4733,6 +4733,9 @@
   "signIn.title": {
     "defaultMessage": "Sign in to continue"
   },
+  "signIn.whitespaceWarning": {
+    "defaultMessage": "Leading or trailing spaces in your email or password can cause issues signing in."
+  },
   "signUp.autoPinLibrariesFailed": {
     "defaultMessage": "Pinning libraries failed"
   },


### PR DESCRIPTION
## Description

Improves local sign-in robustness when users accidentally include leading/trailing whitespace in credentials.

- Backend now normalizes local-login email input with `trim().toLowerCase()` before lookup.
- Frontend local sign-in now trims email before submit.
- Added an inline warning when email or password contains leading/trailing whitespace.
- Added i18n message key for the new warning text.

## Has This Been Tested?

- Ran `pnpm typecheck:server` (pass)
- Ran `pnpm typecheck:client` (pass)
- Verified local-login flow changes in code review for:
  - normalized email lookup in backend auth route
  - warning display condition for boundary whitespace
  - trimmed email submission in local sign-in form

## Screenshots (if applicable)

- N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
