### PR TITLE
ci(codeql): run required checks on all PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,9 +10,6 @@ on:
       - 'docs/**'
   pull_request:
     branches: ['develop']
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
   schedule:
     - cron: '50 7 * * 5'
   workflow_dispatch:


### PR DESCRIPTION
## Description

Ensure required CodeQL checks are always reported on pull requests by removing `pull_request.paths-ignore` from the CodeQL workflow.

This prevents docs-only PRs from being blocked with pending required checks (`Analyze (javascript)`, `Analyze (actions)`, `CodeQL`) when the workflow is skipped.

## Has This Been Tested?

- Verified workflow file parses with GitHub CLI (`gh workflow list --all`).
- Triggered manual CodeQL dispatch previously on a docs-only branch to confirm check reporting behavior.

## Screenshots (if applicable)

- N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
