### PR TITLE
fix(theme): normalize tailwind color presets to hex for the color picker

### DIFF
--- a/src/utils/themeUtils.ts
+++ b/src/utils/themeUtils.ts
@@ -22,19 +22,30 @@ export const getAllTailwindColors = (): string[] => {
     'white',
   ];
 
+  // Tailwind v4 exposes its palette as oklch() strings, but the color picker
+  // (react-colorful / colord) operates on hex, so normalize every preset to a
+  // hex value here and drop anything that cannot be parsed.
+  const addColor = (value: string) => {
+    const hex = parseColorToHex(value);
+    if (hex) {
+      allColors.push(hex);
+    }
+  };
+
   Object.entries(colors).forEach(([colorName, colorShades]) => {
     if (excludeColors.includes(colorName)) return;
     if (typeof colorShades === 'object' && colorShades !== null) {
       Object.values(colorShades).forEach((shade) => {
         if (typeof shade === 'string') {
-          allColors.push(shade);
+          addColor(shade);
         }
       });
     }
   });
 
   // Add black and white separately
-  allColors.push(colors.black, colors.white);
+  addColor(colors.black);
+  addColor(colors.white);
 
   return allColors;
 };


### PR DESCRIPTION
## Description
Tailwind CSS v4 exposes its default palette (`tailwindcss/colors`) as oklch() strings rather than hex. getAllTailwindColors() passed those strings straight through to the color picker's preset swatches, and selecting a preset called setColor() with an oklch value. colord cannot parse oklch, so color resolved to rgb(0,0,0): the picker, the formatted value field and the hex-based react-colorful control all collapsed to black/zero the moment a palette colour was chosen. The modal only looked correct on first open because the stored theme value is hex.

Route every preset through parseColorToHex() (which already handles oklch) so the palette returns hex values, dropping anything unparseable. No picker logic changes; presets now round-trip through colord normally.

## Has This Been Tested?

Tested colorPicker functionality.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
