### PR TITLE
fix(websocket): drop ws-only transport & remove plex ws hijack

### DIFF
--- a/server/lib/proxy/plexProxy.ts
+++ b/server/lib/proxy/plexProxy.ts
@@ -18,7 +18,7 @@ export function createPlexProxy(
     name: 'Plex',
     getTarget: getPlexTarget,
     pathPrefix: '/web',
-    webSocket: true,
+    webSocket: false,
     wsPath: '/web',
     suppressErrors: () => getPlexHealth().status !== 'healthy',
   });

--- a/src/utils/webSocket.ts
+++ b/src/utils/webSocket.ts
@@ -1,3 +1,3 @@
 import { io } from 'socket.io-client';
 
-export const socket = io({ transports: ['websocket'] });
+export const socket = io();


### PR DESCRIPTION
## Description
The Plex /web proxy was created with `ws: true` and no pathFilter. On the first /web request, http-proxy-middleware auto-subscribes a server-level 'upgrade' listener that, with an undefined pathFilter, matches every path — so it proxied all upgrades (including /socket.io/) to Plex, racing engine.io and corrupting the frames ("Invalid frame header"). This also made the auth check in registerWebSocketHandler a no-op, since the auto-subscribe set wsInternalSubscribed and turned our manual proxy.upgrade() into a no-op.

- plexProxy: set webSocket: false; /web upgrades are already handled explicitly via the UpgradeDispatcher, which restores the session auth gate 
- client: drop the websocket-only transport so Socket.IO negotiates polling first and upgrades when the path allows, degrading gracefully behind proxies instead of failing outright

## Has This Been Tested?

Tested on localhost and behind proxy/cdn and confirmed websocket issues resolved.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
