### PR TITLE
fix(hooks): resolve react-hooks compiler rule violations

### DIFF
--- a/src/components/Admin/Downloads/DownloadRow.tsx
+++ b/src/components/Admin/Downloads/DownloadRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { formatBytes, formatSpeed, formatEta } from '@app/utils/numberHelper';
 import type {
@@ -11,6 +11,7 @@ import Toast from '@app/components/Toast';
 import TorrentDetailsModal from './TorrentDetailsModal';
 import RemoveTorrentModal from './RemoveTorrentModal';
 import { useDownloadActions } from '@app/hooks/useDownloads';
+import { useIsClient } from '@app/hooks/useIsClient';
 import {
   PlayIcon,
   PauseIcon,
@@ -54,11 +55,8 @@ const DownloadRow: React.FC<DownloadRowProps> = ({
   const [isActing, setIsActing] = useState(false);
   const [showDetailsModal, setShowDetailsModal] = useState(false);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
-  const [isMounted, setIsMounted] = useState(false);
+  const isMounted = useIsClient();
 
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
   const {
     pause,
     resume,

--- a/src/components/Admin/Downloads/TorrentDetailsModal.tsx
+++ b/src/components/Admin/Downloads/TorrentDetailsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { formatBytes, formatSpeed, formatEta } from '@app/utils/numberHelper';
 import Modal from '@app/components/Common/Modal';
 import Alert from '@app/components/Common/Alert';
@@ -50,14 +50,16 @@ const TorrentDetailsModal: React.FC<TorrentDetailsModalProps> = ({
   const [newTagInput, setNewTagInput] = useState('');
   const [showTagInput, setShowTagInput] = useState(false);
 
-  // Reset transient state when modal closes or torrent changes
-  useEffect(() => {
+  // Reset transient state when the modal transitions to closed
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  if (prevIsOpen !== isOpen) {
+    setPrevIsOpen(isOpen);
     if (!isOpen) {
       setShouldLoadFiles(false);
       setShowTagInput(false);
       setNewTagInput('');
     }
-  }, [isOpen, torrent?.hash]);
+  }
 
   const supportsGlobalTags = torrent?.clientType === 'qbittorrent';
   const supportsTags =

--- a/src/components/Admin/Downloads/index.tsx
+++ b/src/components/Admin/Downloads/index.tsx
@@ -24,7 +24,7 @@ import {
 import useSWR from 'swr';
 import Button from '@app/components/Common/Button';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, useMemo, useState, useEffect } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { useDownloads, useDownloadActions } from '@app/hooks/useDownloads';
@@ -144,7 +144,6 @@ const AdminDownloads = () => {
   const [isPaused, setIsPaused] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [selectedHashes, setSelectedHashes] = useState<Set<string>>(new Set());
-  const [isSelectAllChecked, setIsSelectAllChecked] = useState(false);
   const [isBulkActing, setIsBulkActing] = useState(false);
   const [showBulkRemoveModal, setShowBulkRemoveModal] = useState(false);
   const [isRetrying, setIsRetrying] = useState(false);
@@ -192,10 +191,13 @@ const AdminDownloads = () => {
   }, []);
 
   // Clear selections when filter/page changes
-  useEffect(() => {
+  const selectionResetKey = `${currentFilter}|${currentClient}|${page}`;
+  const [prevSelectionResetKey, setPrevSelectionResetKey] =
+    useState(selectionResetKey);
+  if (prevSelectionResetKey !== selectionResetKey) {
+    setPrevSelectionResetKey(selectionResetKey);
     setSelectedHashes(new Set());
-    setIsSelectAllChecked(false);
-  }, [currentFilter, currentClient, page]);
+  }
 
   // Set filter values to local storage any time they are changed
   useEffect(() => {
@@ -239,16 +241,22 @@ const AdminDownloads = () => {
     DownloadClientSettings[]
   >('/api/v1/settings/downloads');
 
+  // Whether every visible download is currently selected (derived state)
+  const isSelectAllChecked = useMemo(() => {
+    if (data?.results && selectedHashes.size > 0) {
+      return data.results.every((t) => selectedHashes.has(t.hash));
+    }
+    return false;
+  }, [selectedHashes, data]);
+
   // Handle select all checkbox
   const handleSelectAll = useCallback(() => {
     if (isSelectAllChecked) {
       setSelectedHashes(new Set());
-      setIsSelectAllChecked(false);
     } else {
       if (data?.results) {
         const allHashes = new Set(data.results.map((t) => t.hash));
         setSelectedHashes(allHashes);
-        setIsSelectAllChecked(true);
       }
     }
   }, [isSelectAllChecked, data]);
@@ -285,7 +293,6 @@ const AdminDownloads = () => {
 
         // Clear selection after action
         setSelectedHashes(new Set());
-        setIsSelectAllChecked(false);
 
         // Refresh data
         refetch();
@@ -322,7 +329,6 @@ const AdminDownloads = () => {
 
         // Clear selection after action
         setSelectedHashes(new Set());
-        setIsSelectAllChecked(false);
         setShowBulkRemoveModal(false);
 
         // Refresh data
@@ -373,16 +379,6 @@ const AdminDownloads = () => {
       (s) => s.health?.status === 'unhealthy' || s.health?.status === 'retrying'
     ) || [];
   const hasUnhealthyClients = unhealthyClients.length > 0;
-
-  // Update select-all state when selection changes
-  useEffect(() => {
-    if (data?.results && selectedHashes.size > 0) {
-      const allSelected = data.results.every((t) => selectedHashes.has(t.hash));
-      setIsSelectAllChecked(allSelected);
-    } else {
-      setIsSelectAllChecked(false);
-    }
-  }, [selectedHashes, data]);
 
   // Only show full page loading on initial load when we have no data yet
   const isInitialLoading = (isLoadingClients || isLoadingDownloads) && !data;

--- a/src/components/Admin/Settings/ColorPickerModal.tsx
+++ b/src/components/Admin/Settings/ColorPickerModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useMemo, useState } from 'react';
 import { HexColorPicker } from 'react-colorful';
 import type { HslColor } from 'colord';
 import { colord } from 'colord';
@@ -40,9 +40,7 @@ const ColorPickerModal: React.FC<ColorPickerModalProps> = ({
     parseColorToHex(theme[colorName]) ?? theme[colorName]
   );
   const [tab, setTab] = useState<'picker' | 'sliders' | 'palette'>('palette');
-  const [hsl, setHsl] = useState<HslColor>(
-    colord(parseColorToHex(theme[colorName]) ?? theme[colorName]).toHsl()
-  );
+  const hsl = useMemo<HslColor>(() => colord(color).toHsl(), [color]);
   const [format, setFormat] = useState<'hex' | 'rgb' | 'hsl' | 'oklch'>(
     'oklch'
   );
@@ -86,15 +84,16 @@ const ColorPickerModal: React.FC<ColorPickerModalProps> = ({
     },
   ];
 
-  useEffect(() => {
-    if (show && theme[colorName]) {
-      setColor(parseColorToHex(theme[colorName]) ?? theme[colorName]);
+  // Sync the working color to the theme value when the modal opens or target changes
+  const themeColor = theme[colorName];
+  const colorSyncKey = `${show}|${colorName}|${themeColor}`;
+  const [prevColorSyncKey, setPrevColorSyncKey] = useState(colorSyncKey);
+  if (prevColorSyncKey !== colorSyncKey) {
+    setPrevColorSyncKey(colorSyncKey);
+    if (show && themeColor) {
+      setColor(parseColorToHex(themeColor) ?? themeColor);
     }
-  }, [colorName, show, theme]);
-
-  useEffect(() => {
-    setHsl(colord(color).toHsl());
-  }, [color]);
+  }
 
   const getFormattedValue = () => {
     const c = colord(color);
@@ -155,18 +154,19 @@ const ColorPickerModal: React.FC<ColorPickerModalProps> = ({
 
   const updateFromHsl = (newHsl: Partial<HslColor>) => {
     const updated = { ...hsl, ...newHsl };
-    setHsl(updated);
     setColor(colord(updated).toHex());
   };
 
   // Local editable input state so users can type values
   const [inputValue, setInputValue] = useState<string>(getFormattedValue());
 
-  useEffect(() => {
-    // keep the input in sync when the color changes externally
-    setInputValue(getFormattedValue());
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [color, format]);
+  // Keep the editable input in sync when the color or format changes externally
+  const formattedValue = getFormattedValue();
+  const [prevFormattedValue, setPrevFormattedValue] = useState(formattedValue);
+  if (prevFormattedValue !== formattedValue) {
+    setPrevFormattedValue(formattedValue);
+    setInputValue(formattedValue);
+  }
 
   const presets = getAllTailwindColors();
   const currentOption = formatOptions.find((opt) => opt.value === format);

--- a/src/components/Admin/Settings/JobsCache/index.tsx
+++ b/src/components/Admin/Settings/JobsCache/index.tsx
@@ -82,7 +82,7 @@ const jobModalReducer = (
 
 const JobsCacheSettings = () => {
   const intl = useIntl();
-  const [now, setNow] = useState(Date.now());
+  const [now, setNow] = useState(() => Date.now());
 
   useEffect(() => {
     const interval = setInterval(() => setNow(Date.now()), 1000);

--- a/src/components/Admin/Settings/Notifications/WebpushNotifications/index.tsx
+++ b/src/components/Admin/Settings/Notifications/WebpushNotifications/index.tsx
@@ -7,23 +7,23 @@ import { BeakerIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 import { CheckBadgeIcon, XCircleIcon } from '@heroicons/react/24/solid';
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
+import { useClientValue } from '@app/hooks/useIsClient';
 import useSWR, { mutate } from 'swr';
 import { useIntl, FormattedMessage } from 'react-intl';
 
 const WebpushNotifications = () => {
   const intl = useIntl();
   const [isTesting, setIsTesting] = useState(false);
-  const [isHttps, setIsHttps] = useState(false);
+  const isHttps = useClientValue(
+    () => window.location.protocol.startsWith('https'),
+    false
+  );
   const {
     data,
     error,
     mutate: revalidate,
   } = useSWR('/api/v1/settings/notifications/webpush');
-
-  useEffect(() => {
-    setIsHttps(window.location.protocol.startsWith('https'));
-  }, []);
 
   if (!data && !error) {
     return <LoadingEllipsis />;

--- a/src/components/Admin/Settings/Services/Downloads/DownloadClientModal/index.tsx
+++ b/src/components/Admin/Settings/Services/Downloads/DownloadClientModal/index.tsx
@@ -40,7 +40,7 @@ const DownloadClientModal = ({
   const intl = useIntl();
   const initialLoad = useRef(false);
   const [isValidated, setIsValidated] = useState(downloadClient ? true : false);
-  const [isTesting, setIsTesting] = useState(false);
+  const [isTesting, setIsTesting] = useState(() => Boolean(downloadClient));
   const DownloadClientSchema = Yup.object().shape({
     name: Yup.string().required(
       intl.formatMessage({
@@ -85,7 +85,7 @@ const DownloadClientModal = ({
     }),
   });
 
-  const testConnection = useCallback(
+  const performTest = useCallback(
     async ({
       name,
       hostname,
@@ -103,9 +103,8 @@ const DownloadClientModal = ({
       client: DownloadClientType;
       useSsl: boolean;
     }) => {
-      setIsTesting(true);
-      try {
-        const response = await axios.post('/api/v1/settings/downloads/test', {
+      const result = await axios
+        .post('/api/v1/settings/downloads/test', {
           name,
           hostname,
           port,
@@ -113,40 +112,50 @@ const DownloadClientModal = ({
           password,
           client,
           useSsl,
-        });
+        })
+        .then(
+          (response) => ({
+            connected: Boolean(response.data.connected),
+            error: response.data.error,
+          }),
+          (e) => ({
+            connected: false,
+            error: e.response?.data?.message || e.message,
+          })
+        );
 
-        if (!response.data.connected) {
-          throw new Error(response.data.error || 'Connection failed');
-        }
-        setIsValidated(true);
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.downloads.testsuccess',
-                defaultMessage: 'Successfully connected to {client}',
-              },
-              { client: CLIENT_NAMES[client] }
-            ),
-            type: 'success',
-            icon: <CheckBadgeIcon className="size-7" />,
-          });
-        }
-      } catch (e) {
-        setIsValidated(false);
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.downloads.testfailed',
-                defaultMessage: 'Failed to connect to {client}',
-              },
-              { client: CLIENT_NAMES[client] }
-            ),
-            message: e.response?.data?.message || e.message,
-            type: 'error',
-            icon: <XCircleIcon className="size-7" />,
-          });
+      try {
+        if (result.connected) {
+          setIsValidated(true);
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.downloads.testsuccess',
+                  defaultMessage: 'Successfully connected to {client}',
+                },
+                { client: CLIENT_NAMES[client] }
+              ),
+              type: 'success',
+              icon: <CheckBadgeIcon className="size-7" />,
+            });
+          }
+        } else {
+          setIsValidated(false);
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.downloads.testfailed',
+                  defaultMessage: 'Failed to connect to {client}',
+                },
+                { client: CLIENT_NAMES[client] }
+              ),
+              message: result.error || 'Connection failed',
+              type: 'error',
+              icon: <XCircleIcon className="size-7" />,
+            });
+          }
         }
       } finally {
         setIsTesting(false);
@@ -156,9 +165,25 @@ const DownloadClientModal = ({
     [intl]
   );
 
+  const testConnection = useCallback(
+    (params: {
+      name: string;
+      hostname: string;
+      port: number;
+      username?: string;
+      password?: string;
+      client: DownloadClientType;
+      useSsl: boolean;
+    }) => {
+      setIsTesting(true);
+      void performTest(params);
+    },
+    [performTest]
+  );
+
   useEffect(() => {
     if (downloadClient) {
-      testConnection({
+      void performTest({
         name: downloadClient.name,
         hostname: downloadClient.hostname,
         port: downloadClient.port,
@@ -168,7 +193,7 @@ const DownloadClientModal = ({
         useSsl: downloadClient.useSsl,
       });
     }
-  }, [downloadClient, testConnection]);
+  }, [downloadClient, performTest]);
 
   return (
     <Formik

--- a/src/components/Admin/Settings/Services/Downloads/index.tsx
+++ b/src/components/Admin/Settings/Services/Downloads/index.tsx
@@ -20,7 +20,7 @@ import type {
   DownloadClientType,
 } from '@server/lib/settings';
 import axios from 'axios';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import useSWR, { mutate } from 'swr';
 
 const CLIENT_NAMES: Record<DownloadClientType, string> = {
@@ -82,29 +82,34 @@ const DownloadClientInstance = ({
     version?: string;
     error?: string;
   } | null>(null);
-  const [isTesting, setIsTesting] = useState(false);
+  const [isTesting, setIsTesting] = useState(true);
 
-  const testConnection = async () => {
-    setIsTesting(true);
-    try {
-      const response = await axios.post(
-        `/api/v1/settings/downloads/test/${id}`
+  const performTest = useCallback(async () => {
+    const result = await axios
+      .post(`/api/v1/settings/downloads/test/${id}`)
+      .then(
+        (response) => response.data,
+        (e) => ({
+          connected: false,
+          error: e.message || 'Connection failed',
+        })
       );
-      setConnectionStatus(response.data);
-    } catch (e) {
-      setConnectionStatus({
-        connected: false,
-        error: e.message || 'Connection failed',
-      });
+
+    try {
+      setConnectionStatus(result);
     } finally {
       setIsTesting(false);
     }
-  };
+  }, [id]);
+
+  const testConnection = useCallback(() => {
+    setIsTesting(true);
+    void performTest();
+  }, [performTest]);
 
   useEffect(() => {
-    testConnection();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    void performTest();
+  }, [performTest]);
 
   const internalUrl =
     (isSSL ? 'https://' : 'http://') + hostname + ':' + String(port);

--- a/src/components/Admin/Settings/Services/Lidarr/index.tsx
+++ b/src/components/Admin/Settings/Services/Lidarr/index.tsx
@@ -77,7 +77,7 @@ const ServicesLidarr = () => {
       ),
   });
 
-  const testConnection = useCallback(
+  const performTest = useCallback(
     async ({
       hostname,
       port,
@@ -91,46 +91,52 @@ const ServicesLidarr = () => {
       urlBase?: string;
       useSsl?: boolean;
     }) => {
-      setIsTesting(true);
-      try {
-        await axios.post<TestResponse>('/api/v1/settings/lidarr/test', {
+      const success = await axios
+        .post<TestResponse>('/api/v1/settings/lidarr/test', {
           hostname,
           port: Number(port),
           apiKey,
           urlBase,
           useSsl,
-        });
+        })
+        .then(
+          () => true,
+          () => false
+        );
 
-        setIsValidated(true);
-        revalidateAuthStatus();
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.testsuccess',
-                defaultMessage:
-                  '{service} connection established successfully!',
-              },
-              { service: 'Lidarr' }
-            ),
-            type: 'success',
-            icon: <CheckBadgeIcon className="size-7" />,
-          });
-        }
-      } catch {
-        setIsValidated(false);
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.testfailed',
-                defaultMessage: 'Failed to connect to {service}.',
-              },
-              { service: 'Lidarr' }
-            ),
-            type: 'error',
-            icon: <XCircleIcon className="size-7" />,
-          });
+      try {
+        if (success) {
+          setIsValidated(true);
+          revalidateAuthStatus();
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.testsuccess',
+                  defaultMessage:
+                    '{service} connection established successfully!',
+                },
+                { service: 'Lidarr' }
+              ),
+              type: 'success',
+              icon: <CheckBadgeIcon className="size-7" />,
+            });
+          }
+        } else {
+          setIsValidated(false);
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.testfailed',
+                  defaultMessage: 'Failed to connect to {service}.',
+                },
+                { service: 'Lidarr' }
+              ),
+              type: 'error',
+              icon: <XCircleIcon className="size-7" />,
+            });
+          }
         }
       } finally {
         setIsTesting(false);
@@ -138,6 +144,20 @@ const ServicesLidarr = () => {
       }
     },
     [revalidateAuthStatus, intl]
+  );
+
+  const testConnection = useCallback(
+    (params: {
+      hostname: string;
+      port: number;
+      apiKey: string;
+      urlBase?: string;
+      useSsl?: boolean;
+    }) => {
+      setIsTesting(true);
+      void performTest(params);
+    },
+    [performTest]
   );
 
   // Auto-test connection on page load if service is configured
@@ -149,7 +169,7 @@ const ServicesLidarr = () => {
       !isValidated &&
       !isTesting
     ) {
-      testConnection({
+      void performTest({
         hostname: dataLidarr.hostname,
         port: dataLidarr.port,
         apiKey: dataLidarr.apiKey,
@@ -157,7 +177,7 @@ const ServicesLidarr = () => {
         useSsl: dataLidarr.useSsl,
       });
     }
-  }, [dataLidarr, isTesting, isValidated, testConnection]);
+  }, [dataLidarr, isTesting, isValidated, performTest]);
 
   const handleDisableAuth = async () => {
     if (!dataLidarr || isDisablingAuth) return;

--- a/src/components/Admin/Settings/Services/Prowlarr/index.tsx
+++ b/src/components/Admin/Settings/Services/Prowlarr/index.tsx
@@ -73,7 +73,7 @@ const ServicesProwlarr = () => {
       ),
   });
 
-  const testConnection = useCallback(
+  const performTest = useCallback(
     async ({
       hostname,
       port,
@@ -87,46 +87,52 @@ const ServicesProwlarr = () => {
       urlBase?: string;
       useSsl?: boolean;
     }) => {
-      setIsTesting(true);
-      try {
-        await axios.post('/api/v1/settings/prowlarr/test', {
+      const success = await axios
+        .post('/api/v1/settings/prowlarr/test', {
           hostname,
           port: Number(port),
           apiKey,
           urlBase,
           useSsl,
-        });
+        })
+        .then(
+          () => true,
+          () => false
+        );
 
-        setIsValidated(true);
-        revalidateAuthStatus();
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.testsuccess',
-                defaultMessage:
-                  '{service} connection established successfully!',
-              },
-              { service: 'Prowlarr' }
-            ),
-            type: 'success',
-            icon: <CheckBadgeIcon className="size-7" />,
-          });
-        }
-      } catch {
-        setIsValidated(false);
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.testfailed',
-                defaultMessage: 'Failed to connect to {service}.',
-              },
-              { service: 'Prowlarr' }
-            ),
-            type: 'error',
-            icon: <XCircleIcon className="size-7" />,
-          });
+      try {
+        if (success) {
+          setIsValidated(true);
+          revalidateAuthStatus();
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.testsuccess',
+                  defaultMessage:
+                    '{service} connection established successfully!',
+                },
+                { service: 'Prowlarr' }
+              ),
+              type: 'success',
+              icon: <CheckBadgeIcon className="size-7" />,
+            });
+          }
+        } else {
+          setIsValidated(false);
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.testfailed',
+                  defaultMessage: 'Failed to connect to {service}.',
+                },
+                { service: 'Prowlarr' }
+              ),
+              type: 'error',
+              icon: <XCircleIcon className="size-7" />,
+            });
+          }
         }
       } finally {
         setIsTesting(false);
@@ -134,6 +140,20 @@ const ServicesProwlarr = () => {
       }
     },
     [revalidateAuthStatus, intl]
+  );
+
+  const testConnection = useCallback(
+    (params: {
+      hostname: string;
+      port: number;
+      apiKey: string;
+      urlBase?: string;
+      useSsl?: boolean;
+    }) => {
+      setIsTesting(true);
+      void performTest(params);
+    },
+    [performTest]
   );
 
   // Auto-test connection on page load if service is configured
@@ -145,7 +165,7 @@ const ServicesProwlarr = () => {
       !isValidated &&
       !isTesting
     ) {
-      testConnection({
+      void performTest({
         hostname: dataProwlarr.hostname,
         port: dataProwlarr.port,
         apiKey: dataProwlarr.apiKey,
@@ -153,7 +173,7 @@ const ServicesProwlarr = () => {
         useSsl: dataProwlarr.useSsl,
       });
     }
-  }, [dataProwlarr, isTesting, isValidated, testConnection]);
+  }, [dataProwlarr, isTesting, isValidated, performTest]);
 
   const handleDisableAuth = async () => {
     if (!dataProwlarr || isDisablingAuth) return;

--- a/src/components/Admin/Settings/Services/Radarr/RadarrModal/index.tsx
+++ b/src/components/Admin/Settings/Services/Radarr/RadarrModal/index.tsx
@@ -32,7 +32,7 @@ const RadarrModal = ({ onClose, radarr, onSave, show }: RadarrModalProps) => {
   const intl = useIntl();
   const initialLoad = useRef(false);
   const [isValidated, setIsValidated] = useState(radarr ? true : false);
-  const [isTesting, setIsTesting] = useState(false);
+  const [isTesting, setIsTesting] = useState(() => Boolean(radarr));
   const [testResponse, setTestResponse] = useState<TestResponse>();
   const [authStatus, setAuthStatus] = useState<{
     authenticationMethod: string;
@@ -101,7 +101,7 @@ const RadarrModal = ({ onClose, radarr, onSave, show }: RadarrModalProps) => {
       ),
   });
 
-  const testConnection = useCallback(
+  const performTest = useCallback(
     async ({
       hostname,
       port,
@@ -115,56 +115,59 @@ const RadarrModal = ({ onClose, radarr, onSave, show }: RadarrModalProps) => {
       baseUrl?: string;
       useSsl?: boolean;
     }) => {
-      setIsTesting(true);
-      try {
-        const response = await axios.post<TestResponse>(
-          '/api/v1/settings/radarr/test',
-          {
-            hostname,
-            apiKey,
-            port: Number(port),
-            baseUrl,
-            useSsl,
-          }
+      const response = await axios
+        .post<TestResponse>('/api/v1/settings/radarr/test', {
+          hostname,
+          apiKey,
+          port: Number(port),
+          baseUrl,
+          useSsl,
+        })
+        .then(
+          (res) => res,
+          () => null
         );
 
-        setIsValidated(true);
-        setTestResponse(response.data);
-        // Fetch auth status after successful test
-        if (radarr) {
-          axios
-            .get(`/api/v1/settings/radarr/${radarr.id}/auth`)
-            .then((authRes) => setAuthStatus(authRes.data))
-            .catch(() => setAuthStatus(null));
-        }
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.testsuccess',
-                defaultMessage:
-                  '{service} connection established successfully!',
-              },
-              { service: 'Radarr' }
-            ),
-            type: 'success',
-            icon: <CheckBadgeIcon className="size-7" />,
-          });
-        }
-      } catch {
-        setIsValidated(false);
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.testfailed',
-                defaultMessage: 'Failed to connect to {service}.',
-              },
-              { service: 'Radarr' }
-            ),
-            type: 'error',
-            icon: <XCircleIcon className="size-7" />,
-          });
+      try {
+        if (response) {
+          setIsValidated(true);
+          setTestResponse(response.data);
+          // Fetch auth status after successful test
+          if (radarr) {
+            axios
+              .get(`/api/v1/settings/radarr/${radarr.id}/auth`)
+              .then((authRes) => setAuthStatus(authRes.data))
+              .catch(() => setAuthStatus(null));
+          }
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.testsuccess',
+                  defaultMessage:
+                    '{service} connection established successfully!',
+                },
+                { service: 'Radarr' }
+              ),
+              type: 'success',
+              icon: <CheckBadgeIcon className="size-7" />,
+            });
+          }
+        } else {
+          setIsValidated(false);
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.testfailed',
+                  defaultMessage: 'Failed to connect to {service}.',
+                },
+                { service: 'Radarr' }
+              ),
+              type: 'error',
+              icon: <XCircleIcon className="size-7" />,
+            });
+          }
         }
       } finally {
         setIsTesting(false);
@@ -174,9 +177,24 @@ const RadarrModal = ({ onClose, radarr, onSave, show }: RadarrModalProps) => {
     [intl, radarr]
   );
 
+  const testConnection = useCallback(
+    (params: {
+      hostname: string;
+      port: number;
+      apiKey: string;
+      baseUrl?: string;
+      useSsl?: boolean;
+    }) => {
+      setIsTesting(true);
+      void performTest(params);
+    },
+    [performTest]
+  );
+
+  // Auto-test the saved connection when editing an existing server
   useEffect(() => {
     if (radarr) {
-      testConnection({
+      void performTest({
         apiKey: radarr.apiKey,
         hostname: radarr.hostname,
         port: radarr.port,
@@ -184,17 +202,19 @@ const RadarrModal = ({ onClose, radarr, onSave, show }: RadarrModalProps) => {
         useSsl: radarr.useSsl,
       });
     }
-  }, [radarr, testConnection]);
+  }, [radarr, performTest]);
 
-  // Reset auth status and validation when modal closes
-  useEffect(() => {
+  // Reset auth status and validation when the modal closes
+  const [prevShow, setPrevShow] = useState(show);
+  if (prevShow !== show) {
+    setPrevShow(show);
     if (!show) {
       setAuthStatus(null);
       if (radarr) {
         setIsValidated(false);
       }
     }
-  }, [show, radarr]);
+  }
 
   // Fetch auth status when modal opens with existing radarr
   useEffect(() => {

--- a/src/components/Admin/Settings/Services/Sonarr/SonarrModal/index.tsx
+++ b/src/components/Admin/Settings/Services/Sonarr/SonarrModal/index.tsx
@@ -32,7 +32,7 @@ const SonarrModal = ({ onClose, sonarr, onSave, show }: SonarrModalProps) => {
   const intl = useIntl();
   const initialLoad = useRef(false);
   const [isValidated, setIsValidated] = useState(sonarr ? true : false);
-  const [isTesting, setIsTesting] = useState(false);
+  const [isTesting, setIsTesting] = useState(() => Boolean(sonarr));
   const [testResponse, setTestResponse] = useState<TestResponse>();
   const [authStatus, setAuthStatus] = useState<{
     authenticationMethod: string;
@@ -101,7 +101,7 @@ const SonarrModal = ({ onClose, sonarr, onSave, show }: SonarrModalProps) => {
       ),
   });
 
-  const testConnection = useCallback(
+  const performTest = useCallback(
     async ({
       hostname,
       port,
@@ -115,56 +115,59 @@ const SonarrModal = ({ onClose, sonarr, onSave, show }: SonarrModalProps) => {
       baseUrl?: string;
       useSsl?: boolean;
     }) => {
-      setIsTesting(true);
-      try {
-        const response = await axios.post<TestResponse>(
-          '/api/v1/settings/sonarr/test',
-          {
-            hostname,
-            apiKey,
-            port: Number(port),
-            baseUrl,
-            useSsl,
-          }
+      const response = await axios
+        .post<TestResponse>('/api/v1/settings/sonarr/test', {
+          hostname,
+          apiKey,
+          port: Number(port),
+          baseUrl,
+          useSsl,
+        })
+        .then(
+          (res) => res,
+          () => null
         );
 
-        setIsValidated(true);
-        setTestResponse(response.data);
-        // Fetch auth status after successful test
-        if (sonarr) {
-          axios
-            .get(`/api/v1/settings/sonarr/${sonarr.id}/auth`)
-            .then((authRes) => setAuthStatus(authRes.data))
-            .catch(() => setAuthStatus(null));
-        }
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.testsuccess',
-                defaultMessage:
-                  '{service} connection established successfully!',
-              },
-              { service: 'Sonarr' }
-            ),
-            type: 'success',
-            icon: <CheckBadgeIcon className="size-7" />,
-          });
-        }
-      } catch {
-        setIsValidated(false);
-        if (initialLoad.current) {
-          Toast({
-            title: intl.formatMessage(
-              {
-                id: 'servicesSettings.testfailed',
-                defaultMessage: 'Failed to connect to {service}.',
-              },
-              { service: 'Sonarr' }
-            ),
-            type: 'error',
-            icon: <XCircleIcon className="size-7" />,
-          });
+      try {
+        if (response) {
+          setIsValidated(true);
+          setTestResponse(response.data);
+          // Fetch auth status after successful test
+          if (sonarr) {
+            axios
+              .get(`/api/v1/settings/sonarr/${sonarr.id}/auth`)
+              .then((authRes) => setAuthStatus(authRes.data))
+              .catch(() => setAuthStatus(null));
+          }
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.testsuccess',
+                  defaultMessage:
+                    '{service} connection established successfully!',
+                },
+                { service: 'Sonarr' }
+              ),
+              type: 'success',
+              icon: <CheckBadgeIcon className="size-7" />,
+            });
+          }
+        } else {
+          setIsValidated(false);
+          if (initialLoad.current) {
+            Toast({
+              title: intl.formatMessage(
+                {
+                  id: 'servicesSettings.testfailed',
+                  defaultMessage: 'Failed to connect to {service}.',
+                },
+                { service: 'Sonarr' }
+              ),
+              type: 'error',
+              icon: <XCircleIcon className="size-7" />,
+            });
+          }
         }
       } finally {
         setIsTesting(false);
@@ -174,9 +177,23 @@ const SonarrModal = ({ onClose, sonarr, onSave, show }: SonarrModalProps) => {
     [intl, sonarr]
   );
 
+  const testConnection = useCallback(
+    (params: {
+      hostname: string;
+      port: number;
+      apiKey: string;
+      baseUrl?: string;
+      useSsl?: boolean;
+    }) => {
+      setIsTesting(true);
+      void performTest(params);
+    },
+    [performTest]
+  );
+
   useEffect(() => {
     if (sonarr) {
-      testConnection({
+      void performTest({
         apiKey: sonarr.apiKey,
         hostname: sonarr.hostname,
         port: sonarr.port,
@@ -184,17 +201,19 @@ const SonarrModal = ({ onClose, sonarr, onSave, show }: SonarrModalProps) => {
         useSsl: sonarr.useSsl,
       });
     }
-  }, [sonarr, testConnection]);
+  }, [sonarr, performTest]);
 
   // Reset auth status and validation when modal closes
-  useEffect(() => {
+  const [prevShow, setPrevShow] = useState(show);
+  if (prevShow !== show) {
+    setPrevShow(show);
     if (!show) {
       setAuthStatus(null);
       if (sonarr) {
         setIsValidated(false);
       }
     }
-  }, [show, sonarr]);
+  }
 
   // Fetch auth status when modal opens with existing sonarr
   useEffect(() => {

--- a/src/components/Admin/Users/BulkEditModal.tsx
+++ b/src/components/Admin/Users/BulkEditModal.tsx
@@ -69,23 +69,30 @@ const BulkEditModal = ({
     }
   };
 
-  useEffect(() => {
+  // Seed the editable permission from the selected users when the selection changes
+  const [prevUsers, setPrevUsers] = useState(users);
+  const [prevSelectedUserIds, setPrevSelectedUserIds] =
+    useState(selectedUserIds);
+  if (prevUsers !== users || prevSelectedUserIds !== selectedUserIds) {
+    setPrevUsers(users);
+    setPrevSelectedUserIds(selectedUserIds);
     if (users) {
       const selectedUsers = users.filter((u) => selectedUserIds.includes(u.id));
-      if (selectedUsers.length === 0) return;
-      const { permissions: allPermissionsEqual } = selectedUsers.reduce(
-        ({ permissions: aPerms }, { permissions: bPerms }) => {
-          return {
-            permissions: aPerms === bPerms ? aPerms : NaN,
-          };
-        },
-        { permissions: selectedUsers[0].permissions }
-      );
-      if (allPermissionsEqual) {
-        setCurrentPermission(allPermissionsEqual);
+      if (selectedUsers.length > 0) {
+        const { permissions: allPermissionsEqual } = selectedUsers.reduce(
+          ({ permissions: aPerms }, { permissions: bPerms }) => {
+            return {
+              permissions: aPerms === bPerms ? aPerms : NaN,
+            };
+          },
+          { permissions: selectedUsers[0].permissions }
+        );
+        if (allPermissionsEqual) {
+          setCurrentPermission(allPermissionsEqual);
+        }
       }
     }
-  }, [users, selectedUserIds]);
+  }
 
   return (
     <Modal

--- a/src/components/Admin/Users/index.tsx
+++ b/src/components/Admin/Users/index.tsx
@@ -43,6 +43,19 @@ import ToolTip from '@app/components/Common/ToolTip';
 
 type Sort = 'created' | 'updated' | 'invites' | 'displayname';
 
+const getStoredUserFilterSettings = (): {
+  currentSort?: Sort;
+  currentPageSize?: number;
+} => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const filterString = window.localStorage.getItem('ul-filter-settings');
+    return filterString ? JSON.parse(filterString) : {};
+  } catch {
+    return {};
+  }
+};
+
 const AdminUsers = () => {
   const intl = useIntl();
   const router = useRouter();
@@ -50,9 +63,12 @@ const AdminUsers = () => {
   const settings = useSettings();
   const searchParams = useSearchParams();
   const { user: currentUser, hasPermission: currentHasPermission } = useUser();
-  const [hasLoadedSettings, setHasLoadedSettings] = useState(false);
-  const [currentSort, setCurrentSort] = useState<Sort>('displayname');
-  const [currentPageSize, setCurrentPageSize] = useState<number>(10);
+  const [currentSort, setCurrentSort] = useState<Sort>(
+    () => getStoredUserFilterSettings().currentSort ?? 'displayname'
+  );
+  const [currentPageSize, setCurrentPageSize] = useState<number>(
+    () => getStoredUserFilterSettings().currentPageSize ?? 10
+  );
 
   const page = searchParams.get('page') ? Number(searchParams.get('page')) : 1;
   const pageIndex = page - 1;
@@ -94,19 +110,6 @@ const AdminUsers = () => {
   const [selectedUsers, setSelectedUsers] = useState<number[]>([]);
 
   useEffect(() => {
-    const filterString = window.localStorage.getItem('ul-filter-settings');
-
-    if (filterString) {
-      const filterSettings = JSON.parse(filterString);
-
-      setCurrentSort(filterSettings.currentSort);
-      setCurrentPageSize(filterSettings.currentPageSize);
-    }
-    setHasLoadedSettings(true);
-  }, []);
-
-  useEffect(() => {
-    if (!hasLoadedSettings) return;
     window.localStorage.setItem(
       'ul-filter-settings',
       JSON.stringify({
@@ -114,7 +117,7 @@ const AdminUsers = () => {
         currentPageSize,
       })
     );
-  }, [currentSort, currentPageSize, hasLoadedSettings]);
+  }, [currentSort, currentPageSize]);
 
   const isUserPermsEditable = (userId: number) =>
     userId !== 1 && userId !== currentUser?.id;

--- a/src/components/Common/Slider/index.tsx
+++ b/src/components/Common/Slider/index.tsx
@@ -49,11 +49,13 @@ const Slider = ({
     setScrollPos({ isStart, isEnd });
   }, [items]);
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedScroll = useCallback(
-    debounce(() => handleScroll(), 50),
-    [handleScroll]
-  );
+  const debouncedScrollRef = useRef<ReturnType<typeof debounce> | null>(null);
+  useEffect(() => {
+    const debounced = debounce(() => handleScroll(), 50);
+    debouncedScrollRef.current = debounced;
+    return () => debounced.cancel();
+  }, [handleScroll]);
+  const debouncedScroll = useCallback(() => debouncedScrollRef.current?.(), []);
 
   useEffect(() => {
     const handleResize = () => {

--- a/src/components/Common/UserSelector/index.tsx
+++ b/src/components/Common/UserSelector/index.tsx
@@ -90,11 +90,13 @@ const UserSelector = ({
   const [listboxOpen, setListboxOpen] = useState(false);
   const [dropdownMeasured, setDropdownMeasured] = useState(false);
 
-  useEffect(() => {
+  const [prevListboxOpen, setPrevListboxOpen] = useState(listboxOpen);
+  if (prevListboxOpen !== listboxOpen) {
+    setPrevListboxOpen(listboxOpen);
     if (listboxOpen) {
       setDropdownMeasured(false);
     }
-  }, [listboxOpen]);
+  }
 
   useEffect(() => {
     function updateDropdownPosition() {

--- a/src/components/InviteList/InviteModal/index.tsx
+++ b/src/components/InviteList/InviteModal/index.tsx
@@ -110,13 +110,13 @@ const InviteModal = ({
       ),
   });
 
-  useEffect(() => {
-    if (filteredUserData && !user) {
-      setSelectedUser(
-        filteredUserData?.find((u) => u.id === currentUser?.id) ?? null
-      );
-    }
-  }, [currentUser?.id, filteredUserData, user]);
+  const [hasDefaultedUser, setHasDefaultedUser] = useState(false);
+  if (!hasDefaultedUser && filteredUserData && !user) {
+    setHasDefaultedUser(true);
+    setSelectedUser(
+      filteredUserData.find((u) => u.id === currentUser?.id) ?? null
+    );
+  }
 
   const buttonRef = useRef(null);
   const optionsRef = useRef(null);
@@ -129,11 +129,13 @@ const InviteModal = ({
   const [listboxOpen, setListboxOpen] = useState(false);
   const [dropdownMeasured, setDropdownMeasured] = useState(false);
 
-  useEffect(() => {
+  const [prevListboxOpen, setPrevListboxOpen] = useState(listboxOpen);
+  if (prevListboxOpen !== listboxOpen) {
+    setPrevListboxOpen(listboxOpen);
     if (listboxOpen) {
       setDropdownMeasured(false);
     }
-  }, [listboxOpen]);
+  }
 
   useEffect(() => {
     function updateDropdownPosition() {

--- a/src/components/InviteList/index.tsx
+++ b/src/components/InviteList/index.tsx
@@ -189,19 +189,23 @@ const InviteList = () => {
     }
   };
 
-  // Override with query params if provided
-  useEffect(() => {
-    if (Object.values(Filter).includes(searchParams.get('filter') as Filter)) {
-      setCurrentFilter(searchParams.get('filter') as Filter);
+  // Override with query params if provided, keeping in sync as the URL changes
+  const queryFilter = searchParams.get('filter') as Filter;
+  const querySort = searchParams.get('sort') as Sort;
+  const [prevQueryFilter, setPrevQueryFilter] = useState(queryFilter);
+  const [prevQuerySort, setPrevQuerySort] = useState(querySort);
+  if (prevQueryFilter !== queryFilter) {
+    setPrevQueryFilter(queryFilter);
+    if (Object.values(Filter).includes(queryFilter)) {
+      setCurrentFilter(queryFilter);
     }
-    if (
-      Object.values(['created', 'modified']).includes(
-        searchParams.get('sort') as Sort
-      )
-    ) {
-      setCurrentSort(searchParams.get('sort') as Sort);
+  }
+  if (prevQuerySort !== querySort) {
+    setPrevQuerySort(querySort);
+    if (['created', 'modified'].includes(querySort)) {
+      setCurrentSort(querySort);
     }
-  }, [searchParams]);
+  }
 
   // Set filter values to local storage any time they are changed
   useEffect(() => {

--- a/src/components/Layout/Notifications/index.tsx
+++ b/src/components/Layout/Notifications/index.tsx
@@ -11,7 +11,7 @@ import {
   QueueListIcon,
   TrashIcon,
 } from '@heroicons/react/24/solid';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import useSWR, { useSWRConfig } from 'swr';
 import type { NotificationResultsResponse } from '@server/interfaces/api/notificationInterfaces';
 import { useUser } from '@app/hooks/useUser';
@@ -153,13 +153,15 @@ const Notifications = () => {
     }
   };
 
-  useEffect(() => {
+  const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+  if (prevIsOpen !== isOpen) {
+    setPrevIsOpen(isOpen);
     if (!isOpen) {
       setFilter('all');
       setNewPageSize(5);
       setEarlierPageSize(5);
     }
-  }, [isOpen]);
+  }
 
   const unreadNotifications = useMemo(
     () => data?.results.filter((notification) => !notification.isRead) ?? [],

--- a/src/components/NotificationList/index.tsx
+++ b/src/components/NotificationList/index.tsx
@@ -30,6 +30,20 @@ enum Filter {
   UNREAD = 'unread',
 }
 
+const getStoredNotificationFilterSettings = (): {
+  currentFilter?: Filter;
+  currentPageSize?: number;
+} => {
+  if (typeof window === 'undefined') return {};
+  try {
+    const filterString = window.localStorage.getItem('nl-filter-settings');
+    return filterString ? JSON.parse(filterString) : {};
+  } catch {
+    window.localStorage.removeItem('nl-filter-settings');
+    return {};
+  }
+};
+
 const NotificationsList = () => {
   const router = useRouter();
   const pathname = usePathname();
@@ -46,8 +60,14 @@ const NotificationsList = () => {
         : null
     );
   const intl = useIntl();
-  const [currentFilter, setCurrentFilter] = useState<Filter>(Filter.ALL);
-  const [currentPageSize, setCurrentPageSize] = useState<number>(10);
+  const [currentFilter, setCurrentFilter] = useState<Filter>(() => {
+    const queryFilter = searchParams.get('filter') as Filter;
+    if (Object.values(Filter).includes(queryFilter)) return queryFilter;
+    return getStoredNotificationFilterSettings().currentFilter ?? Filter.ALL;
+  });
+  const [currentPageSize, setCurrentPageSize] = useState<number>(
+    () => getStoredNotificationFilterSettings().currentPageSize ?? 10
+  );
 
   const page = searchParams.get('page') ? Number(searchParams.get('page')) : 1;
   const pageIndex = page - 1;
@@ -85,25 +105,15 @@ const NotificationsList = () => {
 
   useNotifications();
 
-  // Restore last set filter values on component mount
-  useEffect(() => {
-    const filterString = window.localStorage.getItem('nl-filter-settings');
-
-    if (filterString) {
-      try {
-        const filterSettings = JSON.parse(filterString);
-        setCurrentFilter(filterSettings.currentFilter);
-        setCurrentPageSize(filterSettings.currentPageSize);
-      } catch {
-        window.localStorage.removeItem('nl-filter-settings');
-      }
+  // Keep the filter in sync with the URL query param when it changes
+  const queryFilter = searchParams.get('filter') as Filter;
+  const [prevQueryFilter, setPrevQueryFilter] = useState(queryFilter);
+  if (prevQueryFilter !== queryFilter) {
+    setPrevQueryFilter(queryFilter);
+    if (Object.values(Filter).includes(queryFilter)) {
+      setCurrentFilter(queryFilter);
     }
-
-    // If filter value is provided in query, use that instead
-    if (Object.values(Filter).includes(searchParams.get('filter') as Filter)) {
-      setCurrentFilter(searchParams.get('filter') as Filter);
-    }
-  }, [searchParams]);
+  }
 
   // Set filter values to local storage any time they are changed
   useEffect(() => {

--- a/src/components/TutorialSpotlight/TutorialTooltip.tsx
+++ b/src/components/TutorialSpotlight/TutorialTooltip.tsx
@@ -220,7 +220,9 @@ const TutorialTooltip: React.FC<TutorialTooltipProps> = ({
   }, [targetRect, step.tooltipPosition, isMobile]);
 
   // Keep ref in sync with latest calculatePosition
-  calculatePositionRef.current = calculatePosition;
+  useEffect(() => {
+    calculatePositionRef.current = calculatePosition;
+  }, [calculatePosition]);
 
   // Recalculate position when targetRect, step, or layout changes
   useEffect(() => {

--- a/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
@@ -16,7 +16,7 @@ import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import type { UserSettingsGeneralResponse } from '@server/interfaces/api/userSettingsInterfaces';
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import useSWR from 'swr';
 import Toast, { dismissToast } from '@app/components/Toast';
@@ -44,10 +44,6 @@ const UserSettingsGeneral = () => {
   const [inviteQuotaEnabled, setInviteQuotaEnabled] = useState(false);
   const [isPinning, setIsPinning] = useState(false);
   const [isRequestingExtension, setIsRequestingExtension] = useState(false);
-  const [plexLibrariesDiffer, setPlexLibrariesDiffer] = useState(false);
-  const [plexPermissionsDiffer, setPlexPermissionsDiffer] = useState<{
-    allowDownloads: boolean;
-  }>({ allowDownloads: false });
   const searchParams = useParams<{ userid: string }>();
   const {
     user,
@@ -92,25 +88,31 @@ const UserSettingsGeneral = () => {
     revalidateOnFocus: false,
   });
 
-  useEffect(() => {
-    setInviteQuotaEnabled(
-      data?.inviteQuotaLimit != undefined && data?.inviteQuotaDays != undefined
-    );
-  }, [data]);
+  // Reset the editable invite-quota toggle whenever the loaded user data changes
+  const derivedInviteQuotaEnabled =
+    data?.inviteQuotaLimit != undefined && data?.inviteQuotaDays != undefined;
+  const [prevQuotaData, setPrevQuotaData] = useState(data);
+  if (prevQuotaData !== data) {
+    setPrevQuotaData(data);
+    setInviteQuotaEnabled(derivedInviteQuotaEnabled);
+  }
 
   // Compare database library/permission values with current Plex state
-  useEffect(() => {
+  const { plexLibrariesDiffer, plexPermissionsDiffer } = useMemo<{
+    plexLibrariesDiffer: boolean;
+    plexPermissionsDiffer: { allowDownloads: boolean };
+  }>(() => {
     if (!data || !plexLibrariesData?.canFetchFromPlex) {
-      setPlexLibrariesDiffer(false);
-      setPlexPermissionsDiffer({ allowDownloads: false });
-      return;
+      return {
+        plexLibrariesDiffer: false,
+        plexPermissionsDiffer: { allowDownloads: false },
+      };
     }
 
     // === Library comparison ===
+    let librariesDiffer = false;
     const plexLibraries = plexLibrariesData.currentPlexLibraries;
-    if (plexLibraries === null) {
-      setPlexLibrariesDiffer(false);
-    } else {
+    if (plexLibraries !== null) {
       // Resolve DB value - if 'server'/null/empty, use global default
       const dbValue =
         !data.sharedLibraries || data.sharedLibraries === 'server'
@@ -138,18 +140,22 @@ const UserSettingsGeneral = () => {
 
       const normalizedDb = normalizeValue(dbValue);
       const normalizedPlex = normalizeValue(plexValue);
-      setPlexLibrariesDiffer(normalizedDb !== normalizedPlex);
+      librariesDiffer = normalizedDb !== normalizedPlex;
     }
 
     // === Permission comparison ===
     const plexPerms = plexLibrariesData.permissions;
-    if (!plexPerms) {
-      setPlexPermissionsDiffer({ allowDownloads: false });
-    } else {
-      setPlexPermissionsDiffer({
-        allowDownloads: (data.allowDownloads ?? false) !== plexPerms.allowSync,
-      });
-    }
+    const permissionsDiffer = !plexPerms
+      ? { allowDownloads: false }
+      : {
+          allowDownloads:
+            (data.allowDownloads ?? false) !== plexPerms.allowSync,
+        };
+
+    return {
+      plexLibrariesDiffer: librariesDiffer,
+      plexPermissionsDiffer: permissionsDiffer,
+    };
   }, [data, plexLibrariesData, allLibrariesData]);
 
   if (!data && !error) {

--- a/src/components/Watch/index.tsx
+++ b/src/components/Watch/index.tsx
@@ -5,6 +5,7 @@ import {
   ServiceNotConfigured,
 } from '@app/components/Common/ServiceError';
 import { useServiceProxy } from '@app/hooks/useServiceProxy';
+import { useClientValue } from '@app/hooks/useIsClient';
 import useSettings from '@app/hooks/useSettings';
 import { useUser, Permission } from '@app/hooks/useUser';
 import { setIframeTheme, parseColorToHex } from '@app/utils/themeUtils';
@@ -40,7 +41,10 @@ const Watch = ({ children, ...props }) => {
     innerFrame = null;
   }
 
-  const [hostname, setHostname] = useState('');
+  const hostname = useClientValue(
+    () => `${window.location.protocol}//${window.location.host}`,
+    ''
+  );
   const [iframeUrl, setIframeUrl] = useState('');
   const { currentSettings } = useSettings();
 
@@ -51,10 +55,10 @@ const Watch = ({ children, ...props }) => {
 
   // Track the parent window's location for the iframe src
   useEffect(() => {
-    let lastParentUrl =
-      window.location.pathname + window.location.search + window.location.hash;
+    // Start empty so the first interval tick seeds iframeUrl from the current
+    // location instead of calling setState synchronously inside the effect.
+    let lastParentUrl = '';
     let lastIframeUrl = '';
-    setIframeUrl(lastParentUrl.replace('/watch', ''));
     const interval = setInterval(() => {
       let parentUrl =
         window.location.pathname +
@@ -248,23 +252,6 @@ const Watch = ({ children, ...props }) => {
       setIframeTheme(innerFrame, currentSettings.theme);
     }
   }, [mountNode, currentSettings.theme, innerFrame]);
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setHostname(`${window?.location?.protocol}//${window?.location?.host}`);
-    }
-  }, [setHostname]);
-
-  useEffect(() => {
-    if (
-      contentRef &&
-      contentRef.src !==
-        `${hostname}${iframeUrl && iframeUrl.replace('null', '')}`
-    ) {
-      contentRef.src = `${hostname}${iframeUrl && iframeUrl.replace('null', '')}`;
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [iframeUrl, hostname]);
 
   if (proxyStatus === 'loading') {
     return <LoadingEllipsis fixed />;

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -55,19 +55,25 @@ export const LanguageProvider: React.FC<LanguageProviderProps> = ({
   children,
   initialLocale = 'en',
 }) => {
-  const [locale, setLocaleState] = useState<AvailableLocale>(initialLocale);
+  const [locale, setLocaleState] = useState<AvailableLocale>(() => {
+    if (typeof window !== 'undefined') {
+      const savedLocale = localStorage.getItem(
+        'streamarr-locale'
+      ) as AvailableLocale;
+      if (savedLocale && availableLanguages[savedLocale]) {
+        return savedLocale;
+      }
+    }
+    return initialLocale;
+  });
   const [messages, setMessages] = useState<Record<string, string>>({});
   const [isLoading, setIsLoading] = useState(true);
 
   // Load messages for the current locale
   const loadMessages = useCallback(async (newLocale: AvailableLocale) => {
-    setIsLoading(true);
+    const localeMessages = await loadLocaleMessages(newLocale);
     try {
-      const localeMessages = await loadLocaleMessages(newLocale);
       setMessages(localeMessages);
-    } catch (error) {
-      console.error('Failed to load locale messages:', error);
-      setMessages({});
     } finally {
       setIsLoading(false);
     }
@@ -75,7 +81,7 @@ export const LanguageProvider: React.FC<LanguageProviderProps> = ({
 
   // Initialize messages and moment locale on mount
   useEffect(() => {
-    loadMessages(locale);
+    void loadMessages(locale);
     // Synchronize moment.js locale with current locale
     setMomentLocale(locale);
   }, [loadMessages, locale]);
@@ -84,30 +90,18 @@ export const LanguageProvider: React.FC<LanguageProviderProps> = ({
   const setLocale = useCallback(
     (newLocale: AvailableLocale) => {
       if (newLocale !== locale) {
+        setIsLoading(true);
         setLocaleState(newLocale);
         // Persist locale preference
         if (typeof window !== 'undefined') {
           localStorage.setItem('streamarr-locale', newLocale);
         }
-        loadMessages(newLocale);
         // Synchronize moment.js locale with new locale
         setMomentLocale(newLocale);
       }
     },
-    [locale, loadMessages]
+    [locale]
   );
-
-  // Load saved locale on client-side
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const savedLocale = localStorage.getItem(
-        'streamarr-locale'
-      ) as AvailableLocale;
-      if (savedLocale && availableLanguages[savedLocale]) {
-        setLocale(savedLocale);
-      }
-    }
-  }, [setLocale]);
 
   const contextValue: LanguageContextProps = { locale, setLocale };
 

--- a/src/context/OnboardingContext.tsx
+++ b/src/context/OnboardingContext.tsx
@@ -152,20 +152,16 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
     adminPhase,
   ]);
 
-  useEffect(() => {
-    if (isSetupRoute) return;
-    if (isSignupRoute) return;
-    if (adminOnboardingJustCompleted) return;
-    if (isAdminOnboarding && adminPhase === 'idle') {
-      setAdminPhase('welcome');
-    }
-  }, [
-    isAdminOnboarding,
-    adminPhase,
-    isSetupRoute,
-    isSignupRoute,
-    adminOnboardingJustCompleted,
-  ]);
+  // Begin the admin welcome phase once admin onboarding starts
+  if (
+    !isSetupRoute &&
+    !isSignupRoute &&
+    !adminOnboardingJustCompleted &&
+    isAdminOnboarding &&
+    adminPhase === 'idle'
+  ) {
+    setAdminPhase('welcome');
+  }
 
   const finalizeAdminOnboarding = useCallback(async () => {
     setAdminOnboardingJustCompleted(true);
@@ -182,7 +178,7 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
     } catch {
       // Silently fail - UI state already updated
     }
-  }, [mutate, user?.id, resetTutorialState]);
+  }, [mutate, user, resetTutorialState]);
 
   const completeAdminTutorial = finalizeAdminOnboarding;
 
@@ -202,9 +198,13 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
     );
   }, [data, loading, error, user, shouldBlockUserOnboarding]);
 
-  useEffect(() => {
+  const [prevShouldWelcomeOpen, setPrevShouldWelcomeOpen] = useState(
+    shouldwelcomeOpenModal
+  );
+  if (prevShouldWelcomeOpen !== shouldwelcomeOpenModal) {
+    setPrevShouldWelcomeOpen(shouldwelcomeOpenModal);
     setWelcomeOpen(shouldwelcomeOpenModal);
-  }, [shouldwelcomeOpenModal]);
+  }
 
   // After welcome completes (or is disabled), check if tutorial should show
   useEffect(() => {
@@ -270,7 +270,7 @@ export const OnboardingProvider: React.FC<OnboardingProviderProps> = ({
     } catch {
       // Silently fail - UI state already handles this
     }
-  }, [isPreviewMode, showAdminWelcome, user?.id, mutate]);
+  }, [isPreviewMode, showAdminWelcome, user, mutate]);
 
   const startTutorial = useCallback(() => {
     setTutorialActive(true);

--- a/src/hooks/useIsClient.ts
+++ b/src/hooks/useIsClient.ts
@@ -1,0 +1,24 @@
+import { useSyncExternalStore } from 'react';
+
+const emptySubscribe = () => () => {};
+
+/**
+ * Returns `false` during SSR and the first client render, then `true` once
+ * hydration has completed. Use this to gate browser-only UI without triggering
+ * a synchronous setState inside an effect (which causes a cascading render).
+ */
+export const useIsClient = (): boolean =>
+  useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
+
+/**
+ * Reads a value that is only available in the browser (e.g. from `window`)
+ * while remaining hydration-safe: `serverValue` is used during SSR and the
+ * first client render, after which `getSnapshot` is used. Unlike a
+ * useState/useEffect pair this does not setState synchronously in an effect.
+ */
+export const useClientValue = <T>(getSnapshot: () => T, serverValue: T): T =>
+  useSyncExternalStore(emptySubscribe, getSnapshot, () => serverValue);


### PR DESCRIPTION
## Description
eslint-plugin-react-hooks 7.1.x promotes the React Compiler ruleset (set-state-in-effect, preserve-manual-memoization, refs) to errors in the recommended config, surfacing 39 violations across the client.

Refactor each to the idiomatic pattern instead of suppressing:
- Service connection tests (Radarr/Sonarr/Prowlarr/Lidarr/Downloads) split into an await-first performTest core (state set inside try/finally, never synchronously in the effect path) plus a thin event-context wrapper for buttons.
- Reset/sync-on-prop-change effects converted to derive-during-render with a previous-value guard.
- Purely derived state (hsl, select-all, plex diff flags, etc.) converted to useMemo.
- Client-only reads moved to useSyncExternalStore via a new useIsClient/useClientValue hook; mount-once reads use lazy useState initializers.
- Debounced scroll handler created in an effect and exposed through a stable ref to satisfy react-hooks/refs.
- Manual useCallback dependency lists aligned with the compiler's inferred dependencies.

No behavioral changes intended; eslint and tsc both pass clean.

## Has This Been Tested?

Yes, confirmed working dev and prod runs seamlesly. 

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
