### PR TITLE
fix: adjust tabs for better overflow handling

### DIFF
--- a/src/app/help/legal/page.tsx
+++ b/src/app/help/legal/page.tsx
@@ -25,14 +25,14 @@ const LegalPage = () => {
         />
       </div>
       <section className="py-5 my-auto bg-zinc-100">
-        <main className=" container max-w-screen-md lg:max-w-screen-lg xl:max-w-screen-xl mx-auto place-content-center p-4 space-y-5">
-          <div role="tablist" className="tabs tabs-lifted">
+        <main className=" container max-w-screen-md lg:max-w-screen-lg xl:max-w-screen-xl mx-auto place-content-center p-1 sm:p-4 space-y-5">
+          <div role="tablist" className="tabs tabs-lifted overflow-x-auto">
             <input
               defaultChecked
               type="radio"
               name="my_tabs_2"
               role="tab"
-              className="tab checked:!bg-secondary checked:text-white text-primary font-extrabold !w-32 !border-none"
+              className="tab checked:!bg-secondary checked:text-white text-primary font-extrabold !border-none !whitespace-nowrap"
               aria-label={intl.formatMessage({
                 id: 'help.legal.termsTab',
                 defaultMessage: 'Terms of Use',
@@ -60,7 +60,7 @@ const LegalPage = () => {
               type="radio"
               name="my_tabs_2"
               role="tab"
-              className="tab checked:!bg-secondary checked:text-white text-primary font-extrabold !w-44 !border-none"
+              className="tab checked:!bg-secondary checked:text-white text-primary font-extrabold !border-none !whitespace-nowrap"
               aria-label={intl.formatMessage({
                 id: 'help.legal.privacyTab',
                 defaultMessage: 'Privacy Statement',
@@ -88,7 +88,7 @@ const LegalPage = () => {
               type="radio"
               name="my_tabs_2"
               role="tab"
-              className="tab checked:!bg-secondary checked:text-white text-primary font-extrabold !w-36 !border-none"
+              className="tab checked:!bg-secondary checked:text-white text-primary font-extrabold !border-none !whitespace-nowrap"
               aria-label={intl.formatMessage({
                 id: 'help.legal.cookiesTab',
                 defaultMessage: 'Cookie Policy',


### PR DESCRIPTION
## Description
This pull request updates the styling of the tabs on the legal help page to improve their responsiveness and layout, especially on smaller screens. The main changes focus on making the tab list horizontally scrollable and ensuring tab labels do not wrap, which enhances usability and appearance.

Styling and layout improvements:

* Added horizontal scrolling to the tab list by applying `overflow-x-auto` to the tab container, making it easier to navigate tabs on smaller screens.
* Replaced fixed tab widths with `!whitespace-nowrap` on each tab to prevent label wrapping and allow the tabs to size naturally based on content. [[1]](diffhunk://#diff-671cdd8cee5c112b6d3d18aefb9f2345eefe6002a97436741b99e0eeb9b88833L28-R35) [[2]](diffhunk://#diff-671cdd8cee5c112b6d3d18aefb9f2345eefe6002a97436741b99e0eeb9b88833L63-R63) [[3]](diffhunk://#diff-671cdd8cee5c112b6d3d18aefb9f2345eefe6002a97436741b99e0eeb9b88833L91-R91)
* Adjusted padding on the main container for better spacing (`p-1 sm:p-4`).
---
- Fixes #253 

## Has This Been Tested?

Visual change only. Improves tab functionality.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
