### PR TITLE
chore(deps): migrate pnpm settings to pnpm-workspace.yaml for pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "streamarr",
   "version": "0.1.0",
   "private": true,
-  "packageManager": "pnpm@10.34.1",
+  "packageManager": "pnpm@11.5.0",
   "scripts": {
     "dev": "nodemon -e ts --watch server --watch streamarr-api.yml -e .json,.ts,.yml -x tsx --tsconfig server/tsconfig.json server/index.ts",
     "build:next": "next build",
@@ -190,7 +190,7 @@
   },
   "engines": {
     "node": ">=24.0.0",
-    "pnpm": "^10.0.0"
+    "pnpm": "^11.0.0"
   },
   "config": {
     "commitizen": {
@@ -308,16 +308,5 @@
         }
       ]
     ]
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "bcrypt",
-      "cypress",
-      "sharp",
-      "sqlite3"
-    ],
-    "overrides": {
-      "eslint-config-next>typescript-eslint": "^8.58.2"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+allowBuilds:
+  bcrypt: true
+  cypress: true
+  sharp: true
+  sqlite3: true
+  '@parcel/watcher': false
+  '@scarf/scarf': false
+  esbuild: false
+  unrs-resolver: false
+overrides:
+  eslint-config-next>typescript-eslint: ^8.58.2


### PR DESCRIPTION
## Description
pnpm 11 no longer reads the `pnpm` field from package.json and removed the `onlyBuiltDependencies` setting in favour of an `allowBuilds` map, with `strictDepBuilds` now defaulting to true (an undeclared dependency build script becomes a hard error). Under pnpm 11 the existing config produced ERR_PNPM_IGNORED_BUILDS and silently dropped the typescript-eslint override.

Move both settings into pnpm-workspace.yaml:
- allowBuilds explicitly allows the four native deps that were built under pnpm 10 (bcrypt, cypress, sharp, sqlite3) and explicitly denies the build scripts that were never run (@parcel/watcher, @scarf/scarf, esbuild, unrs-resolver), satisfying strictDepBuilds.
- overrides preserves the eslint-config-next>typescript-eslint pin.

packageManager and engines.pnpm are bumped to 11. The lockfile is unchanged: relocating build settings does not alter the resolution graph, and the override was already applied. `pnpm install --frozen-lockfile` no longer errors on the build configuration.

## Has This Been Tested?

Yes, running dev and prod servers remain working and unchanged.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
