### PR TITLE
fix: reduce excessive logging in service proxy registration

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,9 +1,7 @@
 import type { IncomingMessage } from 'http';
 import type { Session as ExpressSession } from 'express-session';
-import PlexAPI from '@server/api/plexapi';
 import dataSource, { getRepository } from '@server/datasource';
 import { Session } from '@server/entity/Session';
-import { User } from '@server/entity/User';
 import { startJobs } from '@server/job/schedule';
 import notificationManager from '@server/lib/notifications';
 import LocalAgent, {
@@ -75,27 +73,6 @@ app
     const settings = await getSettings().load();
     initI18n();
     await initializeOnboardingDefaults();
-
-    // Migrate library types
-    if (
-      settings.plex.libraries.length > 1 &&
-      !settings.plex.libraries[0].type
-    ) {
-      const userRepository = getRepository(User);
-      const admin = await userRepository.findOne({
-        select: { id: true, plexToken: true },
-        where: { id: 1 },
-      });
-
-      if (admin) {
-        logger.info('Migrating Plex libraries to include media type', {
-          label: 'Settings',
-        });
-
-        const plexapi = new PlexAPI({ plexToken: admin.plexToken });
-        await plexapi.syncLibraries();
-      }
-    }
 
     // Register Notification Agents
     notificationManager.registerAgents([

--- a/server/routes/serviceProxy.ts
+++ b/server/routes/serviceProxy.ts
@@ -73,6 +73,7 @@ export function createServiceProxyRouter(
 ): Router {
   const router = Router();
   const settings = getSettings();
+  const registeredRoutes: { name: string; path: string }[] = [];
 
   const authMiddleware = [sessionMiddleware, checkUser, isAuthenticated()];
   const adminMiddleware = [
@@ -92,7 +93,7 @@ export function createServiceProxyRouter(
       ...(requireAdmin ? adminMiddleware : authMiddleware),
       proxy
     );
-    logger.info(`${label} proxy registered at ${path}`, { label: 'Proxy' });
+    registeredRoutes.push({ name: label, path });
   };
 
   if (settings.plex.ip) {
@@ -186,9 +187,7 @@ export function createServiceProxyRouter(
 
     // Static assets (no auth - loaded as resources after authenticated page loads)
     router.use(TDARR_STATIC_PATH, createTdarrStaticProxy(tdarrConfig));
-    logger.info(`Tdarr Static proxy registered at ${TDARR_STATIC_PATH}`, {
-      label: 'Proxy',
-    });
+    registeredRoutes.push({ name: 'Tdarr Static', path: TDARR_STATIC_PATH });
   }
 
   // Register Tautulli proxy
@@ -208,6 +207,13 @@ export function createServiceProxyRouter(
       'Tautulli',
       false
     );
+  }
+
+  if (registeredRoutes.length > 0) {
+    logger.info('Proxy routes registered successfully', {
+      label: 'Proxy',
+      services: registeredRoutes.map(({ name, path }) => `${name} at ${path}`),
+    });
   }
 
   return router;


### PR DESCRIPTION
## Description
This pull request primarily refactors how proxy route registrations are logged in the `serviceProxy` router, consolidating individual log messages into a single summary log. Additionally, it removes legacy Plex library migration logic from the server initialization. The changes improve logging clarity and streamline server startup.

**Logging improvements in service proxy routes:**

* Introduced a `registeredRoutes` array to collect all registered proxy routes instead of logging each one individually (`server/routes/serviceProxy.ts`).
* Updated proxy route registration to push route info into `registeredRoutes` rather than logging immediately (`server/routes/serviceProxy.ts`). [[1]](diffhunk://#diff-d9b575c26a1c65a032ff78f6da01dea7b2e787d2491ba9b97fca9de0d7f5cce5L95-R96) [[2]](diffhunk://#diff-d9b575c26a1c65a032ff78f6da01dea7b2e787d2491ba9b97fca9de0d7f5cce5L189-R190)
* Added a consolidated log statement at the end of router setup, summarizing all registered proxy routes in a single log entry (`server/routes/serviceProxy.ts`).

**Server initialization cleanup:**

* Removed legacy code that migrated Plex libraries to include media types during server startup, simplifying the initialization process (`server/index.ts`). [[1]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68L79-L99) [[2]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68L3-L6)

**Open Issues:**
- Fixes #274 

## Has This Been Tested?

Confirmed logging is condensed into 1 entry on startup. Legacy plex migration is irrelevant today.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
