### PR TITLE
feat: linked accounts settings and improved Plex invite and localAuth

### DIFF
--- a/server/python/plex_invite.py
+++ b/server/python/plex_invite.py
@@ -1,7 +1,7 @@
 from flask import Flask, request, jsonify
 from plexapi.myplex import MyPlexAccount
 import traceback
-import logging
+import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
 import os
 import json
@@ -52,16 +52,21 @@ def health():
 
 @app.route('/invite', methods=['POST'])
 def invite():
-    data = request.json
+    data = request.json or {}
     token = data.get('token')
     server_id = data.get('server_id')
     email = data.get('email')
+
+    if not token or not server_id or not email:
+        return jsonify({'success': False, 'error': 'Missing required parameters: token, server_id, email'}), 400
+
     libraries = data.get('libraries', [])
     allow_sync = data.get('allow_sync', False)
     allow_camera_upload = data.get('allow_camera_upload', False)
     allow_channels = data.get('allow_channels', False)
     plex_home = data.get('plex_home', False)
     user_token = data.get('user_token')  # Optional: token of the user being invited for auto-accept
+    server_name = data.get('server_name')  # Optional: friendly name of the Plex server for invite matching
 
     try:
         account = MyPlexAccount(token=token)
@@ -77,7 +82,6 @@ def invite():
         sections_response.raise_for_status()
 
         # Parse the XML response to get section info
-        import xml.etree.ElementTree as ET
         root = ET.fromstring(sections_response.text)
 
         # Build mappings of section key to title (key is what Node.js sends)
@@ -131,18 +135,39 @@ def invite():
 
             if user_token:
                 try:
-                    time.sleep(3)
                     user_account = MyPlexAccount(token=user_token)
-                    pending_invites = user_account.pendingInvites()
+                    matching_invite = None
+                    # Retry up to 5 times (3 s apart) — Plex can take a few seconds to
+                    # propagate a new invite to the receiver's account.
+                    for _ in range(5):
+                        time.sleep(3)
+                        pending_invites = user_account.pendingInvites(includeSent=False, includeReceived=True)
+                        if not pending_invites:
+                            continue
+                        # Match by server friendly name (primary) or any server-share invite (fallback).
+                        server_invite_fallback = None
+                        for inv in pending_invites:
+                            if server_name:
+                                for srv in getattr(inv, 'servers', []):
+                                    if getattr(srv, 'name', None) == server_name:
+                                        matching_invite = inv
+                                        break
+                            if getattr(inv, 'server', False) and server_invite_fallback is None:
+                                server_invite_fallback = inv
+                            if matching_invite:
+                                break
+                        if not matching_invite and server_invite_fallback:
+                            matching_invite = server_invite_fallback
+                        if matching_invite:
+                            break
 
-                    if pending_invites and len(pending_invites) > 0:
-                        user_account.acceptInvite(pending_invites[0])
+                    if matching_invite:
+                        user_account.acceptInvite(matching_invite)
                         message = 'User invited and automatically accepted.'
+                    else:
+                        logger.error('Auto-accept failed: invite never appeared in pending list', {'email': email})
                 except Exception as accept_error:
-                    logger.error('Unable to auto-accept invite', {
-                        'email': email,
-                        'error': str(accept_error)
-                    })
+                    logger.error('Unable to auto-accept invite', {'email': email, 'error': str(accept_error)})
 
         return jsonify({'success': True, 'message': message})
     except Exception as e:
@@ -176,13 +201,7 @@ def libraries():
                 break
 
         if not target_user:
-            logger.error(f'User not found in account friends: {email}', {
-                'email': email,
-                'available_users': [
-                    {'email': user.email, 'title': getattr(user, 'title', 'N/A')}
-                    for user in account_users if user.email
-                ]
-            })
+            logger.error('User not found in Plex account friends', {'email': email, 'total_users': len(account_users)})
             return jsonify({'success': False, 'error': 'User not found in account friends'}), 404
 
         if request.method == 'GET':
@@ -273,7 +292,6 @@ def libraries():
                 sections_response.raise_for_status()
 
                 # Parse the XML response to get section IDs
-                import xml.etree.ElementTree as ET
                 root = ET.fromstring(sections_response.text)
 
                 # Build a mapping of section title to section id
@@ -597,7 +615,6 @@ def pin_libraries():
 
     except Exception as e:
         logger.error('Pin libraries error', {'error': str(e)})
-        traceback.print_exc()
         return jsonify({'success': False, 'error': str(e)}), 500
 
 @app.route('/library-details', methods=['GET'])
@@ -641,7 +658,6 @@ def library_details():
 
     except Exception as e:
         logger.error('Library details error', {'error': str(e)})
-        traceback.print_exc()
         return jsonify({'success': False, 'error': str(e)}), 500
 
 if __name__ == '__main__':

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -26,7 +26,7 @@ import ImageProxy from '@server/lib/imageproxy';
 import { Router } from 'express';
 
 import { In, Not } from 'typeorm';
-import userSettingsRoutes, { isOwnProfileOrAdmin } from './usersettings';
+import userSettingsRoutes from './usersettings';
 import userOnboardingRoutes from './onboarding';
 import PreparedEmail from '@server/lib/email';
 import path from 'path';
@@ -34,6 +34,7 @@ import crypto from 'crypto';
 import Invite from '@server/entity/Invite';
 import Notification from '@server/entity/Notification';
 import { plexSync } from '@server/lib/plexSync';
+import { isOwnProfileOrAdmin } from '@server/utils/profileMiddleware';
 
 const router = Router();
 

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -15,23 +15,11 @@ import { Router } from 'express';
 import { canMakePermissionsChange } from '@server/routes/user';
 import { UserType } from '@server/constants/user';
 import axios from 'axios';
-
-export const isOwnProfileOrAdmin = () => {
-  const authMiddleware = (req, res, next) => {
-    if (
-      !req.user?.hasPermission(Permission.MANAGE_USERS) &&
-      req.user?.id !== Number(req.params.id)
-    ) {
-      return next({
-        status: 403,
-        message: "You do not have permission to view this user's settings.",
-      });
-    }
-
-    next();
-  };
-  return authMiddleware;
-};
+import PlexTvAPI from '@server/api/plextv';
+import {
+  isOwnProfile,
+  isOwnProfileOrAdmin,
+} from '@server/utils/profileMiddleware';
 
 const userSettingsRoutes = Router({ mergeParams: true });
 
@@ -149,7 +137,7 @@ userSettingsRoutes.post<
 
     if (!user.settings) {
       user.settings = new UserSettings({
-        user: req.user,
+        user,
         locale: req.body.locale,
         sharedLibraries: newSharedLibraries,
         allowDownloads: req.body.allowDownloads ?? false,
@@ -326,6 +314,277 @@ userSettingsRoutes.post<
   }
 });
 
+userSettingsRoutes.post<{ id: string }, unknown, { authToken: string }>(
+  '/linked-accounts/plex',
+  isOwnProfile(),
+  async (req, res, next) => {
+    const userRepository = getRepository(User);
+
+    let account: Awaited<ReturnType<PlexTvAPI['getUser']>>;
+    try {
+      const plextv = new PlexTvAPI(req.body.authToken);
+      account = await plextv.getUser();
+    } catch {
+      return next({ status: 401, message: 'Invalid or expired Plex token.' });
+    }
+
+    try {
+      if (await userRepository.exists({ where: { plexId: account.id } })) {
+        return next({
+          status: 422,
+          message: 'This Plex account is already linked to a Streamarr user.',
+        });
+      }
+
+      const user = await userRepository.findOne({
+        where: { id: Number(req.params.id) },
+        relations: ['settings'],
+      });
+
+      if (!user) {
+        return next({ status: 404, message: 'User not found.' });
+      }
+
+      if (user.email?.toLowerCase() !== account.email?.toLowerCase()) {
+        return next({
+          status: 422,
+          message:
+            'This Plex account is registered under a different email address.',
+        });
+      }
+
+      const plexServerId = getSettings().plex.machineId;
+      let librarySectionIds: string[] = [];
+
+      const adminUser = await userRepository
+        .createQueryBuilder('user')
+        .addSelect('user.plexToken')
+        .where('user.id = :id', { id: 1 })
+        .getOne();
+
+      // Resolve the libraries to share: honour any pre-existing user setting first,
+      // then fall back to the admin-configured default.
+      const existingSharedLibraries = user.settings?.sharedLibraries;
+      const enabledLibraries = getSettings().plex.libraries.filter(
+        (lib) => lib.enabled
+      );
+
+      if (existingSharedLibraries) {
+        // User already has explicit library settings — validate against enabled list
+        const requestedIds = existingSharedLibraries
+          .split(/[,|]/)
+          .map((id) => id.trim())
+          .filter((id) => id !== '');
+        librarySectionIds = requestedIds.filter((libId) =>
+          enabledLibraries.some((enabled) => enabled.id === libId)
+        );
+      } else {
+        // Fall back to admin default shared libraries
+        const defaultLibs = getSettings().main.sharedLibraries;
+
+        if (defaultLibs === 'all' || !defaultLibs) {
+          librarySectionIds = enabledLibraries.map((lib) => lib.id);
+        } else {
+          const adminConfiguredLibs = defaultLibs
+            .split(/[,|]/)
+            .map((id) => id.trim())
+            .filter((id) => id !== '');
+          librarySectionIds = adminConfiguredLibs.filter((libId) =>
+            enabledLibraries.some((enabled) => enabled.id === libId)
+          );
+        }
+      }
+
+      // valid plex user found, link to current user
+      user.userType = UserType.PLEX;
+      user.plexId = account.id;
+      user.plexUsername = account.username;
+      user.plexToken = account.authToken;
+
+      if (!user.settings) {
+        user.settings = new UserSettings({
+          user,
+          sharedLibraries:
+            librarySectionIds.length > 0 ? librarySectionIds.join('|') : null,
+          allowDownloads: getSettings().main.downloads ?? false,
+          allowLiveTv: getSettings().main.liveTv ?? false,
+        });
+      } else {
+        // Only overwrite sharedLibraries if the user didn't already have an explicit value
+        if (!existingSharedLibraries) {
+          user.settings.sharedLibraries =
+            librarySectionIds.length > 0 ? librarySectionIds.join('|') : null;
+        }
+        user.settings.allowDownloads =
+          user.settings.allowDownloads ?? getSettings().main.downloads ?? false;
+        user.settings.allowLiveTv =
+          user.settings.allowLiveTv ?? getSettings().main.liveTv ?? false;
+      }
+
+      await userRepository.save(user);
+
+      if (!adminUser || !adminUser.plexToken) {
+        logger.error(
+          'Missing Plex admin token — skipping Plex invitation for linked account',
+          { label: 'User Settings', userEmail: user.email }
+        );
+        return res.status(204).send();
+      }
+
+      // Check whether the user already has access to the Plex server.
+      const mainPlexTv = new PlexTvAPI(adminUser.plexToken);
+      let alreadyOnServer = false;
+      try {
+        alreadyOnServer = await mainPlexTv.checkUserAccess(account.id);
+      } catch (e) {
+        logger.error('Failed to check Plex server access for linked account', {
+          label: 'User Settings',
+          userEmail: user.email,
+          error: e.message,
+        });
+      }
+
+      const identifiers = [user.email, user.plexUsername].filter(
+        (identifier): identifier is string => !!identifier
+      );
+
+      if (alreadyOnServer) {
+        // User already has server access — update libraries
+        for (const identifier of identifiers) {
+          try {
+            const response = await axios.post(
+              'http://localhost:5005/libraries',
+              {
+                token: adminUser.plexToken,
+                server_id: plexServerId,
+                email: identifier,
+                libraries: librarySectionIds,
+                allow_sync: getSettings().main.downloads ?? false,
+                allow_camera_upload: false,
+                allow_channels: false,
+              }
+            );
+
+            if (!response.data.success) {
+              throw new Error(
+                response.data.error || 'Failed to update shared libraries'
+              );
+            }
+
+            logger.debug('Plex account linked successfully', {
+              label: 'User Settings',
+              userEmail: user.email,
+              identifier,
+              sharedLibraries: librarySectionIds,
+            });
+            break;
+          } catch (e) {
+            logger.warn(`Plex account link attempt failed`, {
+              label: 'User Settings',
+              userEmail: user.email,
+              identifier,
+              message: e.message,
+              responseData: e.response?.data,
+            });
+          }
+        }
+      } else {
+        // User not yet on server — send invite with auto-accept
+        for (const identifier of identifiers) {
+          try {
+            const response = await axios.post('http://localhost:5005/invite', {
+              token: adminUser.plexToken,
+              server_id: plexServerId,
+              server_name: getSettings().plex.name || null,
+              email: identifier,
+              libraries: librarySectionIds,
+              allow_sync: getSettings().main.downloads ?? false,
+              allow_camera_upload: false,
+              allow_channels: false,
+              plex_home: false,
+              user_token: req.body.authToken || user.plexToken || null,
+            });
+
+            if (!response.data.success) {
+              throw new Error(
+                response.data.error ||
+                  'Failed to invite user via Python service'
+              );
+            }
+
+            logger.debug('Plex account linked successfully', {
+              label: 'User Settings',
+              userEmail: user.email,
+              identifier,
+              sharedLibraries: librarySectionIds,
+            });
+            break;
+          } catch (e) {
+            logger.warn(`Plex account link attempt failed`, {
+              label: 'User Settings',
+              userEmail: user.email,
+              identifier,
+              message: e.message,
+              responseData: e.response?.data,
+            });
+          }
+        }
+      }
+
+      return res.status(204).send();
+    } catch (e) {
+      return next({ status: 500, message: e.message });
+    }
+  }
+);
+
+userSettingsRoutes.delete<{ id: string }>(
+  '/linked-accounts/plex',
+  isOwnProfileOrAdmin(),
+  async (req, res, next) => {
+    const userRepository = getRepository(User);
+
+    try {
+      const user = await userRepository
+        .createQueryBuilder('user')
+        .addSelect('user.password')
+        .where({
+          id: Number(req.params.id),
+        })
+        .getOne();
+
+      if (!user) {
+        return next({ status: 404, message: 'User not found.' });
+      }
+
+      if (user.id === 1) {
+        return next({
+          status: 400,
+          message:
+            'Cannot unlink media server accounts for the primary administrator.',
+        });
+      }
+
+      if (!user.email || !user.password) {
+        return next({
+          status: 400,
+          message: 'User does not have a local email or password set.',
+        });
+      }
+
+      user.userType = UserType.LOCAL;
+      user.plexId = null;
+      user.plexUsername = null;
+      user.plexToken = null;
+      await userRepository.save(user);
+
+      return res.status(204).send();
+    } catch (e) {
+      return next({ status: 500, message: e.message });
+    }
+  }
+);
+
 userSettingsRoutes.get<{ id: string }, UserSettingsNotificationsResponse>(
   '/notifications',
   isOwnProfileOrAdmin(),
@@ -380,7 +639,7 @@ userSettingsRoutes.post<{ id: string }, UserSettingsNotificationsResponse>(
 
       if (!user.settings) {
         user.settings = new UserSettings({
-          user: req.user,
+          user,
           pgpKey: req.body.pgpKey,
           notificationTypes: req.body.notificationTypes,
         });
@@ -503,13 +762,13 @@ userSettingsRoutes.post<{ id: string }>(
         });
       }
 
-      const mainUser = await userRepository
+      const adminUser = await userRepository
         .createQueryBuilder('user')
         .addSelect('user.plexToken')
         .where('user.id = :id', { id: 1 })
         .getOne();
 
-      if (!mainUser || !mainUser.plexToken) {
+      if (!adminUser || !adminUser.plexToken) {
         return next({
           status: 500,
           message: 'Admin Plex token missing',
@@ -538,7 +797,7 @@ userSettingsRoutes.post<{ id: string }>(
           'http://localhost:5005/library-details',
           {
             params: {
-              token: mainUser.plexToken,
+              token: adminUser.plexToken,
               server_id: plexSettings.machineId,
               email: user.email,
             },

--- a/server/utils/profileMiddleware.ts
+++ b/server/utils/profileMiddleware.ts
@@ -1,0 +1,30 @@
+import { Permission } from '@server/lib/permissions';
+
+export const isOwnProfile = (): Middleware => {
+  return (req, res, next) => {
+    if (req.user?.id !== Number(req.params.id)) {
+      return next({
+        status: 403,
+        message: "You do not have permission to view this user's settings.",
+      });
+    }
+    next();
+  };
+};
+
+export const isOwnProfileOrAdmin = (): Middleware => {
+  const authMiddleware = (req, res, next) => {
+    if (
+      !req.user?.hasPermission(Permission.MANAGE_USERS) &&
+      req.user?.id !== Number(req.params.id)
+    ) {
+      return next({
+        status: 403,
+        message: "You do not have permission to view this user's settings.",
+      });
+    }
+
+    next();
+  };
+  return authMiddleware;
+};

--- a/src/app/admin/users/[userid]/settings/linked-accounts/page.tsx
+++ b/src/app/admin/users/[userid]/settings/linked-accounts/page.tsx
@@ -1,0 +1,6 @@
+import UserSettingsAccounts from '@app/components/UserProfile/UserSettings/UserSettingsAccounts';
+
+const UsersSettingsLinkedAccountsPage = () => {
+  return <UserSettingsAccounts />;
+};
+export default UsersSettingsLinkedAccountsPage;

--- a/src/app/profile/settings/linked-accounts/page.tsx
+++ b/src/app/profile/settings/linked-accounts/page.tsx
@@ -1,0 +1,7 @@
+import UserSettingsAccounts from '@app/components/UserProfile/UserSettings/UserSettingsAccounts';
+
+const UserSettingsAccountsPage = () => {
+  return <UserSettingsAccounts />;
+};
+
+export default UserSettingsAccountsPage;

--- a/src/components/SignIn/LocalSignIn.tsx
+++ b/src/components/SignIn/LocalSignIn.tsx
@@ -4,17 +4,20 @@ import useSettings from '@app/hooks/useSettings';
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import * as Yup from 'yup';
 import validator from 'validator';
 import { FormattedMessage, useIntl } from 'react-intl';
+import type { UserHookResponse } from '@app/hooks/useUser';
 
 interface LocalLoginProps {
-  revalidate: () => void;
+  revalidate: UserHookResponse['revalidate'];
 }
 
 const LocalLogin = ({ revalidate }: LocalLoginProps) => {
   const settings = useSettings();
+  const router = useRouter();
   const [loginError, setLoginError] = useState<string | null>(null);
   const intl = useIntl();
 
@@ -57,10 +60,16 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
       onSubmit={async (values) => {
         setLoginError(null);
         try {
-          await axios.post('/api/v1/auth/local', {
-            email: values.email.trim(),
-            password: values.password,
-          });
+          const { data: authenticatedUser } = await axios.post(
+            '/api/v1/auth/local',
+            {
+              email: values.email.trim(),
+              password: values.password,
+            }
+          );
+          revalidate(authenticatedUser, false).then(() =>
+            router.push('/watch')
+          );
         } catch {
           setLoginError(
             intl.formatMessage({
@@ -68,8 +77,6 @@ const LocalLogin = ({ revalidate }: LocalLoginProps) => {
               defaultMessage: 'Something went wrong while trying to sign in.',
             })
           );
-        } finally {
-          revalidate();
         }
       }}
     >

--- a/src/components/UserProfile/UserSettings/UserSettingsAccounts/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsAccounts/index.tsx
@@ -1,0 +1,247 @@
+'use client';
+import PlexLogo from '@app/assets/services/plex.svg';
+import Alert from '@app/components/Common/Alert';
+import ConfirmButton from '@app/components/Common/ConfirmButton';
+import { Permission, UserType, useUser } from '@app/hooks/useUser';
+import PlexOAuth from '@app/utils/plex';
+import { TrashIcon } from '@heroicons/react/24/solid';
+import axios from 'axios';
+import { useParams } from 'next/navigation';
+import { useMemo, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import useSWR from 'swr';
+
+const plexOAuth = new PlexOAuth();
+
+enum LinkedAccountType {
+  Plex = 'Plex',
+}
+
+type LinkedAccount = {
+  type: LinkedAccountType;
+  username: string;
+};
+
+const UserSettingsAccounts = () => {
+  const intl = useIntl();
+  const { user: currentUser, hasPermission: currentUserHasPermission } =
+    useUser();
+  const searchParams = useParams<{ userid: string }>();
+  const { user, revalidate: revalidateUser } = useUser({
+    id: Number(searchParams.userid),
+  });
+  const { data: passwordInfo } = useSWR<{ hasPassword: boolean }>(
+    user ? `/api/v1/user/${user?.id}/settings/password` : null
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const accounts: LinkedAccount[] = useMemo(() => {
+    const accounts: LinkedAccount[] = [];
+    if (!user) return accounts;
+    if (user.userType === UserType.PLEX && user.plexUsername)
+      accounts.push({
+        type: LinkedAccountType.Plex,
+        username: user.plexUsername,
+      });
+    return accounts;
+  }, [user]);
+
+  const linkPlexAccount = async () => {
+    setError(null);
+    try {
+      const authToken = await plexOAuth.login();
+      await axios.post(
+        `/api/v1/user/${user?.id}/settings/linked-accounts/plex`,
+        {
+          authToken,
+        }
+      );
+      await revalidateUser();
+    } catch (e) {
+      setError(
+        e.response?.data?.message ??
+          intl.formatMessage({
+            id: 'linkedAccounts.linkFailed',
+            defaultMessage: 'An error occurred while linking your Plex account',
+          })
+      );
+    }
+  };
+
+  const linkable = [
+    {
+      name: 'Plex',
+      action: () => {
+        plexOAuth.preparePopup();
+        setTimeout(() => linkPlexAccount(), 1500);
+      },
+      hide: accounts.some((a) => a.type === LinkedAccountType.Plex),
+    },
+  ].filter((l) => !l.hide);
+
+  const deleteRequest = async () => {
+    try {
+      await axios.delete(
+        `/api/v1/user/${user?.id}/settings/linked-accounts/plex`
+      );
+      await revalidateUser();
+    } catch {
+      setError(
+        intl.formatMessage({
+          id: 'linkedAccounts.deleteFailed',
+          defaultMessage: 'Failed to delete linked account',
+        })
+      );
+    }
+  };
+
+  if (
+    currentUser?.id !== user?.id &&
+    !currentUserHasPermission(Permission.MANAGE_USERS)
+  ) {
+    return (
+      <>
+        <div className="mb-6">
+          <h3 className="heading">
+            <FormattedMessage
+              id="linkedAccounts.title"
+              defaultMessage="Linked Accounts"
+            />
+          </h3>
+        </div>
+        <Alert
+          title={
+            <FormattedMessage
+              id="linkedAccounts.noPermissionDescription"
+              defaultMessage="You do not have permission to view this user's linked accounts"
+            />
+          }
+          type="error"
+        />
+      </>
+    );
+  }
+
+  const enableMediaServerUnlink = user?.id !== 1 && passwordInfo?.hasPassword;
+
+  return (
+    <>
+      <div className="mb-6 flex items-end justify-between mt-5">
+        <div>
+          <h3 className="text-2xl font-extrabold">
+            <FormattedMessage
+              id="linkedAccounts.title"
+              defaultMessage="Linked Accounts"
+            />
+          </h3>
+        </div>
+      </div>
+      {error && <Alert title={error} type="error" />}
+      {currentUser?.id === user?.id && !!linkable.length && (
+        <ul className="space-y-4">
+          {linkable.map(({ name, action }) => (
+            <li
+              key={name}
+              className="flex flex-wrap items-center gap-4 overflow-hidden rounded-lg bg-base-200/50 px-4 py-5 shadow ring-1 ring-neutral sm:p-6"
+            >
+              <div className="flex aspect-square h-full items-center justify-center rounded-full bg-neutral-800">
+                <PlexLogo className="w-9" />
+              </div>
+              <div>
+                <div className="truncate text-sm font-bold text-gray-300">
+                  {name}
+                </div>
+                <div className="text-xl font-semibold text-white">
+                  <FormattedMessage
+                    id="linkedAccounts.notLinked"
+                    defaultMessage="No Account Linked"
+                    values={{ name }}
+                  />
+                </div>
+              </div>
+              <div className="flex-grow" />
+              <button
+                onClick={action}
+                className="max-sm:btn-block rounded-md bg-primary px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
+              >
+                <FormattedMessage
+                  id="linkedAccounts.linkButton"
+                  defaultMessage="Link {name} Account"
+                  values={{ name }}
+                />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {accounts.length ? (
+        <ul className="space-y-4">
+          {accounts.map((acct, i) => (
+            <li
+              key={i}
+              className="flex flex-wrap items-center gap-4 overflow-hidden rounded-lg bg-base-200/50 px-4 py-5 shadow ring-1 ring-neutral sm:p-6"
+            >
+              <div className="w-12">
+                {acct.type === LinkedAccountType.Plex && (
+                  <div className="flex aspect-square h-full items-center justify-center rounded-full bg-neutral-800">
+                    <PlexLogo className="w-9" />
+                  </div>
+                )}
+              </div>
+              <div>
+                <div className="truncate text-sm font-bold text-gray-300">
+                  {acct.type}
+                </div>
+                <div className="text-xl font-semibold text-white">
+                  {acct.username}
+                </div>
+              </div>
+              <div className="flex-grow" />
+              {currentUser?.id === user?.id && enableMediaServerUnlink && (
+                <ConfirmButton
+                  buttonSize="sm"
+                  onClick={() => {
+                    deleteRequest();
+                  }}
+                  confirmText={
+                    <FormattedMessage
+                      id="common.areYouSure"
+                      defaultMessage="Are you sure?"
+                    />
+                  }
+                  className="max-sm:btn-block"
+                >
+                  <TrashIcon className="size-5 mr-2" />
+                  <span>
+                    <FormattedMessage
+                      id="common.unlinkAccount"
+                      defaultMessage="Unlink Account"
+                    />
+                  </span>
+                </ConfirmButton>
+              )}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="mt-4 text-center md:py-12">
+          <h3 className="text-lg font-semibold text-neutral">
+            {user?.id === currentUser?.id ? (
+              <FormattedMessage
+                id="linkedAccounts.noLinkedAccounts"
+                defaultMessage="You do not have any external accounts linked to your account."
+              />
+            ) : (
+              <FormattedMessage
+                id="linkedAccounts.userNoLinkedAccounts"
+                defaultMessage="This user does not have any external accounts linked to their account."
+              />
+            )}
+          </h3>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default UserSettingsAccounts;

--- a/src/components/UserProfile/UserSettings/index.tsx
+++ b/src/components/UserProfile/UserSettings/index.tsx
@@ -11,8 +11,6 @@ import { useParams, usePathname } from 'next/navigation';
 import { useIntl } from 'react-intl';
 import useSWR from 'swr';
 
-//TODO: Add a Linked Accounts page for users to link their accounts with external services and manage those connections
-
 const UserSettings = ({ children }: { children: React.ReactNode }) => {
   const intl = useIntl();
   const settings = useSettings();
@@ -56,6 +54,14 @@ const UserSettings = ({ children }: { children: React.ReactNode }) => {
         (currentUser?.id !== 1 &&
           currentUser?.id !== user?.id &&
           hasPermission(Permission.ADMIN, user?.permissions ?? 0)),
+    },
+    {
+      text: intl.formatMessage({
+        id: 'settings.linkedAccounts',
+        defaultMessage: 'Linked Accounts',
+      }),
+      route: '/settings/linked-accounts',
+      regex: /\/settings\/linked-accounts/,
     },
     {
       text: intl.formatMessage({

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -45,7 +45,7 @@ export interface UserSettings {
   inAppEnabled?: boolean;
 }
 
-interface UserHookResponse {
+export interface UserHookResponse {
   user?: User;
   loading: boolean;
   error: string;

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -746,6 +746,9 @@
   "common.unlimited": {
     "defaultMessage": "Unlimited"
   },
+  "common.unlinkAccount": {
+    "defaultMessage": "Unlink Account"
+  },
   "common.unread": {
     "defaultMessage": "unread"
   },
@@ -3608,6 +3611,30 @@
   "librarySelector.defaultLibrariesWith": {
     "defaultMessage": "Default Libraries ({libraries})"
   },
+  "linkedAccounts.deleteFailed": {
+    "defaultMessage": "Failed to delete linked account"
+  },
+  "linkedAccounts.linkButton": {
+    "defaultMessage": "Link {name} Account"
+  },
+  "linkedAccounts.linkFailed": {
+    "defaultMessage": "An error occurred while linking your Plex account"
+  },
+  "linkedAccounts.noLinkedAccounts": {
+    "defaultMessage": "You do not have any external accounts linked to your account."
+  },
+  "linkedAccounts.noPermissionDescription": {
+    "defaultMessage": "You do not have permission to view this user's linked accounts"
+  },
+  "linkedAccounts.notLinked": {
+    "defaultMessage": "No Account Linked"
+  },
+  "linkedAccounts.title": {
+    "defaultMessage": "Linked Accounts"
+  },
+  "linkedAccounts.userNoLinkedAccounts": {
+    "defaultMessage": "This user does not have any external accounts linked to their account."
+  },
   "localSignup.confirmPasswordRequired": {
     "defaultMessage": "Please confirm your password"
   },
@@ -4297,6 +4324,9 @@
   },
   "settings.librariesSynced": {
     "defaultMessage": "Libraries have been synced with Plex."
+  },
+  "settings.linkedAccounts": {
+    "defaultMessage": "Linked Accounts"
   },
   "settings.notifications.description": {
     "defaultMessage": "Configure and enable notification agents."

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -5310,6 +5310,58 @@ paths:
       responses:
         '204':
           description: User password updated
+  /user/{userId}/settings/linked-accounts/plex:
+    post:
+      summary: Link a Plex account to the logged-in user
+      description: Links a Plex account to the logged-in user using a provided Plex token. Requires an active session.
+      tags:
+        - users
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                authToken:
+                  type: string
+              required:
+                - authToken
+      responses:
+        '204':
+          description: Plex account successfully linked
+        '401':
+          description: Invalid or expired Plex token
+        '422':
+          description: Plex account already linked to another user, or email mismatch
+        '500':
+          description: Server error while linking Plex account
+    delete:
+      summary: Unlink the Plex account from the logged-in user
+      description: Unlinks the Plex account from the logged-in user. Requires an active session.
+      tags:
+        - users
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Plex account successfully unlinked
+        '400':
+          description: Cannot unlink — user is the primary administrator or has no local credentials
+        '404':
+          description: User not found
+        '500':
+          description: Server error while unlinking Plex account
   /user/{userId}/settings/notifications:
     get:
       summary: Get notification settings for a user


### PR DESCRIPTION
## Description
This pull request introduces major enhancements to user account linking and management, particularly around Plex account integration, as well as some codebase organization improvements. The changes add robust endpoints for linking and unlinking Plex accounts to user profiles, improve error handling, and refactor middleware for profile access control. Additionally, there are UI updates to support the new linked accounts functionality.

**Plex Account Linking and User Management:**

* Added new endpoints to allow users to link and unlink their Plex accounts, including validation to prevent duplicate links, email matching, and automatic Plex server invitations or library updates as needed. This includes both POST and DELETE handlers for `/linked-accounts/plex`.
* Improved the Plex invitation flow in `plex_invite.py` to better handle auto-acceptance of invites by retrying and matching on server name, and improved error logging throughout the invite and library management process. [[1]](diffhunk://#diff-ea2b06fb6f8497d91b28fca0c5c2a7c1b1e652c357c228e8e1d45f925717ed0bL55-R69) [[2]](diffhunk://#diff-ea2b06fb6f8497d91b28fca0c5c2a7c1b1e652c357c228e8e1d45f925717ed0bL134-R170)
* Enhanced error handling and logging in several endpoints, removing unnecessary stack traces and improving the clarity of error messages for missing users or failed operations. [[1]](diffhunk://#diff-ea2b06fb6f8497d91b28fca0c5c2a7c1b1e652c357c228e8e1d45f925717ed0bL179-R204) [[2]](diffhunk://#diff-ea2b06fb6f8497d91b28fca0c5c2a7c1b1e652c357c228e8e1d45f925717ed0bL600) [[3]](diffhunk://#diff-ea2b06fb6f8497d91b28fca0c5c2a7c1b1e652c357c228e8e1d45f925717ed0bL644)

**Middleware and Code Organization:**

* Refactored profile access control middleware (`isOwnProfile`, `isOwnProfileOrAdmin`) into a dedicated utility file for reuse and clarity, and updated all references to use the new location. [[1]](diffhunk://#diff-fef5f4ff8cde676fed21eac2d0f3d43db4484951af939c6dec553895e3a540c3R1-R30) [[2]](diffhunk://#diff-20f9b030a139bdbd17c8a67a791feeef0c2a22aac142d68c15777cef4e6bf792L29-R37) [[3]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L18-R22)
* Updated user settings routes to use the correct user object when creating new settings, and improved naming consistency for admin user lookups. [[1]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L152-R140) [[2]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L506-R771) [[3]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926L541-R800)

**UI and Frontend Support:**

* Added new React pages for managing linked accounts in both the admin and user settings sections, utilizing the new `UserSettingsAccounts` component. ([src/app/admin/users/[userid]/settings/linked-accounts/page.tsxR1-R6](diffhunk://#diff-59d128a8473b0a68a0ed43933f81c443b062680abca53d6cfe60d09b16f13a12R1-R6), [src/app/profile/settings/linked-accounts/page.tsxR1-R7](diffhunk://#diff-fea3a06fbdd644dcee3da3fece500576711caabccb6f4c4ed80011a69691ab69R1-R7))
* Updated the local sign-in form to use the new router and type-safe revalidation prop, preparing for improved user session handling.

**Other Technical Improvements:**

* Moved XML parsing import to the top of `plex_invite.py` for clarity and removed redundant imports. [[1]](diffhunk://#diff-ea2b06fb6f8497d91b28fca0c5c2a7c1b1e652c357c228e8e1d45f925717ed0bL4-R4) [[2]](diffhunk://#diff-ea2b06fb6f8497d91b28fca0c5c2a7c1b1e652c357c228e8e1d45f925717ed0bL80) [[3]](diffhunk://#diff-ea2b06fb6f8497d91b28fca0c5c2a7c1b1e652c357c228e8e1d45f925717ed0bL276)

**Related Issues**

- Fixes #212 

## Has This Been Tested?

Tested on new signup, existing users, linked and unlinked accounts.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)