### PR TITLE
fix(websocket): upgrade dispatcher & guarded Next.js HMR

### DIFF
--- a/cypress/e2e/websocket.cy.ts
+++ b/cypress/e2e/websocket.cy.ts
@@ -1,0 +1,38 @@
+/// <reference types="cypress" />
+
+import { io } from 'socket.io-client';
+
+describe('WebSocket', () => {
+  it('should connect to socket.io with an authenticated session', () => {
+    cy.loginAsAdmin();
+    cy.visit('/');
+
+    cy.then(
+      () =>
+        new Cypress.Promise<void>((resolve, reject) => {
+          const socket = io({
+            transports: ['websocket'],
+            reconnection: false,
+            timeout: 10000,
+          });
+
+          const timeout = setTimeout(() => {
+            socket.close();
+            reject(new Error('Timed out connecting to Socket.IO'));
+          }, 12000);
+
+          socket.on('connect', () => {
+            clearTimeout(timeout);
+            socket.close();
+            resolve();
+          });
+
+          socket.on('connect_error', (err) => {
+            clearTimeout(timeout);
+            socket.close();
+            reject(err);
+          });
+        })
+    );
+  });
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -40,6 +40,7 @@ import {
   createServiceProxyRouter,
   getActiveProxyPaths,
 } from '@server/routes/serviceProxy';
+import { createUpgradeDispatcher } from '@server/lib/websocket/upgradeDispatcher';
 import * as OpenApiValidator from 'express-openapi-validator';
 import type { Store } from 'express-session';
 import session from 'express-session';
@@ -49,6 +50,7 @@ import swaggerUi from 'swagger-ui-express';
 import YAML from 'yamljs';
 import { Server as SocketIOServer } from 'socket.io';
 import { createServer } from 'http';
+import type { Duplex } from 'stream';
 
 interface SocketRequest extends IncomingMessage {
   session?: ExpressSession & { userId?: number };
@@ -175,25 +177,46 @@ app
         origin: '*',
         methods: ['GET', 'POST'],
       },
+      destroyUpgrade: false,
     });
     io.engine.use(sessionMiddleware);
     server.set('io', io);
     setSocketIO(io);
     restartManager.initialize(httpServer, io);
+    const upgradeDispatcher = createUpgradeDispatcher(httpServer);
 
     // Next.js lazily attaches a catch-all `upgrade` listener (via
     // getRequestHandler) that hijacks the /socket.io/ upgrade and corrupts the
     // WebSocket frame ("Invalid frame header"). Mark Next's WS setup as already
-    // done so it never registers its catch-all, then route only /_next/* (HMR)
-    // upgrades to Next ourselves. Must stay after the Socket.IO server is
-    // constructed so engine.io's upgrade listener is registered first.
+    // done so it never registers its catch-all. This relies on NextCustomServer
+    // internals (`didWebSocketSetup`) and must be re-verified on Next.js major
+    // upgrades.
     (app as unknown as { didWebSocketSetup: boolean }).didWebSocketSetup = true;
-    const nextUpgradeHandler = app.getUpgradeHandler();
-    httpServer.on('upgrade', (req, socket, head) => {
-      if (req.url?.startsWith('/_next/')) {
-        nextUpgradeHandler(req, socket, head);
+    if (dev) {
+      const nextUpgradeHandler = (
+        app as unknown as {
+          upgradeHandler?: (
+            req: IncomingMessage,
+            socket: Duplex,
+            head: Buffer
+          ) => void;
+        }
+      ).upgradeHandler;
+
+      if (typeof nextUpgradeHandler === 'function') {
+        upgradeDispatcher.register({
+          name: 'next:hmr',
+          match: (url) => url.startsWith('/_next/'),
+          handle: (req, socket, head) =>
+            nextUpgradeHandler(req, socket as Duplex, head),
+        });
+      } else {
+        logger.warn(
+          'Next.js upgradeHandler unavailable; HMR over WebSocket disabled',
+          { label: 'Server' }
+        );
       }
-    });
+    }
     io.on('connection', async (socket) => {
       const req = socket.request as SocketRequest;
       // Check for valid session and user
@@ -229,7 +252,7 @@ app
     );
     const apiDocs = YAML.load(API_SPEC_PATH);
     server.use('/api-docs', swaggerUi.serve, swaggerUi.setup(apiDocs));
-    server.use(createServiceProxyRouter(httpServer, sessionMiddleware));
+    server.use(createServiceProxyRouter(upgradeDispatcher, sessionMiddleware));
     server.use(
       OpenApiValidator.middleware({
         apiSpec: API_SPEC_PATH,

--- a/server/lib/proxy/index.ts
+++ b/server/lib/proxy/index.ts
@@ -1,7 +1,8 @@
-import type { IncomingMessage, Server } from 'http';
+import type { IncomingMessage } from 'http';
 import type { Socket } from 'net';
 import type { Request, RequestHandler, Response } from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
+import type { UpgradeDispatcher } from '@server/lib/websocket/upgradeDispatcher';
 import logger from '@server/logger';
 
 // Extended request type for session data
@@ -87,13 +88,15 @@ export function createServiceProxy(config: ServiceProxyConfig) {
 }
 
 export function registerWebSocketHandler(
-  httpServer: Server,
+  dispatcher: UpgradeDispatcher,
   sessionMiddleware: RequestHandler,
   wsPath: string,
   proxy: ReturnType<typeof createProxyMiddleware>
 ) {
-  httpServer.on('upgrade', (req: SessionRequest, socket, head) => {
-    if (req.url?.startsWith(wsPath)) {
+  dispatcher.register({
+    name: `proxy:${wsPath}`,
+    match: (url) => url.startsWith(wsPath),
+    handle: (req: SessionRequest, socket, head) => {
       sessionMiddleware(req as unknown as Request, {} as Response, () => {
         if (!req.session?.userId) {
           logger.warn('Unauthenticated WebSocket upgrade attempt', {
@@ -106,6 +109,6 @@ export function registerWebSocketHandler(
         }
         proxy.upgrade(req, socket as Socket, head);
       });
-    }
+    },
   });
 }

--- a/server/lib/proxy/plexProxy.ts
+++ b/server/lib/proxy/plexProxy.ts
@@ -1,7 +1,7 @@
-import type { Server } from 'http';
 import type { RequestHandler } from 'express';
 import { getSettings } from '@server/lib/settings';
 import { getPlexHealth } from '@server/lib/plexHealthCheck';
+import type { UpgradeDispatcher } from '@server/lib/websocket/upgradeDispatcher';
 import { createServiceProxy, registerWebSocketHandler } from './index';
 
 function getPlexTarget(): string {
@@ -11,7 +11,7 @@ function getPlexTarget(): string {
 }
 
 export function createPlexProxy(
-  httpServer: Server,
+  dispatcher: UpgradeDispatcher,
   sessionMiddleware: RequestHandler
 ) {
   const proxy = createServiceProxy({
@@ -23,7 +23,7 @@ export function createPlexProxy(
     suppressErrors: () => getPlexHealth().status !== 'healthy',
   });
 
-  registerWebSocketHandler(httpServer, sessionMiddleware, '/web', proxy);
+  registerWebSocketHandler(dispatcher, sessionMiddleware, '/web', proxy);
 
   return proxy;
 }

--- a/server/lib/proxy/tdarrProxy.ts
+++ b/server/lib/proxy/tdarrProxy.ts
@@ -1,7 +1,8 @@
-import type { Server, IncomingMessage } from 'http';
+import type { IncomingMessage } from 'http';
 import type { Socket } from 'net';
 import type { Request, RequestHandler, Response } from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
+import type { UpgradeDispatcher } from '@server/lib/websocket/upgradeDispatcher';
 import logger from '@server/logger';
 
 /** Hardcoded proxy paths for Tdarr (no custom base URL support) */
@@ -128,12 +129,15 @@ export function createTdarrStaticProxy(config: TdarrProxyConfig) {
  * Registers WebSocket handler for Tdarr Socket.IO connections.
  */
 export function registerTdarrWebSocketHandler(
-  httpServer: Server,
+  dispatcher: UpgradeDispatcher,
   sessionMiddleware: RequestHandler,
   proxy: ReturnType<typeof createProxyMiddleware>
 ) {
-  httpServer.on('upgrade', (req: SessionRequest, socket, head) => {
-    if (req.url?.startsWith(`${TDARR_PROXY_PATH}/socket.io`)) {
+  const wsPath = `${TDARR_PROXY_PATH}/socket.io`;
+  dispatcher.register({
+    name: `tdarr:${wsPath}`,
+    match: (url) => url.startsWith(wsPath),
+    handle: (req: SessionRequest, socket, head) => {
       sessionMiddleware(req as unknown as Request, {} as Response, () => {
         if (!req.session?.userId) {
           socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
@@ -142,6 +146,6 @@ export function registerTdarrWebSocketHandler(
         }
         proxy.upgrade(req, socket as Socket, head);
       });
-    }
+    },
   });
 }

--- a/server/lib/websocket/upgradeDispatcher.ts
+++ b/server/lib/websocket/upgradeDispatcher.ts
@@ -1,0 +1,71 @@
+import type { IncomingMessage, Server } from 'http';
+import type { Duplex } from 'stream';
+import logger from '@server/logger';
+
+export interface UpgradeMatcher {
+  /** Human-readable name used in logs. */
+  name: string;
+  /** Returns true when this matcher should handle the given request URL. */
+  match: (url: string) => boolean;
+  /** Handles the upgrade. May be async. */
+  handle: (
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer
+  ) => void | Promise<void>;
+}
+
+export class UpgradeDispatcher {
+  private matchers: UpgradeMatcher[] = [];
+
+  private static isSocketIOUpgrade(url: string): boolean {
+    return url === '/socket.io' || url.startsWith('/socket.io/');
+  }
+
+  public constructor(httpServer: Server) {
+    httpServer.on('upgrade', (req, socket, head) => {
+      const url = req.url ?? '';
+      const matcher = this.matchers.find((m) => m.match(url));
+
+      // Socket.IO's engine.io listener still handles its own upgrade path.
+      if (!matcher) {
+        if (UpgradeDispatcher.isSocketIOUpgrade(url)) {
+          return;
+        }
+
+        socket.end('HTTP/1.1 404 Not Found\r\nConnection: close\r\n\r\n');
+        return;
+      }
+
+      try {
+        const result = matcher.handle(req, socket, head);
+        if (result instanceof Promise) {
+          result.catch((e) => this.handleError(matcher, socket, e));
+        }
+      } catch (e) {
+        this.handleError(matcher, socket, e);
+      }
+    });
+  }
+
+  public register(matcher: UpgradeMatcher): void {
+    this.matchers.push(matcher);
+  }
+
+  private handleError(
+    matcher: UpgradeMatcher,
+    socket: Duplex,
+    e: unknown
+  ): void {
+    logger.error('WebSocket upgrade handler failed', {
+      label: 'WebSocket',
+      matcher: matcher.name,
+      message: e instanceof Error ? e.message : String(e),
+    });
+    socket.destroy();
+  }
+}
+
+export function createUpgradeDispatcher(httpServer: Server): UpgradeDispatcher {
+  return new UpgradeDispatcher(httpServer);
+}

--- a/server/routes/serviceProxy.ts
+++ b/server/routes/serviceProxy.ts
@@ -1,9 +1,9 @@
-import type { Server } from 'http';
 import type { RequestHandler } from 'express';
 import { Router } from 'express';
 import { checkUser, isAuthenticated } from '@server/middleware/auth';
 import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
+import type { UpgradeDispatcher } from '@server/lib/websocket/upgradeDispatcher';
 import { createPlexProxy } from '@server/lib/proxy/plexProxy';
 import { createArrProxy } from '@server/lib/proxy/arrProxy';
 import {
@@ -68,7 +68,7 @@ export function getActiveProxyPaths(): string[] {
  * Creates the service proxy router with session-protected proxy routes.
  */
 export function createServiceProxyRouter(
-  httpServer: Server,
+  dispatcher: UpgradeDispatcher,
   sessionMiddleware: RequestHandler
 ): Router {
   const router = Router();
@@ -99,7 +99,7 @@ export function createServiceProxyRouter(
   if (settings.plex.ip) {
     registerProxy(
       '/web',
-      createPlexProxy(httpServer, sessionMiddleware),
+      createPlexProxy(dispatcher, sessionMiddleware),
       'Plex'
     );
   }
@@ -183,7 +183,7 @@ export function createServiceProxyRouter(
 
     const tdarrProxy = createTdarrProxy(tdarrConfig);
     registerProxy(TDARR_PROXY_PATH, tdarrProxy, 'Tdarr', true);
-    registerTdarrWebSocketHandler(httpServer, sessionMiddleware, tdarrProxy);
+    registerTdarrWebSocketHandler(dispatcher, sessionMiddleware, tdarrProxy);
 
     // Static assets (no auth - loaded as resources after authenticated page loads)
     router.use(TDARR_STATIC_PATH, createTdarrStaticProxy(tdarrConfig));


### PR DESCRIPTION
## Description
This pull request introduces a new centralized mechanism for handling WebSocket upgrade requests across the server. The main change is the introduction of an `UpgradeDispatcher` class to manage and route WebSocket upgrade requests, replacing the previous approach of directly attaching multiple `upgrade` listeners to the HTTP server. All relevant proxy handlers and the Next.js HMR handler are now registered through this dispatcher.

Key changes include:

**WebSocket Upgrade Handling Infrastructure:**

* Added the `UpgradeDispatcher` class in `server/lib/websocket/upgradeDispatcher.ts`, which manages a registry of upgrade handlers and dispatches incoming WebSocket upgrade requests to the correct handler based on URL matching. This centralizes error handling and prevents conflicts between different upgrade consumers.
* All proxy modules and the service proxy router have been refactored to accept an `UpgradeDispatcher` instance instead of the raw HTTP server, and to register their WebSocket handlers using the new dispatcher interface. [[1]](diffhunk://#diff-ef4be02cc28af7518f7930e19ecf68f9ea294e755b5003e9db4c541c2d1edffeL1-R5) [[2]](diffhunk://#diff-ef4be02cc28af7518f7930e19ecf68f9ea294e755b5003e9db4c541c2d1edffeL90-R99) [[3]](diffhunk://#diff-ef4be02cc28af7518f7930e19ecf68f9ea294e755b5003e9db4c541c2d1edffeL109-R112) [[4]](diffhunk://#diff-a9d1fb5f02bc636e9e0ab4ba16bebfa826aad2e8cd53b904a268c3d8f9569bb9L1-R4) [[5]](diffhunk://#diff-a9d1fb5f02bc636e9e0ab4ba16bebfa826aad2e8cd53b904a268c3d8f9569bb9L14-R14) [[6]](diffhunk://#diff-a9d1fb5f02bc636e9e0ab4ba16bebfa826aad2e8cd53b904a268c3d8f9569bb9L26-R26) [[7]](diffhunk://#diff-c29cb1439d75a338e94356edb06d2730d0cf82471d1a06504b8ef2c4e98100ffL1-R5) [[8]](diffhunk://#diff-c29cb1439d75a338e94356edb06d2730d0cf82471d1a06504b8ef2c4e98100ffL131-R140) [[9]](diffhunk://#diff-c29cb1439d75a338e94356edb06d2730d0cf82471d1a06504b8ef2c4e98100ffL145-R149) [[10]](diffhunk://#diff-d9b575c26a1c65a032ff78f6da01dea7b2e787d2491ba9b97fca9de0d7f5cce5L1-R6) [[11]](diffhunk://#diff-d9b575c26a1c65a032ff78f6da01dea7b2e787d2491ba9b97fca9de0d7f5cce5L71-R71) [[12]](diffhunk://#diff-d9b575c26a1c65a032ff78f6da01dea7b2e787d2491ba9b97fca9de0d7f5cce5L102-R102) [[13]](diffhunk://#diff-d9b575c26a1c65a032ff78f6da01dea7b2e787d2491ba9b97fca9de0d7f5cce5L186-R186)

**Server Integration and Next.js HMR:**

* In `server/index.ts`, the server now creates an `UpgradeDispatcher` and uses it to register the Next.js HMR WebSocket handler only in development mode, with improved error logging if the handler is unavailable. This prevents Next.js from interfering with other WebSocket consumers and ensures only the correct handler processes upgrade requests. [[1]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68R43) [[2]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68R53) [[3]](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68R180-R219)
* The service proxy router is now initialized with the dispatcher, ensuring all service proxies use the new upgrade handling flow.

**Testing:**

* Added a new Cypress test (`cypress/e2e/websocket.cy.ts`) to verify that Socket.IO connections can be established with an authenticated session, ensuring that the new upgrade handling infrastructure works as intended.

## Has This Been Tested?

Yes - all proxy routes function correctly, plex and tautulli websockets connect, streamarrs notification socket works as normal.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
