### PR TITLE
chore(docs): clarify Python Plex invite service startup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
    pnpm dev
    ```
 
-   This starts the Node.js server with hot reloading via `nodemon` including the Python Plex invite service. The app will be available at `http://localhost:3000`.
+   This starts the Node.js server with hot reloading via `nodemon`. The Node.js server also starts and monitors the Python Plex invite service. The app will be available at `http://localhost:3000`.
 
    To start the Python Plex invite service independently:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,9 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
    pnpm dev
    ```
 
-   This starts the Node.js server with hot reloading via `nodemon`. The app will be available at `http://localhost:3000`.
+   This starts the Node.js server with hot reloading via `nodemon` including the Python Plex invite service. The app will be available at `http://localhost:3000`.
 
-   To also start the Python Plex invite service (in a separate terminal):
+   To start the Python Plex invite service independently:
 
    ```bash
    pnpm start:python
@@ -168,6 +168,9 @@ Streamarr uses `react-intl` for internationalization. Source strings are extract
 3. Use the self-hosted Weblate instance at https://weblate.streamarr.dev/ to translate existing strings.
 
 4. If you are changing translation keys or strings in code, make sure the extracted locale files are up to date before opening a PR.
+
+### Translation Status:
+<a href="https://weblate.streamarr.dev/engage/streamarr/"><img src="https://weblate.streamarr.dev/widget/streamarr/multi-auto.svg" alt="Translation status" /></a>
 
 ## Need Help?
 


### PR DESCRIPTION
## Description
This pull request updates the `CONTRIBUTING.md` documentation to clarify how to start the Python Plex invite service and adds a translation status badge for contributors. 

Documentation improvements:

* Clarified that running `pnpm dev` now starts both the Node.js server and the Python Plex invite service, and updated instructions for starting the Python service independently.
* Added a translation status badge with a link to Weblate, making it easier for contributors to track and participate in translation efforts.

## Has This Been Tested?

Docs only.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
