### PR TITLE
feat(i18n): add LanguagePicker to Help Centre

### DIFF
--- a/src/components/Help/Breadcrumbs/index.tsx
+++ b/src/components/Help/Breadcrumbs/index.tsx
@@ -4,6 +4,8 @@ import React from 'react';
 import { ChevronRightIcon, PrinterIcon } from '@heroicons/react/24/solid';
 import Link from 'next/link';
 import { FormattedMessage } from 'react-intl';
+import LanguagePicker from '@app/components/Layout/LanguagePicker';
+import { useUser } from '@app/hooks/useUser';
 
 type TBreadCrumbProps = {
   homeElement: ReactNode;
@@ -20,7 +22,7 @@ type TBreadCrumbProps = {
 const Breadcrumbs = ({
   homeElement = 'Help Centre',
   separator = <ChevronRightIcon className="w-5 h-5 mx-3" />,
-  containerClasses = 'flex flex-wrap mx-4 md:mx-16 place-items-center print:hidden',
+  containerClasses = 'flex flex-wrap mx-4 md:mx-16 place-items-center print:hidden relative',
   listClasses = 'inline-flex items-center gap-2 link-primary',
   activeClasses = 'text-neutral hover:text-neutral pointer-events-none',
   capitalizeLinks = true,
@@ -30,6 +32,7 @@ const Breadcrumbs = ({
 }: TBreadCrumbProps) => {
   const pathNames = paths.split('/').filter((path) => path);
   const pathTitles = names.split(',').filter((name) => name);
+  const { user, loading } = useUser({ disableAutoRevalidation: true });
 
   return (
     <div className={containerClasses}>
@@ -55,18 +58,25 @@ const Breadcrumbs = ({
           </React.Fragment>
         );
       })}
-      {print && (
-        <button
-          onClick={() => {
-            window.print();
-            return false;
-          }}
-          className="btn rounded-none bg-zinc-200 border-zinc-600 border-2 text-zinc-600 hover:bg-zinc-500 hover:text-white hover:border-zinc-500 btn-sm min-h-10 uppercase ms-auto"
-        >
-          <PrinterIcon className="w-5 h-5" />{' '}
-          <FormattedMessage id="common.print" defaultMessage="Print" />
-        </button>
-      )}
+      <div className="ms-auto flex flex-wrap items-center gap-2">
+        {!user && !loading && (
+          <div className="text-white">
+            <LanguagePicker />
+          </div>
+        )}
+        {print && (
+          <button
+            onClick={() => {
+              window.print();
+              return false;
+            }}
+            className="btn rounded-none bg-zinc-200 border-zinc-600 border-2 text-zinc-600 hover:bg-zinc-500 hover:text-white hover:border-zinc-500 btn-sm min-h-10 uppercase"
+          >
+            <PrinterIcon className="w-5 h-5" />{' '}
+            <FormattedMessage id="common.print" defaultMessage="Print" />
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/components/Help/Header/index.tsx
+++ b/src/components/Help/Header/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 import ImageFader from '@app/components/Common/ImageFader';
 import Header from '@app/components/Layout/Header';
+import LanguagePicker from '@app/components/Layout/LanguagePicker';
+import { useUser } from '@app/hooks/useUser';
 import { FormattedMessage } from 'react-intl';
 import useSWR from 'swr';
 
@@ -10,6 +12,7 @@ const HelpHeader = () => {
     refreshWhenHidden: false,
     revalidateOnFocus: false,
   });
+  const { user, loading } = useUser({ disableAutoRevalidation: true });
 
   return (
     <>
@@ -24,6 +27,11 @@ const HelpHeader = () => {
             ) ?? ['/img/people-cinema-watching.jpg']
           }
         />
+        {!user && !loading && (
+          <div className="absolute top-4 right-4 text-white">
+            <LanguagePicker />
+          </div>
+        )}
         <div className="container max-w-screen-xl mx-auto h-44 content-center z-0">
           <h2 className="text-center font-extrabold text-3xl my-4 text-white">
             <FormattedMessage


### PR DESCRIPTION
## Description
This pull request enhances the Help Centre's accessibility for unauthenticated users by adding a language picker to both the breadcrumbs and header components when no user is logged in. It also makes minor layout improvements to better accommodate these changes.

**User experience improvements:**

* Added the `LanguagePicker` component to the Help Centre header, displayed only when the user is not logged in, to allow language selection for unauthenticated users. [[1]](diffhunk://#diff-b91d076f147e2503aefacff3ec07b3c4fac0f102d6b7589091b8426611fb054dR4-R5) [[2]](diffhunk://#diff-b91d076f147e2503aefacff3ec07b3c4fac0f102d6b7589091b8426611fb054dR15) [[3]](diffhunk://#diff-b91d076f147e2503aefacff3ec07b3c4fac0f102d6b7589091b8426611fb054dR30-R34)
* Added the `LanguagePicker` component to the Help Centre breadcrumbs, also shown only for unauthenticated users, ensuring consistent language selection options throughout the help pages. [[1]](diffhunk://#diff-87e32de76d7bd714203fafb672f390dc13513a43f02c7e41fc10764d8803a7b6R7-R8) [[2]](diffhunk://#diff-87e32de76d7bd714203fafb672f390dc13513a43f02c7e41fc10764d8803a7b6R35) [[3]](diffhunk://#diff-87e32de76d7bd714203fafb672f390dc13513a43f02c7e41fc10764d8803a7b6R61-R80)

**Layout adjustments:**

* Updated the breadcrumbs container to use `relative` positioning, and adjusted the button styling to better fit the new layout with the language picker. [[1]](diffhunk://#diff-87e32de76d7bd714203fafb672f390dc13513a43f02c7e41fc10764d8803a7b6L23-R25) [[2]](diffhunk://#diff-87e32de76d7bd714203fafb672f390dc13513a43f02c7e41fc10764d8803a7b6R61-R80)

- Fixes #277 

## Has This Been Tested?
Yes on both authed and unauthed. Component renders and changes language correctly.

## Screenshots (if applicable)
<img width="626" height="266" alt="image" src="https://github.com/user-attachments/assets/ac461929-62cf-42c2-a3ce-ccb460cb8b76" />
<img width="479" height="256" alt="image" src="https://github.com/user-attachments/assets/0fb00941-6fc7-427d-9f31-44c18fe85b74" />


## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
