### PR TITLE
docs: update pnpm version references to v11

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -115,7 +115,7 @@ A separate, lightweight migration system for JSON settings (not TypeORM). Files 
 - **Python service (port 5005)**: Internal-only; must not be exposed externally. The Node server communicates with it over `localhost:5005` with no auth token (loopback-only trust). Do not add public-facing routes that proxy directly to port 5005.
 - **Session store**: TypeORM-backed sessions (`Session` entity via `connect-typeorm`). Cleared on server restart in development — expect re-login after restart.
 - **Server-side i18n**: `server/i18n/index.ts` provides translation helpers for notification emails and subscribers. Locale files live at `server/i18n/locale/<lang>.json`. Extract with `pnpm i18n:extract:server`. The build step copies these to `dist/i18n/locale/`.
-- **Docker runtime**: Uses `node:26-alpine`. `engines` in `package.json` requires `node >=24.0.0` and `pnpm ^10.0.0`.
+- **Docker runtime**: Uses `node:26-alpine`. `engines` in `package.json` requires `node >=24.0.0` and `pnpm ^11.0.0`.
 
 ## External Integrations
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ By participating in this project, you agree to abide by our [Code of Conduct](CO
 ### Prerequisites
 
 - [Node.js](https://nodejs.org/) **v24 or higher** (required by `engines` in `package.json`; the official Docker images build on Node 26)
-- [pnpm](https://pnpm.io/) **v10** (the repo pins a specific version via the `packageManager` field — enable it with `corepack enable`)
+- [pnpm](https://pnpm.io/) **v11** (the repo pins a specific version via the `packageManager` field — enable it with `corepack enable`)
 - [Python 3](https://www.python.org/) (for the Plex invite service)
 - [Git](https://git-scm.com/)
 


### PR DESCRIPTION
## Description
Follow-up to the pnpm-workspace.yaml migration, which bumped packageManager and engines.pnpm to 11. Update the prerequisite in CONTRIBUTING.md and the engines note in the Copilot instructions so the documented minimum matches package.json.

## Has This Been Tested?

Docs only.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
