### PR TITLE
fix(mobilemenu): track active route via router, not window.location

### DIFF
--- a/src/components/Layout/MobileMenu/index.tsx
+++ b/src/components/Layout/MobileMenu/index.tsx
@@ -26,8 +26,10 @@ import {
 import Image from 'next/image';
 import Link from 'next/link';
 import type { JSX } from 'react';
-import { cloneElement, useEffect, useRef, useState } from 'react';
+import { cloneElement, useRef, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import { usePathname } from 'next/navigation';
+import useHash from '@app/hooks/useHash';
 import useSWR from 'swr';
 import type { UserSettingsGeneralResponse } from '@server/interfaces/api/userSettingsInterfaces';
 
@@ -52,23 +54,10 @@ const MobileMenu = () => {
   const ref = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [menuType, setMenuType] = useState<string | null>(null);
-  const [currentUrl, setCurrentUrl] = useState(() =>
-    typeof window !== 'undefined'
-      ? window.location.pathname + window.location.hash
-      : ''
-  );
-  useEffect(() => {
-    let lastUrl = window.location.pathname + window.location.hash;
-    const interval = setInterval(() => {
-      const newUrl = window.location.pathname + window.location.hash;
-      if (newUrl !== lastUrl) {
-        lastUrl = newUrl;
-        setCurrentUrl(newUrl);
-      }
-    }, 100);
-    return () => clearInterval(interval);
-  }, []);
-  const url = currentUrl;
+  const pathname = usePathname();
+  const hash = useHash();
+  const url = pathname + (hash || '');
+
   useClickOutside(ref, () => {
     setTimeout(() => {
       if (isOpen) {


### PR DESCRIPTION
## Description
The mobile menu derived the current route from a window.location snapshot plus a 100ms polling loop. The Home/Watch route embeds the Plex web app in an iframe and rewrites the parent URL via history.replaceState to keep them in sync. On the first navigation off a proxy/watch route, the freshly mounted menu captured a stale/contended location for both its initial value and its
polling baseline, so the active item lagged until the next non-proxy navigation.

Source the route reactively from usePathname() + useHash() — the same mechanism the Sidebar already uses — so the active item updates on the route change and no longer depends on the contended window.location.

- Fixes #393  

## Has This Been Tested?

Tested both in iframe deep linking and external links for correct routing and active class application.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
