### PR TITLE
fix(security): harden avatar proxy and fix push subscription transaction

### DIFF
--- a/server/routes/avatarproxy.ts
+++ b/server/routes/avatarproxy.ts
@@ -11,14 +11,25 @@ const DEFAULT_AVATAR =
   'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mm&s=200';
 const AVATAR_MAX_AGE = 60 * 60 * 24; // 24 hours
 
-// Block loopback and RFC-1918 private address ranges to prevent SSRF
-const PRIVATE_HOST_RE =
-  /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|::1$|fc00:|fe80:)/i;
+// Only allow avatars from these known, trusted hosts
+const ALLOWED_AVATAR_HOSTS = new Set([
+  'plex.tv',
+  'metadata.provider.plex.tv',
+  'secure.gravatar.com',
+  'www.gravatar.com',
+  'gravatar.com',
+  'i.imgur.com',
+  'cdn.discordapp.com',
+]);
 
 function isValidAvatarUrl(url: string): boolean {
   try {
     const { protocol, hostname } = new URL(url);
-    return protocol === 'https:' && !PRIVATE_HOST_RE.test(hostname);
+    if (protocol !== 'https:') return false;
+    // Check exact match or subdomain match for allowed hosts
+    return [...ALLOWED_AVATAR_HOSTS].some(
+      (allowed) => hostname === allowed || hostname.endsWith(`.${allowed}`)
+    );
   } catch {
     return false;
   }
@@ -52,10 +63,17 @@ router.get('/:userId', async (req, res) => {
       where: { id: userId },
     });
     const dbAvatar = user?.avatar;
-    if (dbAvatar && !isValidAvatarUrl(dbAvatar)) {
-      return res.status(400).send('Invalid avatar URL');
+    const avatarAllowed = !!dbAvatar && isValidAvatarUrl(dbAvatar);
+    if (dbAvatar && !avatarAllowed) {
+      logger.warn('Avatar URL not in allowlist, falling back to default', {
+        label: 'Avatar Proxy',
+        userId,
+        avatarHost: URL.canParse(dbAvatar)
+          ? new URL(dbAvatar).hostname
+          : 'unknown',
+      });
     }
-    const avatarUrl = dbAvatar || DEFAULT_AVATAR;
+    const avatarUrl = avatarAllowed ? dbAvatar : DEFAULT_AVATAR;
 
     const proxy = getAvatarProxy();
     const imageData = await proxy.getImage(avatarUrl);

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -7,7 +7,7 @@ import SeerrAPI from '@server/api/seerr';
 import TautulliAPI, { type TautulliHistoryRecord } from '@server/api/tautulli';
 import TheMovieDb from '@server/api/themoviedb';
 import { UserType } from '@server/constants/user';
-import dataSource, { getRepository } from '@server/datasource';
+import { getRepository } from '@server/datasource';
 import { User } from '@server/entity/User';
 import { UserPushSubscription } from '@server/entity/UserPushSubscription';
 import type {
@@ -24,7 +24,7 @@ import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
 import ImageProxy from '@server/lib/imageproxy';
 import { Router } from 'express';
-import type { EntityManager } from 'typeorm';
+
 import { In, Not } from 'typeorm';
 import userSettingsRoutes, { isOwnProfileOrAdmin } from './usersettings';
 import userOnboardingRoutes from './onboarding';
@@ -212,8 +212,8 @@ router.post<
   { endpoint: string; p256dh: string; auth: string; userAgent: string }
 >('/registerPushSubscription', async (req, res, next) => {
   try {
-    await dataSource.transaction(
-      async (transactionalEntityManager: EntityManager) => {
+    await getRepository(UserPushSubscription).manager.transaction(
+      async (transactionalEntityManager) => {
         const transactionalRepo =
           transactionalEntityManager.getRepository(UserPushSubscription);
 


### PR DESCRIPTION
## Description

Hardens the avatar proxy against SSRF attacks and fixes push subscription DB access to follow project conventions.

**`server/routes/avatarproxy.ts`**
- Replace private-IP SSRF regex with an explicit allowlist of trusted avatar hosts (Plex, Gravatar, Imgur, Discord CDN) to prevent DNS rebinding and open-redirect attacks
- Fall back to `DEFAULT_AVATAR` with a warning log when a stored avatar URL is not in the allowlist, instead of returning `400` — avoids breaking avatar rendering for users with stale/unsupported URLs in the DB

**`server/routes/user/index.ts`**
- Replace direct `dataSource.transaction()` with `getRepository(UserPushSubscription).manager.transaction()` to keep all DB access going through `getRepository` per project conventions

## Has This Been Tested?

Yes — tested locally against the existing live database. Avatar proxy falls back correctly for off-allowlist URLs, and push subscription registration continues to function as expected.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)