### PR TITLE
fix(onboarding): prevent onboarding starting on signup prematurely

### DIFF
--- a/src/context/OnboardingContext.tsx
+++ b/src/context/OnboardingContext.tsx
@@ -84,6 +84,7 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
   const pathname = usePathname();
 
   const isSetupRoute = pathname?.startsWith('/setup');
+  const isSignupRoute = pathname?.startsWith('/signup');
   const isAdmin = hasPermission(Permission.ADMIN);
   const allowSkipWelcome = data?.settings.allowSkipWelcome ?? true;
   const allowSkipTutorial = data?.settings.allowSkipTutorial ?? true;
@@ -138,12 +139,14 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
   const shouldBlockUserOnboarding = useMemo(() => {
     return (
       isSetupRoute ||
+      isSignupRoute ||
       isAdminOnboarding ||
       adminOnboardingJustCompleted ||
       adminPhase !== 'idle'
     );
   }, [
     isSetupRoute,
+    isSignupRoute,
     isAdminOnboarding,
     adminOnboardingJustCompleted,
     adminPhase,
@@ -151,6 +154,7 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
 
   useEffect(() => {
     if (isSetupRoute) return;
+    if (isSignupRoute) return;
     if (adminOnboardingJustCompleted) return;
     if (isAdminOnboarding && adminPhase === 'idle') {
       setAdminPhase('welcome');
@@ -159,6 +163,7 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
     isAdminOnboarding,
     adminPhase,
     isSetupRoute,
+    isSignupRoute,
     adminOnboardingJustCompleted,
   ]);
 


### PR DESCRIPTION
## Description
This pull request updates the onboarding logic in the `OnboardingProvider` component to also account for the `/signup` route, ensuring that onboarding flows are correctly blocked or skipped when users are on the signup page. The main change is the introduction of the `isSignupRoute` check alongside the existing `isSetupRoute` logic.

**Onboarding flow adjustments:**

* Added `isSignupRoute` to detect when the user is on the `/signup` route, similar to how `/setup` is handled. (`src/context/OnboardingContext.tsx`)
* Updated the `shouldBlockUserOnboarding` calculation to include `isSignupRoute`, so onboarding is blocked during signup. (`src/context/OnboardingContext.tsx`)
* Modified the effect dependencies and early returns to account for the signup route, preventing onboarding steps from triggering when on `/signup`. (`src/context/OnboardingContext.tsx`)

## Has This Been Tested?

Only prevents onboarding appearing on signup routes.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
