### PR TITLE
fix: improve condition for displaying progress in RecentlyWatched

### DIFF
--- a/src/components/Common/Slider/RecentlyWatched.tsx
+++ b/src/components/Common/Slider/RecentlyWatched.tsx
@@ -116,7 +116,7 @@ const RecentlyWatched = ({ item }: { item?: WatchHistoryItem }) => {
             </p>
           </div>
         )}
-        {Number(item?.percentComplete) &&
+        {!!item?.percentComplete &&
           item.percentComplete > 0 &&
           item.percentComplete < 85 && (
             <div className="mt-1.5">


### PR DESCRIPTION
## Description
This pull request makes a small change to the logic for displaying the progress bar in the `RecentlyWatched` component. The condition now correctly checks that `percentComplete` is a non-zero, defined value before rendering the progress bar.

* Improved the conditional rendering in `RecentlyWatched.tsx` to ensure the progress bar only appears when `item.percentComplete` is defined and non-zero, preventing potential display issues.

- Fixes #283 

## Has This Been Tested?

Confirmed working on 0 percent, progress and completed states.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
