### PR TITLE
fix(users): handle users removed from Plex out-of-band

### DIFF
--- a/docs/using-streamarr/notifications/README.md
+++ b/docs/using-streamarr/notifications/README.md
@@ -29,18 +29,20 @@ Streamarr groups notification agents into two delivery models:
 
 Streamarr can send notifications for the following events:
 
-| Event                 | Description                                |
-| --------------------- | ------------------------------------------ |
-| **Test Notification** | Test message to verify agent configuration |
-| **Invite Redeemed**   | When an invite code is used                |
-| **Invite Expired**    | When an invite expires                     |
-| **User Created**      | When a new user account is created         |
-| **Local Message**     | Custom messages sent by admins             |
-| **New Event**         | Calendar event reminders                   |
-| **System**            | System alerts and warnings                 |
-| **Updates**           | Application update notifications           |
-| **Friend Watching**   | When a friend starts watching content      |
-| **New Invite**        | When a new invite is created               |
+| Event                          | Description                                                                                |
+| ------------------------------ | ------------------------------------------------------------------------------------------ |
+| **Test Notification**          | Test message to verify agent configuration                                                 |
+| **Invite Redeemed**            | When an invite code is used                                                                |
+| **Invite Expired**             | When an invite expires                                                                     |
+| **User Created**               | When a new user account is created                                                         |
+| **Local Message**              | Custom messages sent by admins                                                             |
+| **New Event**                  | Calendar event reminders                                                                   |
+| **System**                     | System alerts and warnings                                                                 |
+| **Updates**                    | Application update notifications                                                           |
+| **Friend Watching**            | When a friend starts watching content                                                      |
+| **New Invite**                 | When a new invite is created                                                               |
+| **Access Extension Requested** | When a user requests an access extension (admins only)                                     |
+| **Plex Access Removed**        | When a user is removed from the Plex server and their account is deactivated (admins only) |
 
 ---
 

--- a/docs/using-streamarr/settings/README.md
+++ b/docs/using-streamarr/settings/README.md
@@ -539,19 +539,22 @@ Streamarr performs maintenance tasks as scheduled jobs. You can also run them on
 
 ### Scheduled Jobs
 
-| Job                          | Default Schedule  | Description                                                                           |
-| ---------------------------- | ----------------- | ------------------------------------------------------------------------------------- |
-| **Plex Full Library Scan**   | Daily at 3:00 AM  | Full sync of Plex library metadata                                                    |
-| **Plex Refresh Token**       | Daily at 5:00 AM  | Refresh admin Plex token                                                              |
-| **Image Cache Cleanup**      | Daily at 5:00 AM  | Clean stale cached images                                                             |
-| **Invite & QR Code Cleanup** | Daily at 1:00 AM  | Mark expired invites and clean QR codes                                               |
-| **Notification Cleanup**     | Daily at 1:30 AM  | Clean old notifications                                                               |
-| **Account Expiry Check**     | Daily at 12:00 AM | Check for expired trials and account access, and process trial outcomes / expirations |
+| Job                          | Default Schedule  | Description                                                                                                                                   |
+| ---------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Plex Full Library Scan**   | Daily at 3:00 AM  | Full sync of Plex library metadata                                                                                                            |
+| **Plex Refresh Token**       | Daily at 5:00 AM  | Refresh admin Plex token                                                                                                                      |
+| **Image Cache Cleanup**      | Daily at 5:00 AM  | Clean stale cached images                                                                                                                     |
+| **Invite & QR Code Cleanup** | Daily at 1:00 AM  | Mark expired invites and clean QR codes                                                                                                       |
+| **Notification Cleanup**     | Daily at 1:30 AM  | Clean old notifications                                                                                                                       |
+| **Account Expiry Check**     | Daily at 12:00 AM | Check for expired trials and account access, and process trial outcomes / expirations                                                         |
+| **Plex Membership Check**    | Every 15 minutes  | Validate that active Plex users still exist in the Plex server's shared list; users removed from Plex are deactivated and admins are notified |
 
 Each job row shows the job name, a type badge, the next scheduled execution time, and the available actions.
 
 {% hint style="info" %}
 The **Account Expiry Check** job underpins the [Trial Period](README.md#trial-period) feature—it evaluates trial end dates and account access windows each day. See [Trial Outcome & Extension Requests](README.md#trial-outcome--extension-requests).
+
+The **Plex Membership Check** job detects users who have been removed from the Plex server outside of Streamarr. It uses a single plex.tv API call per run regardless of user count, and only acts on a definitive removal—API outages never deactivate anyone. See [Removed from Plex](../users/README.md#removed-from-plex).
 {% endhint %}
 
 ### Job Status

--- a/docs/using-streamarr/users/README.md
+++ b/docs/using-streamarr/users/README.md
@@ -164,6 +164,20 @@ Users with **Manage Users** or **Manage Invites** permissions bypass trial restr
 
 ---
 
+## Removed from Plex
+
+If a user is removed from the Plex server's shared list outside of Streamarr (e.g. directly in the Plex app), Streamarr detects it automatically—when an admin views their profile or settings, when the user attempts to sign in, or via the [Plex Membership Check](../settings/README.md#scheduled-jobs) job—and deactivates the account. Any pending trial period is cleared, Seerr permissions are revoked, and admins with **Manage Users** permission receive a **Plex Access Removed** notification.
+
+Removed users are shown as **Deactivated** (distinct from **Expired**, which indicates a lapsed trial) in the user list and on their profile. Like expired users, they can still sign in to view their profile and settings, and may submit an access extension request.
+
+To restore access, open the user's settings and click **Reinvite**. This sends a new Plex invite using the user's existing shared libraries, download, and Plex Home settings, and reactivates the account. If the invite cannot be sent, the user remains deactivated and the error is shown—simply retry once Plex is reachable. Previously connected accounts are typically auto-accepted by Plex; otherwise the user must accept the invite from their Plex account.
+
+{% hint style="info" %}
+Detection only occurs on a confirmed removal from the shared users list. Temporary plex.tv outages or token issues never deactivate users.
+{% endhint %}
+
+---
+
 ## Password Reset
 
 Users can reset their password by:
@@ -219,7 +233,7 @@ Shown when sign-up is enabled **or** the user has sent or received invites:
 
 #### Trial Period
 
-When a trial period is active for the user, a dedicated card replaces the invite quota card showing the trial end date.
+When a trial period is active for the user, a dedicated card replaces the invite quota card showing the trial end date. If the account is deactivated—whether from a lapsed trial (**Account Expired**) or removal from Plex (**Account Deactivated**)—a status card is shown instead, with guidance for the user or admin.
 
 #### Seerr Request Quota
 

--- a/server/constants/notification.ts
+++ b/server/constants/notification.ts
@@ -9,6 +9,7 @@ export enum NotificationType {
   // 2048, 4096, 8192 reserved (previously SYSTEM / UPDATES / FRIEND_WATCHING — unused)
   NEW_INVITE = 16384,
   ACCESS_EXTENSION_REQUESTED = 32768,
+  PLEX_ACCESS_LOST = 65536,
 }
 
 export enum NotificationSeverity {

--- a/server/constants/user.ts
+++ b/server/constants/user.ts
@@ -2,3 +2,5 @@ export enum UserType {
   PLEX = 1,
   LOCAL = 2,
 }
+
+export type AccessRevokedReason = 'trial_expired' | 'plex_removed';

--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -1,4 +1,5 @@
 import { UserType } from '@server/constants/user';
+import type { AccessRevokedReason } from '@server/constants/user';
 import { getRepository } from '@server/datasource';
 import PreparedEmail from '@server/lib/email';
 import type { PermissionCheckOptions } from '@server/lib/permissions';
@@ -92,6 +93,9 @@ export class User {
 
   @Column({ type: 'datetime', nullable: true })
   public accessRevokedAt?: Date | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  public accessRevokedReason?: AccessRevokedReason | null;
 
   @Column('text')
   public avatar: string;

--- a/server/i18n/locale/en.json
+++ b/server/i18n/locale/en.json
@@ -6,11 +6,13 @@
   "notifications.invite.new.subject": "New Invite: {icode}",
   "notifications.invite.redeemed.message": "Your invite has been redeemed by {displayName}.",
   "notifications.invite.redeemed.subject": "Invite Redeemed: {icode}",
+  "notifications.plexAccessLost.message": "This user was removed from the Plex server and their account has been deactivated.",
+  "notifications.plexAccessLost.subject": "Plex Access Removed: {displayName}",
   "notifications.test.failed": "Failed to send {type} notification.",
   "notifications.test.message": "Check check, 1, 2, 3. Are we coming in clear?",
   "notifications.test.subject": "Test Notification",
   "notifications.user.created.message": "Invited by {displayName}.",
   "notifications.user.created.subject": "New User Created: {displayName}",
   "notifications.userSettings.extensionRequested": "Access extension requested",
-  "notifications.userSettings.extensionRequestedMessage": "{displayName} requested an access extension. {isPast, select, true {Trial Ended} other {Trial Ends}}: {accessEndDate}"
+  "notifications.userSettings.extensionRequestedMessage": "{displayName} requested an access extension. {state, select, deactivated {Account Deactivated} ended {Trial Ended} other {Trial Ends}}: {accessEndDate}"
 }

--- a/server/interfaces/api/userSettingsInterfaces.ts
+++ b/server/interfaces/api/userSettingsInterfaces.ts
@@ -32,6 +32,7 @@ export interface UserSettingsGeneralResponse {
   requestHostname?: string;
   requestEnabled?: boolean;
   releaseSched?: boolean;
+  plexSync?: 'synced' | 'removed' | 'failed' | 'skipped';
 }
 
 export type NotificationAgentTypes = Record<NotificationAgentKey, number>;

--- a/server/job/schedule.ts
+++ b/server/job/schedule.ts
@@ -8,6 +8,7 @@ import schedule from 'node-schedule';
 import expiredInvites from '@server/lib/expiredInvites';
 import cleanUpNotifications from '@server/lib/cleanUpNotifications';
 import trialExpiry from '@server/lib/trialExpiry';
+import { plexAccess } from '@server/lib/plexAccessLost';
 
 interface ScheduledJob {
   id: JobId;
@@ -122,6 +123,19 @@ export const startJobs = (): void => {
     }),
     running: () => trialExpiry.status().running,
     cancelFn: () => trialExpiry.cancel(),
+  });
+
+  scheduledJobs.push({
+    id: 'plex-membership-check',
+    name: 'Plex Membership Check',
+    type: 'process',
+    interval: 'minutes',
+    cronSchedule: jobs['plex-membership-check']?.schedule,
+    job: schedule.scheduleJob(jobs['plex-membership-check']?.schedule, () => {
+      plexAccess.run();
+    }),
+    running: () => plexAccess.status().running,
+    cancelFn: () => plexAccess.cancel(),
   });
 
   logger.info('Scheduled jobs loaded', { label: 'Jobs' });

--- a/server/lib/notifications/agents/email.ts
+++ b/server/lib/notifications/agents/email.ts
@@ -63,6 +63,7 @@ class EmailAgent
       [NotificationType.INVITE_EXPIRED]: 'inviteexpired',
       [NotificationType.NEW_INVITE]: 'newinvite',
       [NotificationType.NEW_EVENT]: 'newevent',
+      [NotificationType.PLEX_ACCESS_LOST]: 'plexaccesslost',
     };
 
     const templateName = TEMPLATE_MAP[type];
@@ -149,7 +150,7 @@ class EmailAgent
               recipient: payload.notifyUser.displayName,
               type: NotificationType[type],
               subject: payload.subject,
-              errorMessage: e.message,
+              errorMessage: e instanceof Error ? e.message : String(e),
             });
 
             return false;
@@ -201,7 +202,7 @@ class EmailAgent
                 recipient: user.displayName,
                 type: NotificationType[type],
                 subject: payload.subject,
-                errorMessage: e.message,
+                errorMessage: e instanceof Error ? e.message : String(e),
               });
             }
           })

--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -44,6 +44,7 @@ export const getAdminPermission = (type: NotificationType): Permission[] => {
       return [Permission.MANAGE_INVITES, Permission.ADMIN];
     case NotificationType.USER_CREATED:
     case NotificationType.ACCESS_EXTENSION_REQUESTED:
+    case NotificationType.PLEX_ACCESS_LOST:
       return [Permission.MANAGE_USERS, Permission.ADMIN];
     case NotificationType.LOCAL_MESSAGE:
       return [Permission.MANAGE_NOTIFICATIONS, Permission.ADMIN];

--- a/server/lib/plexAccessLost.ts
+++ b/server/lib/plexAccessLost.ts
@@ -1,0 +1,284 @@
+import PlexTvAPI from '@server/api/plextv';
+import SeerrAPI from '@server/api/seerr';
+import {
+  NotificationSeverity,
+  NotificationType,
+} from '@server/constants/notification';
+import { UserType } from '@server/constants/user';
+import { getRepository } from '@server/datasource';
+import { User } from '@server/entity/User';
+import { UserSettings } from '@server/entity/UserSettings';
+import { getAdminPlexToken } from '@server/lib/adminPlexToken';
+import { userAcceptsNotificationType } from '@server/lib/notifications';
+import { sendGroupNotification } from '@server/lib/notifications/dispatch';
+import { Permission } from '@server/lib/permissions';
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+
+const LABEL = 'Plex Sync';
+const inFlight = new Set<number>();
+
+/**
+ * Handles a user that has been definitively removed from the Plex server's
+ * shared users list (but still exists in Streamarr).
+ *
+ * Deactivates the account (allowing profile-only sign-in, matching the
+ * trial-deactivation behavior), revokes Seerr permissions, and notifies
+ * admins.
+ */
+export const handlePlexAccessLost = async (user: User): Promise<void> => {
+  if (user.id === 1 || user.userType !== UserType.PLEX || !user.active) {
+    return;
+  }
+
+  if (inFlight.has(user.id)) {
+    return;
+  }
+  inFlight.add(user.id);
+
+  try {
+    user.active = false;
+    user.accessRevokedAt = new Date();
+    user.accessRevokedReason = 'plex_removed';
+    await getRepository(User).save(user);
+
+    try {
+      const settingsRepository = getRepository(UserSettings);
+      const userSettings =
+        user.settings ??
+        (await settingsRepository.findOne({
+          where: { user: { id: user.id } },
+        }));
+      if (
+        userSettings &&
+        (userSettings.trialPeriodEndsAt || userSettings.trialPeriodOutcome)
+      ) {
+        userSettings.trialPeriodEndsAt = null;
+        userSettings.trialPeriodOutcome = null;
+        await settingsRepository.save(userSettings);
+      }
+    } catch (e) {
+      logger.error('Failed to clear trial period for removed user', {
+        label: LABEL,
+        userId: user.id,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    logger.info(
+      'User was removed from the Plex server and their account deactivated',
+      {
+        label: LABEL,
+        userId: user.id,
+        email: user.email,
+      }
+    );
+
+    const seerrSettings = getSettings().overseerr;
+    if (user.plexId && seerrSettings.enabled && seerrSettings.hostname) {
+      try {
+        const seerrApi = new SeerrAPI(seerrSettings);
+        await seerrApi.revokeAllPermissionsByPlexId(user.plexId);
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        // A user that was never imported into Seerr is expected, not an error
+        !message.includes('not found') &&
+          logger.error('Failed to revoke Seerr permissions', {
+            label: LABEL,
+            userId: user.id,
+            errorMessage: message,
+          });
+      }
+    }
+
+    try {
+      const admins = await getRepository(User)
+        .createQueryBuilder('user')
+        .leftJoinAndSelect('user.settings', 'settings')
+        .where(
+          '(user.permissions & :manageUsers) = :manageUsers OR (user.permissions & :admin) = :admin',
+          {
+            manageUsers: Permission.MANAGE_USERS,
+            admin: Permission.ADMIN,
+          }
+        )
+        .getMany();
+
+      const usersToNotify = admins.filter(
+        (recipient) =>
+          recipient.id !== user.id &&
+          userAcceptsNotificationType(
+            recipient,
+            NotificationType.PLEX_ACCESS_LOST
+          )
+      );
+
+      await sendGroupNotification(
+        NotificationType.PLEX_ACCESS_LOST,
+        usersToNotify,
+        (intl) => ({
+          subject: intl.formatMessage(
+            {
+              id: 'notifications.plexAccessLost.subject',
+              defaultMessage: 'Plex Access Removed: {displayName}',
+            },
+            { displayName: user.displayName }
+          ),
+          message: intl.formatMessage({
+            id: 'notifications.plexAccessLost.message',
+            defaultMessage:
+              'This user was removed from the Plex server and their account has been deactivated.',
+          }),
+          actionUrl: `/admin/users/${user.id}/settings`,
+          actionUrlTitle: 'View User Settings',
+          severity: NotificationSeverity.WARNING,
+        })
+      );
+    } catch (e) {
+      logger.error('Failed to send Plex access lost notification', {
+        label: LABEL,
+        userId: user.id,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
+    }
+  } finally {
+    inFlight.delete(user.id);
+  }
+};
+
+/**
+ * Validates that every active Plex user still exists in the Plex server's
+ * shared users list, deactivating any that have been removed out-of-band.
+ */
+let isRunning = false;
+let cancelled = false;
+
+export const validateActivePlexMembership = async (
+  isCancelled?: () => boolean
+): Promise<void> => {
+  if (isRunning) {
+    return;
+  }
+  isRunning = true;
+  cancelled = false;
+
+  try {
+    await runMembershipValidation(
+      () => cancelled || (isCancelled?.() ?? false)
+    );
+  } finally {
+    isRunning = false;
+  }
+};
+
+export const plexAccess = {
+  status: (): { running: boolean } => ({
+    running: isRunning,
+  }),
+  cancel: (): void => {
+    cancelled = true;
+  },
+  run: async (isCancelled?: () => boolean): Promise<void> => {
+    try {
+      await validateActivePlexMembership(isCancelled);
+    } catch (e) {
+      logger.error('Plex membership check failed.', {
+        label: 'Jobs',
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
+    }
+  },
+};
+
+const runMembershipValidation = async (
+  isCancelled?: () => boolean
+): Promise<void> => {
+  const settings = getSettings();
+  const machineId = settings.plex.machineId;
+  const adminToken = await getAdminPlexToken();
+
+  if (!adminToken || !machineId) {
+    logger.warn(
+      'Missing admin Plex token or machineId — Plex membership validation skipped.',
+      { label: 'Jobs' }
+    );
+    return;
+  }
+
+  const activeUsers = await getRepository(User)
+    .createQueryBuilder('user')
+    .leftJoinAndSelect('user.settings', 'settings')
+    .where('user.active = :active', { active: true })
+    .andWhere('user.userType = :type', { type: UserType.PLEX })
+    .andWhere('user.id != 1')
+    .getMany();
+
+  if (activeUsers.length === 0) {
+    return;
+  }
+
+  let plexUsers: Awaited<
+    ReturnType<PlexTvAPI['getUsers']>
+  >['MediaContainer']['User'];
+  try {
+    const usersResponse = await new PlexTvAPI(adminToken).getUsers();
+    const raw = usersResponse.MediaContainer.User;
+    plexUsers = Array.isArray(raw) ? raw : raw ? [raw] : [];
+  } catch (e) {
+    logger.warn(
+      'Unable to fetch shared users from plex.tv — Plex membership validation skipped.',
+      {
+        label: 'Jobs',
+        errorMessage: e instanceof Error ? e.message : String(e),
+      }
+    );
+    return;
+  }
+
+  if (plexUsers.length === 0) {
+    logger.warn(
+      'plex.tv returned no shared users — Plex membership validation skipped.',
+      { label: 'Jobs' }
+    );
+    return;
+  }
+
+  const sharedIds = new Set<number>();
+  const sharedEmails = new Set<string>();
+  const sharedUsernames = new Set<string>();
+
+  for (const plexUser of plexUsers) {
+    const serversRaw = plexUser.Server;
+    const servers = Array.isArray(serversRaw)
+      ? serversRaw
+      : serversRaw
+        ? [serversRaw]
+        : [];
+    if (!servers.some((server) => server.$.machineIdentifier === machineId)) {
+      continue;
+    }
+    sharedIds.add(parseInt(plexUser.$.id, 10));
+    if (plexUser.$.email) {
+      sharedEmails.add(plexUser.$.email.toLowerCase());
+    }
+    if (plexUser.$.username) {
+      sharedUsernames.add(plexUser.$.username.toLowerCase());
+    }
+  }
+
+  for (const user of activeUsers) {
+    if (isCancelled?.()) {
+      return;
+    }
+
+    const hasAccess =
+      (user.plexId != null && sharedIds.has(user.plexId)) ||
+      (!!user.email && sharedEmails.has(user.email.toLowerCase())) ||
+      (!!user.plexUsername &&
+        sharedUsernames.has(user.plexUsername.toLowerCase()));
+
+    if (!hasAccess) {
+      await handlePlexAccessLost(user);
+    }
+  }
+};

--- a/server/lib/plexSync.ts
+++ b/server/lib/plexSync.ts
@@ -22,6 +22,13 @@ const AUTO_ACCEPT_DELAY_MS = 3_000;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+export class PlexUserNotFoundError extends Error {
+  constructor() {
+    super('User not found in Plex shared users list.');
+    this.name = 'PlexUserNotFoundError';
+  }
+}
+
 export interface PlexSyncOptions {
   /** undefined leaves the current Plex value unchanged */
   allowSync?: boolean;
@@ -94,9 +101,12 @@ class PlexSync {
 
   /**
    * Gets the user's current library access on the Plex server.
-   * The empty array means "all libraries"
+   * The empty array means "all libraries".
+   * `existsInPlex` is false when the user is definitively absent from the
+   * server's shared users list (transport errors still throw).
    */
   public async getCurrentPlexLibraries(user: User): Promise<{
+    existsInPlex: boolean;
     libraries: string[];
     permissions?: {
       allowSync: boolean;
@@ -112,10 +122,11 @@ class PlexSync {
     );
 
     if (!share) {
-      throw new Error('User not found in Plex shared users list.');
+      return { existsInPlex: false, libraries: [] };
     }
 
     return {
+      existsInPlex: true,
       libraries: share.allLibraries
         ? []
         : share.sections
@@ -184,7 +195,7 @@ class PlexSync {
 
         const share = await api.getUserShare(this.getIdentity(user), machineId);
         if (!share) {
-          throw new Error('User not found in Plex shared users list.');
+          throw new PlexUserNotFoundError();
         }
 
         const sectionIds = await this.mapKeysToSectionIds(
@@ -217,6 +228,9 @@ class PlexSync {
           userId: user.id,
           error: message,
         });
+        if (e instanceof PlexUserNotFoundError) {
+          throw e;
+        }
         throw new Error(`Plex sync error: ${message}`);
       }
     });
@@ -317,10 +331,26 @@ class PlexSync {
         });
       });
     } else {
-      logger.warn(
-        'No user token is available — auto-accept skipped, the user must accept the invite manually',
-        { label: LABEL, userId: user.id }
-      );
+      // Plex auto-accepts re-shares for previously connected accounts, so
+      // check the admin-side share before assuming a manual accept is needed.
+      void (async () => {
+        await sleep(AUTO_ACCEPT_DELAY_MS);
+        if (
+          (await this.isShareAccepted(this.getIdentity(user), user.id)) ===
+          false
+        ) {
+          logger.warn(
+            'No user token is available — auto-accept skipped, the user must accept the invite manually',
+            { label: LABEL, userId: user.id }
+          );
+        }
+      })().catch((e) => {
+        logger.error('Unable to verify Plex invite acceptance', {
+          label: LABEL,
+          userId: user.id,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        });
+      });
     }
   }
 

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -358,7 +358,8 @@ export type JobId =
   | 'invites-qrcode-cleanup'
   | 'image-cache-cleanup'
   | 'notification-cleanup'
-  | 'trial-expiry';
+  | 'trial-expiry'
+  | 'plex-membership-check';
 
 export interface AllSettings {
   clientId: string;
@@ -588,6 +589,7 @@ class Settings {
         'invites-qrcode-cleanup': { schedule: '0 0 1 * * *' },
         'notification-cleanup': { schedule: '0 30 1 * * *' },
         'trial-expiry': { schedule: '0 0 0 * * *' },
+        'plex-membership-check': { schedule: '0 */15 * * * *' },
       },
       onboarding: {
         initialized: false,

--- a/server/lib/trialExpiry.ts
+++ b/server/lib/trialExpiry.ts
@@ -164,6 +164,7 @@ class TrialExpiry {
 
           user.active = false;
           user.accessRevokedAt = trialEndDateAtExpiry;
+          user.accessRevokedReason = 'trial_expired';
           if (user.settings) {
             user.settings.trialPeriodEndsAt = null;
             user.settings.trialExtensionRequested = false;

--- a/server/migration/1781200000000-AddAccessRevokedReason.ts
+++ b/server/migration/1781200000000-AddAccessRevokedReason.ts
@@ -1,0 +1,17 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAccessRevokedReason1781200000000 implements MigrationInterface {
+  name = 'AddAccessRevokedReason1781200000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD COLUMN "accessRevokedReason" varchar`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP COLUMN "accessRevokedReason"`
+    );
+  }
+}

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -6,6 +6,7 @@ import { User } from '@server/entity/User';
 import type { UserSummary } from '@server/interfaces/api/userInterfaces';
 import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
+import { handlePlexAccessLost } from '@server/lib/plexAccessLost';
 import logger from '@server/logger';
 import { resetPasswordLimiter } from '@server/lib/rateLimiters';
 import { isAuthenticated } from '@server/middleware/auth';
@@ -102,12 +103,42 @@ authRoutes.post('/plex', async (req, res, next) => {
         });
       }
 
-      if (
+      const hasPlexAccess =
         account.id === mainUser.plexId ||
         (account.email === mainUser.email && !mainUser.plexId) ||
-        (await mainPlexTv.checkUserAccess(account.id)) ||
-        (user && !user.active)
+        (await mainPlexTv.checkUserAccess(account.id));
+
+      if (
+        !hasPlexAccess &&
+        user &&
+        user.active &&
+        user.userType === UserType.PLEX
       ) {
+        try {
+          const share = await mainPlexTv.getUserShare(
+            {
+              plexId: account.id,
+              email: account.email,
+              username: account.username,
+            },
+            settings.plex.machineId
+          );
+          if (share === null) {
+            await handlePlexAccessLost(user);
+          }
+        } catch (e) {
+          logger.debug(
+            'Unable to verify Plex share state during sign-in; leaving user active',
+            {
+              label: 'API',
+              userId: user.id,
+              errorMessage: e instanceof Error ? e.message : String(e),
+            }
+          );
+        }
+      }
+
+      if (hasPlexAccess || (user && !user.active)) {
         if (user) {
           if (!user.plexId) {
             logger.info(
@@ -218,7 +249,15 @@ authRoutes.post('/local', async (req, res, next) => {
   try {
     const user = await userRepository
       .createQueryBuilder('user')
-      .select(['user.id', 'user.email', 'user.password', 'user.plexId'])
+      .select([
+        'user.id',
+        'user.email',
+        'user.password',
+        'user.plexId',
+        'user.plexUsername',
+        'user.userType',
+        'user.active',
+      ])
       .where('user.email = :email', { email: normalizedEmail })
       .getOne();
 
@@ -239,23 +278,52 @@ authRoutes.post('/local', async (req, res, next) => {
     const mainPlexTv = new PlexTvAPI(mainUser.plexToken ?? '');
 
     if (
+      user.active &&
       user.plexId &&
       user.plexId !== mainUser.plexId &&
       !(await mainPlexTv.checkUserAccess(user.plexId))
     ) {
-      logger.warn(
-        'Failed sign-in attempt from Plex user without access to the media app',
-        {
-          label: 'API',
-          account: {
-            ip: req.ip,
-            email: normalizedEmail,
-            userId: user.id,
-            plexId: user.plexId,
-          },
+      let removedFromPlex = false;
+      if (user.userType === UserType.PLEX) {
+        try {
+          const share = await mainPlexTv.getUserShare(
+            {
+              plexId: user.plexId,
+              email: user.email,
+              username: user.plexUsername,
+            },
+            settings.plex.machineId
+          );
+          removedFromPlex = share === null;
+        } catch (e) {
+          logger.debug(
+            'Unable to verify Plex share state during sign-in; leaving user active',
+            {
+              label: 'API',
+              userId: user.id,
+              errorMessage: e instanceof Error ? e.message : String(e),
+            }
+          );
         }
-      );
-      return next({ status: 403, message: 'Access denied.' });
+      }
+
+      if (removedFromPlex) {
+        await handlePlexAccessLost(user);
+      } else {
+        logger.warn(
+          'Failed sign-in attempt from Plex user without access to the media app',
+          {
+            label: 'API',
+            account: {
+              ip: req.ip,
+              email: normalizedEmail,
+              userId: user.id,
+              plexId: user.plexId,
+            },
+          }
+        );
+        return next({ status: 403, message: 'Access denied.' });
+      }
     }
 
     // Set logged in session

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -34,6 +34,7 @@ import crypto from 'crypto';
 import Invite from '@server/entity/Invite';
 import Notification from '@server/entity/Notification';
 import { plexSync } from '@server/lib/plexSync';
+import { handlePlexAccessLost } from '@server/lib/plexAccessLost';
 import { isOwnProfileOrAdmin } from '@server/utils/profileMiddleware';
 
 const router = Router();
@@ -1093,10 +1094,22 @@ router.get('/:id/plex/libraries', isAuthenticated(), async (req, res, next) => {
     try {
       const plexData = await plexSync.getCurrentPlexLibraries(user);
 
+      if (!plexData.existsInPlex) {
+        await handlePlexAccessLost(user);
+
+        res.status(200).json({
+          currentPlexLibraries: null,
+          canFetchFromPlex: true,
+          existsInPlex: false,
+        });
+        return;
+      }
+
       res.status(200).json({
         currentPlexLibraries:
           plexData.libraries.length > 0 ? plexData.libraries.join('|') : '',
         canFetchFromPlex: true,
+        existsInPlex: true,
         permissions: plexData.permissions,
       });
     } catch (error) {

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -8,7 +8,8 @@ import type {
 } from '@server/interfaces/api/userSettingsInterfaces';
 import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
-import { plexSync } from '@server/lib/plexSync';
+import { plexSync, PlexUserNotFoundError } from '@server/lib/plexSync';
+import { handlePlexAccessLost } from '@server/lib/plexAccessLost';
 import {
   NotificationSeverity,
   NotificationType,
@@ -172,6 +173,13 @@ userSettingsRoutes.post<{ id: string }>(
         )
         .getMany();
 
+      const isDeactivated =
+        !user.active && user.accessRevokedReason === 'plex_removed';
+      const isExpired = !user.active && !isDeactivated;
+      const referenceDate = user.active
+        ? user.settings.trialPeriodEndsAt
+        : (user.accessRevokedAt ?? user.settings.trialPeriodEndsAt);
+
       await sendGroupNotification(
         NotificationType.ACCESS_EXTENSION_REQUESTED,
         admins,
@@ -184,17 +192,19 @@ userSettingsRoutes.post<{ id: string }>(
             {
               id: 'notifications.userSettings.extensionRequestedMessage',
               defaultMessage:
-                '{displayName} requested an access extension. {isPast, select, true {Trial Ended} other {Trial Ends}}: {accessEndDate}',
+                '{displayName} requested an access extension. {state, select, deactivated {Account Deactivated} ended {Trial Ended} other {Trial Ends}}: {accessEndDate}',
             },
             {
               displayName: user.displayName,
               accessEndDate:
-                moment(user.settings.trialPeriodEndsAt ?? user.accessRevokedAt)
+                moment(referenceDate)
                   .locale(intl.locale)
                   .format('MMM D, h:mm A') ?? 'Unknown',
-              isPast: moment(
-                user.settings.trialPeriodEndsAt ?? user.accessRevokedAt
-              ).isBefore(moment()),
+              state: isDeactivated
+                ? 'deactivated'
+                : isExpired
+                  ? 'ended'
+                  : 'active',
             }
           ),
           actionUrl: `/admin/users/${user.id}/settings`,
@@ -316,6 +326,7 @@ userSettingsRoutes.post<
         if (!user.active) {
           user.active = true;
           user.accessRevokedAt = null;
+          user.accessRevokedReason = null;
         }
       } else {
         const trialDate = new Date(req.body.trialPeriodEndsAt);
@@ -347,6 +358,7 @@ userSettingsRoutes.post<
         ) {
           user.active = true;
           user.accessRevokedAt = null;
+          user.accessRevokedReason = null;
         } else if (
           trialPeriodOutcome === 'deactivate' &&
           user.active &&
@@ -484,6 +496,8 @@ userSettingsRoutes.post<
       !plexHomeChanged &&
       user.active;
 
+    let plexSyncStatus: 'synced' | 'removed' | 'failed' | 'skipped' = 'skipped';
+
     if (
       req.user?.hasPermission(Permission.MANAGE_USERS) &&
       shouldSync &&
@@ -495,7 +509,15 @@ userSettingsRoutes.post<
         await plexSync.syncUserLibraries(user, newSharedLibraries, {
           allowSync: req.body.allowDownloads,
         });
+        plexSyncStatus = 'synced';
       } catch (e) {
+        if (e instanceof PlexUserNotFoundError) {
+          // The user was removed from Plex out-of-band
+          await handlePlexAccessLost(user);
+          plexSyncStatus = 'removed';
+        } else {
+          plexSyncStatus = 'failed';
+        }
         logger.error('Failed to sync user libraries with Plex', {
           label: 'Plex Sync',
           userId: user.id,
@@ -508,11 +530,126 @@ userSettingsRoutes.post<
     res.status(200).json({
       username: user.username,
       locale: user.settings.locale,
+      plexSync: plexSyncStatus,
     });
   } catch (e) {
     next({ status: 500, message: e.message });
   }
 });
+
+userSettingsRoutes.post<{ id: string }>(
+  '/reinvite',
+  isOwnProfileOrAdmin(),
+  async (req, res, next) => {
+    const userRepository = getRepository(User);
+
+    try {
+      if (
+        !req.user?.hasPermission(Permission.MANAGE_USERS) ||
+        req.user.id === Number(req.params.id)
+      ) {
+        return next({
+          status: 403,
+          message: 'You do not have permission to reinvite this user.',
+        });
+      }
+
+      const user = await userRepository
+        .createQueryBuilder('user')
+        .addSelect('user.plexToken')
+        .leftJoinAndSelect('user.settings', 'settings')
+        .where('user.id = :id', { id: Number(req.params.id) })
+        .getOne();
+
+      if (!user) {
+        return next({ status: 404, message: 'User not found.' });
+      }
+
+      if (user.id === 1 || user.userType !== UserType.PLEX) {
+        return next({
+          status: 400,
+          message: 'This user cannot be reinvited.',
+        });
+      }
+
+      if (user.active) {
+        return next({ status: 400, message: 'User is already active.' });
+      }
+
+      try {
+        const librarySectionIds = resolveSharedLibraryKeys({
+          value: user.settings?.sharedLibraries ?? null,
+          adminDefault: getSettings().main.sharedLibraries,
+          enabledLibraries: getSettings().plex.libraries.filter(
+            (lib) => lib.enabled
+          ),
+        });
+
+        await plexSync.inviteUser(user, {
+          libraries: librarySectionIds,
+          allowSync: user.settings?.allowDownloads ?? false,
+          plexHome: user.settings?.allowPlexHome ?? false,
+        });
+      } catch (e) {
+        const plexInviteError = e instanceof Error ? e.message : String(e);
+        logger.error('Failed to reinvite user to plex', {
+          label: 'User Settings',
+          userId: user.id,
+          errorMessage: plexInviteError,
+        });
+
+        res.status(200).json({
+          active: user.active,
+          plexInvite: 'failed',
+          plexInviteError,
+        });
+        return;
+      }
+
+      if (
+        user.settings?.trialPeriodEndsAt &&
+        new Date(user.settings.trialPeriodEndsAt) <= new Date()
+      ) {
+        user.settings.trialPeriodEndsAt = null;
+        user.settings.trialPeriodOutcome = null;
+      }
+
+      if (user.settings) {
+        user.settings.trialExtensionRequested = false;
+        user.settings.trialExtensionRequestedAt = null;
+      }
+
+      user.active = true;
+      user.accessRevokedAt = null;
+      user.accessRevokedReason = null;
+      await userRepository.save(user);
+
+      const seerrSettings = getSettings().overseerr;
+      if (user.plexId && seerrSettings.enabled && seerrSettings.hostname) {
+        try {
+          const seerrApi = new SeerrAPI(seerrSettings);
+          await seerrApi.restoreDefaultPermissionsByPlexId(user.plexId);
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e);
+          // A user that was never imported into Seerr is expected, not an error
+          !message.includes('not found') &&
+            logger.error('Failed to restore Seerr permissions', {
+              label: 'User Settings',
+              userId: user.id,
+              errorMessage: message,
+            });
+        }
+      }
+
+      res.status(200).json({
+        active: user.active,
+        plexInvite: 'invited',
+      });
+    } catch (e) {
+      next({ status: 500, message: e.message });
+    }
+  }
+);
 
 userSettingsRoutes.get<{ id: string }, { hasPassword: boolean }>(
   '/password',

--- a/server/templates/email/plexaccesslost/html.pug
+++ b/server/templates/email/plexaccesslost/html.pug
@@ -1,0 +1,48 @@
+doctype html
+head
+  meta(charset='utf-8')
+  meta(name='x-apple-disable-message-reformatting')
+  meta(http-equiv='x-ua-compatible' content='ie=edge')
+  meta(name='viewport' content='width=device-width, initial-scale=1')
+  meta(name='format-detection' content='telephone=no, date=no, address=no, email=no')
+  link(href='https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap' rel='stylesheet' media='screen')
+  style.
+    .title:hover * {
+    text-decoration: underline;
+    }
+    @media only screen and (max-width:600px) {
+    table {
+    font-size: 20px !important;
+    width: 100% !important;
+    }
+    }
+div(style='display: block; background-color: #1f1f1f; padding: 2.5rem 0;')
+  table(style='margin: 0 auto; font-family: Inter, Arial, sans-serif; color: #fff; font-size: 16px; width: 26rem;')
+    tr
+      td(style="text-align: center;")
+        if applicationUrl
+          a(href=applicationUrl style='margin: 0 1rem;')
+            img(src=applicationUrl + logoUrl style='width: 26rem; image-rendering: crisp-edges; image-rendering: -webkit-optimize-contrast;')
+        else
+          div(style='margin: 0 1rem 2.5rem; font-size: 3em; font-weight: 700;')
+            | #{applicationTitle}
+    if recipientName !== recipientEmail
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 0 0; font-size: 1.25em;')
+            | Hi, #{recipientName.replace(/\.|@/g, ((x) => x + '\ufeff'))}!
+    tr
+      td(style='text-align: center;')
+        div(style='margin: 1rem 0 0; font-size: 1.25em;')
+          | #{subject}
+    if message
+      tr
+        td(style='text-align: center;')
+          div(style='margin: 1rem 1rem 0; font-size: 1.0em;')
+            | #{message}
+    if applicationUrl
+      tr
+        td
+          a(href=applicationUrl style='display: block; margin: 1.5rem 3rem 0; text-decoration: none; font-size: 1.0em; line-height: 2.25em;')
+            span(style='padding: 0.2rem; font-weight: 500; text-align: center; border-radius: 10px; background-color: rgb(127, 17, 224); color: #fff; display: block; border: 1px solid rgba(255,255,255,0.2);')
+              | Open #{applicationTitle}

--- a/server/templates/email/plexaccesslost/subject.pug
+++ b/server/templates/email/plexaccesslost/subject.pug
@@ -1,0 +1,1 @@
+!= `Plex Access Removed [${applicationTitle}]`

--- a/src/components/Admin/Users/index.tsx
+++ b/src/components/Admin/Users/index.tsx
@@ -692,10 +692,17 @@ const AdminUsers = () => {
                       href={`/admin/users/${user.id}/settings`}
                       badgeType="error"
                     >
-                      <FormattedMessage
-                        id="common.expired"
-                        defaultMessage="Expired"
-                      />
+                      {user?.accessRevokedReason === 'plex_removed' ? (
+                        <FormattedMessage
+                          id="common.deactivated"
+                          defaultMessage="Deactivated"
+                        />
+                      ) : (
+                        <FormattedMessage
+                          id="common.expired"
+                          defaultMessage="Expired"
+                        />
+                      )}
                     </Badge>
                     {user?.settings?.trialExtensionRequested && (
                       <ToolTip

--- a/src/components/Common/Button/index.tsx
+++ b/src/components/Common/Button/index.tsx
@@ -8,6 +8,7 @@ export type ButtonType =
   | 'error'
   | 'warning'
   | 'success'
+  | 'accent'
   | 'info'
   | 'ghost';
 
@@ -68,6 +69,9 @@ function Button<P extends ElementTypes = 'button'>(
       break;
     case 'info':
       buttonStyle.push('btn-info');
+      break;
+    case 'accent':
+      buttonStyle.push('btn-accent');
       break;
     default:
       buttonStyle.push('btn-neutral');

--- a/src/components/Common/NotificationTypeSelector/index.tsx
+++ b/src/components/Common/NotificationTypeSelector/index.tsx
@@ -185,6 +185,21 @@ const NotificationTypeSelector = ({
         hidden: !!user && !hasPermission(Permission.MANAGE_USERS),
         hasNotifyUser: true,
       },
+      {
+        id: 'plex-access-lost',
+        name: intl.formatMessage({
+          id: 'notification.plexAccessLost',
+          defaultMessage: 'Plex Access Removed',
+        }),
+        description: intl.formatMessage({
+          id: 'notification.plexAccessLost.description',
+          defaultMessage:
+            'Get notified when a user is removed from the Plex server and deactivated',
+        }),
+        value: Notification.PLEX_ACCESS_LOST,
+        hidden: !!user && !hasPermission(Permission.MANAGE_USERS),
+        hasNotifyUser: true,
+      },
       // {
       //   id: 'system',
       //   name: intl.formatMessage({

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -192,14 +192,22 @@ const Layout = ({
         ) : (
           children
         )}
-        {shouldShowExpiredOverlay && <ExpiredAccessOverlay />}
+        {shouldShowExpiredOverlay && (
+          <ExpiredAccessOverlay
+            isTrialExpiry={user?.accessRevokedReason !== 'plex_removed'}
+          />
+        )}
       </OnboardingProvider>
     </SWRConfig>
   );
 };
 export default Layout;
 
-const ExpiredAccessOverlay = () => {
+const ExpiredAccessOverlay = ({
+  isTrialExpiry,
+}: {
+  isTrialExpiry: boolean;
+}) => {
   const intl = useIntl();
   const router = useRouter();
   const { currentSettings } = useSettings();
@@ -209,17 +217,27 @@ const ExpiredAccessOverlay = () => {
       show
       size="sm"
       onCancel={() => router.push('/profile')}
-      title={intl.formatMessage({
-        id: 'expiredAccess.title',
-        defaultMessage: 'Account Access Expired',
-      })}
+      title={
+        isTrialExpiry
+          ? intl.formatMessage({
+              id: 'expiredAccess.title',
+              defaultMessage: 'Account Access Expired',
+            })
+          : intl.formatMessage({
+              id: 'expiredAccess.deactivatedTitle',
+              defaultMessage: 'Account Deactivated',
+            })
+      }
       subtitle={intl.formatMessage(
         {
           id: 'expiredAccess.message',
           defaultMessage:
-            'Your account is currently expired. You can still access your profile and settings{isTrialEnabled, select, true { including trial extension request options.} other {. Please contact an administrator to reactivate your access.}}',
+            'Your account is currently {state, select, true {expired} other {deactivated}}. You can still access your profile and settings{isTrialEnabled, select, true { including trial extension request options.} other {. Please contact an administrator to reactivate your access.}}',
         },
-        { isTrialEnabled: currentSettings.enableTrialPeriod }
+        {
+          isTrialEnabled: currentSettings.enableTrialPeriod,
+          state: isTrialExpiry,
+        }
       )}
       onOk={() => router.push('/profile/settings/general')}
       okText={intl.formatMessage({

--- a/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
@@ -16,7 +16,7 @@ import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import type { UserSettingsGeneralResponse } from '@server/interfaces/api/userSettingsInterfaces';
 import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import useSWR from 'swr';
 import Toast, { dismissToast } from '@app/components/Toast';
@@ -26,6 +26,7 @@ import {
   CheckIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
+  PaperAirplaneIcon,
   XMarkIcon,
 } from '@heroicons/react/24/solid';
 import { useParams } from 'next/navigation';
@@ -42,6 +43,7 @@ const UserSettingsGeneral = () => {
   const { resetOnboarding, data: onboardingData } = useOnboardingContext();
   const [inviteQuotaEnabled, setInviteQuotaEnabled] = useState(false);
   const [isPinning, setIsPinning] = useState(false);
+  const [isReactivating, setIsReactivating] = useState(false);
   const [isRequestingExtension, setIsRequestingExtension] = useState(false);
   const searchParams = useParams<{ userid: string }>();
   const {
@@ -67,6 +69,7 @@ const UserSettingsGeneral = () => {
   } = useSWR<{
     currentPlexLibraries: string | null;
     canFetchFromPlex: boolean;
+    existsInPlex?: boolean;
     permissions?: {
       allowSync: boolean;
       allowCameraUpload: boolean;
@@ -157,6 +160,67 @@ const UserSettingsGeneral = () => {
     };
   }, [data, plexLibrariesData, allLibrariesData]);
 
+  const userRemovedFromPlex = plexLibrariesData?.existsInPlex === false;
+
+  useEffect(() => {
+    if (userRemovedFromPlex && user?.active) {
+      revalidateUser();
+    }
+  }, [userRemovedFromPlex, user?.active, revalidateUser]);
+
+  const showReactivate =
+    user?.userType === UserType.PLEX &&
+    user?.id !== 1 &&
+    currentUser?.id !== user?.id &&
+    currentHasPermission(Permission.MANAGE_USERS) &&
+    (userRemovedFromPlex || user?.active === false);
+
+  const reactivateUser = async () => {
+    setIsReactivating(true);
+    try {
+      const response = await axios.post(
+        `/api/v1/user/${user?.id}/settings/reinvite`
+      );
+
+      if (response.data?.plexInvite === 'invited') {
+        Toast({
+          title: intl.formatMessage({
+            id: 'settings.reinviteSuccess',
+            defaultMessage: 'User reinvited successfully!',
+          }),
+          type: 'success',
+          icon: <CheckBadgeIcon className="size-7" />,
+        });
+      } else {
+        Toast({
+          title: intl.formatMessage({
+            id: 'settings.reinviteFailed',
+            defaultMessage:
+              'The Plex invite failed and the user remains deactivated.',
+          }),
+          message: response.data?.plexInviteError,
+          type: 'error',
+          icon: <ExclamationTriangleIcon className="size-7" />,
+        });
+      }
+    } catch (e) {
+      Toast({
+        title: intl.formatMessage({
+          id: 'settings.reinviteError',
+          defaultMessage: 'Failed to reinvite user.',
+        }),
+        message: e.response?.data?.message || e.message,
+        type: 'error',
+        icon: <XCircleIcon className="size-7" />,
+      });
+    } finally {
+      setIsReactivating(false);
+      revalidateUser();
+      revalidate();
+      revalidatePlexLibraries();
+    }
+  };
+
   if (!data && !error) {
     return <LoadingEllipsis />;
   }
@@ -207,21 +271,10 @@ const UserSettingsGeneral = () => {
         }}
         enableReinitialize
         onSubmit={async (values) => {
-          // Handle previous values correctly to detect changes
-          const previousSharedLibraries =
-            data?.sharedLibraries === null
-              ? 'server'
-              : data?.sharedLibraries && data?.sharedLibraries !== ''
-                ? data.sharedLibraries
-                : 'server';
-
           const newSharedLibraries =
             values.sharedLibraries === 'server' || values.sharedLibraries === ''
               ? 'server'
               : values.sharedLibraries;
-
-          const librariesChanged =
-            previousSharedLibraries !== (newSharedLibraries || 'server');
 
           const isPlexUser = user?.userType === UserType.PLEX;
           const canManageUsers = currentHasPermission(Permission.MANAGE_USERS);
@@ -280,7 +333,7 @@ const UserSettingsGeneral = () => {
               }
             }
 
-            await axios.post(
+            const response = await axios.post(
               `/api/v1/user/${user?.id}/settings/main`,
               submitData
             );
@@ -293,23 +346,53 @@ const UserSettingsGeneral = () => {
               );
             }
 
-            Toast({
-              title: intl.formatMessage({
-                id: 'common.saveSuccess',
-                defaultMessage: 'Settings saved successfully!',
-              }),
-              type: 'success',
-              icon: <CheckBadgeIcon className="size-7" />,
-              message:
-                isPlexUser &&
-                canManageUsers &&
-                (librariesChanged || shouldForceSync)
-                  ? intl.formatMessage({
-                      id: 'settings.librariesSynced',
-                      defaultMessage: 'Libraries have been synced with Plex.',
-                    })
-                  : undefined,
-            });
+            const plexSyncStatus = response.data?.plexSync;
+
+            if (plexSyncStatus === 'removed') {
+              Toast({
+                title: intl.formatMessage({
+                  id: 'settings.savedUserRemovedFromPlex',
+                  defaultMessage: 'Settings saved, but user not found in Plex.',
+                }),
+                message: intl.formatMessage({
+                  id: 'settings.savedUserRemovedFromPlexMessage',
+                  defaultMessage:
+                    'This user was removed from the Plex server and their account has been deactivated.',
+                }),
+                type: 'warning',
+                icon: <ExclamationTriangleIcon className="size-7" />,
+              });
+            } else if (plexSyncStatus === 'failed') {
+              Toast({
+                title: intl.formatMessage({
+                  id: 'settings.savedPlexSyncFailed',
+                  defaultMessage: 'Settings saved, but Plex sync failed.',
+                }),
+                message: intl.formatMessage({
+                  id: 'settings.savedPlexSyncFailedMessage',
+                  defaultMessage:
+                    'Your changes were saved, but they could not be synced with Plex.',
+                }),
+                type: 'warning',
+                icon: <ExclamationTriangleIcon className="size-7" />,
+              });
+            } else {
+              Toast({
+                title: intl.formatMessage({
+                  id: 'common.saveSuccess',
+                  defaultMessage: 'Settings saved successfully!',
+                }),
+                type: 'success',
+                icon: <CheckBadgeIcon className="size-7" />,
+                message:
+                  plexSyncStatus === 'synced'
+                    ? intl.formatMessage({
+                        id: 'settings.librariesSynced',
+                        defaultMessage: 'Libraries have been synced with Plex.',
+                      })
+                    : undefined,
+              });
+            }
           } catch (e) {
             Toast({
               title: intl.formatMessage({
@@ -351,10 +434,17 @@ const UserSettingsGeneral = () => {
                     <div className="flex max-w-lg items-center">
                       {!user?.active ? (
                         <Badge badgeType="error">
-                          <FormattedMessage
-                            id="common.expired"
-                            defaultMessage="Expired"
-                          />
+                          {user?.accessRevokedReason === 'plex_removed' ? (
+                            <FormattedMessage
+                              id="common.deactivated"
+                              defaultMessage="Deactivated"
+                            />
+                          ) : (
+                            <FormattedMessage
+                              id="common.expired"
+                              defaultMessage="Expired"
+                            />
+                          )}
                         </Badge>
                       ) : user?.userType === UserType.PLEX ? (
                         <Badge badgeType="warning">
@@ -530,6 +620,15 @@ const UserSettingsGeneral = () => {
                                     />
                                   </div>
                                 )}
+                              {userRemovedFromPlex && (
+                                <div className="mt-2 text-sm text-warning">
+                                  <ExclamationTriangleIcon className="inline h-5 w-5 mr-1" />
+                                  <FormattedMessage
+                                    id="settings.userRemovedFromPlexWarning"
+                                    defaultMessage="This user was removed from the Plex server and their account has been deactivated. You can reinvite them below."
+                                  />
+                                </div>
+                              )}
                             </>
                           )}
                         </div>
@@ -728,6 +827,7 @@ const UserSettingsGeneral = () => {
                     </>
                   )}
                 {user?.userType === UserType.PLEX &&
+                  user?.active &&
                   (user?.id === currentUser.id ||
                     (currentHasPermission(Permission.MANAGE_USERS) &&
                       !hasPermission(Permission.MANAGE_USERS))) && (
@@ -1190,6 +1290,32 @@ const UserSettingsGeneral = () => {
               </div>
               <div className="divider divider-primary mb-0 col-span-full" />
               <div className="flex justify-end col-span-3 mt-4">
+                {showReactivate && (
+                  <span className="inline-flex rounded-md shadow-sm">
+                    <Button
+                      buttonType="accent"
+                      buttonSize="sm"
+                      type="button"
+                      disabled={isReactivating}
+                      onClick={() => reactivateUser()}
+                    >
+                      <PaperAirplaneIcon className="size-4 mr-2" />
+                      <span>
+                        {isReactivating ? (
+                          <FormattedMessage
+                            id="settings.reinviting"
+                            defaultMessage="Reinviting…"
+                          />
+                        ) : (
+                          <FormattedMessage
+                            id="settings.reinvite"
+                            defaultMessage="Reinvite"
+                          />
+                        )}
+                      </span>
+                    </Button>
+                  </span>
+                )}
                 <span className="ml-3 inline-flex rounded-md shadow-sm">
                   <Button
                     buttonType="primary"

--- a/src/components/UserProfile/index.tsx
+++ b/src/components/UserProfile/index.tsx
@@ -21,6 +21,7 @@ import ProgressCircle from '@app/components/Common/ProgressCircle';
 import Slider from '@app/components/Common/Slider';
 import RecentInvite from '@app/components/Common/Slider/RecentInvite';
 import { FormattedMessage } from 'react-intl';
+import { useEffect } from 'react';
 import RecentNotification from '@app/components/Common/Slider/RecentNotification';
 import RecentlyWatched from '@app/components/Common/Slider/RecentlyWatched';
 import useSettings from '@app/hooks/useSettings';
@@ -40,10 +41,30 @@ const Placeholder = () => {
 const UserProfile = () => {
   const { currentSettings } = useSettings();
   const userQuery = useParams<{ userid: string }>();
-  const { user, error, hasPermission } = useUser({
+  const {
+    user,
+    error,
+    hasPermission,
+    revalidate: revalidateUser,
+  } = useUser({
     id: Number(userQuery.userid),
   });
   const { user: currentUser, hasPermission: currentHasPermission } = useUser();
+  const { data: plexShareCheck } = useSWR<{ existsInPlex?: boolean }>(
+    user?.userType === UserType.PLEX &&
+      user?.id !== 1 &&
+      currentHasPermission(Permission.MANAGE_USERS) &&
+      !hasPermission(Permission.MANAGE_USERS)
+      ? `/api/v1/user/${user?.id}/plex/libraries`
+      : null,
+    { revalidateOnFocus: false }
+  );
+
+  useEffect(() => {
+    if (plexShareCheck?.existsInPlex === false && user?.active) {
+      revalidateUser();
+    }
+  }, [plexShareCheck?.existsInPlex, user?.active, revalidateUser]);
   const { data: notificationSettings } =
     useSWR<UserSettingsNotificationsResponse>(
       currentUser
@@ -70,6 +91,8 @@ const UserProfile = () => {
       ? `/api/v1/user/${user.id}/quota`
       : null
   );
+
+  const isTrialExpiry = user?.accessRevokedReason !== 'plex_removed';
 
   const { data: notifications, error: notificationError } =
     useSWR<UserNotificationsResponse>(
@@ -205,7 +228,8 @@ const UserProfile = () => {
           {currentSettings.enableSignUp ? (
             quota ? (
               <>
-                {quota.invite.trialPeriodActive &&
+                {user.active &&
+                quota.invite.trialPeriodActive &&
                 quota.invite.trialPeriodEnabled ? (
                   <div className="overflow-hidden rounded-lg bg-yellow-900/30 backdrop-blur px-4 py-5 shadow ring-1 ring-yellow-500 sm:p-6">
                     <dt className="truncate text-sm font-bold text-yellow-300 flex items-center">
@@ -232,20 +256,67 @@ const UserProfile = () => {
                 ) : !user.active ? (
                   <div className="overflow-hidden xl:col-span-2 rounded-lg bg-red-900/30 backdrop-blur px-4 py-5 shadow ring-1 ring-red-500 sm:p-6">
                     <dt className="truncate text-sm font-bold text-red-300 flex items-center">
-                      <FormattedMessage
-                        id="common.accountExpired"
-                        defaultMessage="Account Expired"
-                      />
+                      {isTrialExpiry ? (
+                        <FormattedMessage
+                          id="common.accountExpired"
+                          defaultMessage="Account Expired"
+                        />
+                      ) : (
+                        <FormattedMessage
+                          id="common.accountDeactivated"
+                          defaultMessage="Account Deactivated"
+                        />
+                      )}
                     </dt>
                     <dd className="mt-1 text-sm font-semibold text-red-200">
                       {user?.id !== currentUser?.id ? (
+                        isTrialExpiry ? (
+                          <FormattedMessage
+                            id="profile.accountExpiredMessageAdmin"
+                            defaultMessage="This user's account has expired. {trialPeriodEnabled, select, true {Extend by setting a new trial period {link}.} other {Enable trial periods again to extend access.}}"
+                            values={{
+                              link: (
+                                <Link
+                                  href={`/admin/users/${user.id}/settings`}
+                                  className="font-bold underline hover:text-red-300"
+                                >
+                                  <FormattedMessage
+                                    id="common.here"
+                                    defaultMessage="here"
+                                  />
+                                </Link>
+                              ),
+                              trialPeriodEnabled:
+                                quota.invite.trialPeriodEnabled ?? false,
+                            }}
+                          />
+                        ) : (
+                          <FormattedMessage
+                            id="profile.accountDeactivatedMessageAdmin"
+                            defaultMessage="This user's account has been deactivated. You can reactivate them from their settings {link}."
+                            values={{
+                              link: (
+                                <Link
+                                  href={`/admin/users/${user.id}/settings`}
+                                  className="font-bold underline hover:text-red-300"
+                                >
+                                  <FormattedMessage
+                                    id="common.here"
+                                    defaultMessage="here"
+                                  />
+                                </Link>
+                              ),
+                            }}
+                          />
+                        )
+                      ) : isTrialExpiry ? (
                         <FormattedMessage
-                          id="profile.accountExpiredMessageAdmin"
-                          defaultMessage="This user's account has expired. {trialPeriodEnabled, select, true {Extend by setting a new trial period {link}.} other {Enable trial periods again to extend access.}}"
+                          id="profile.accountExpiredMessage"
+                          defaultMessage="Your account access has expired. {trialPeriodEnabled, select, true {You can request an extension {link}.} other {Contact an administrator to extend your access.}}"
                           values={{
                             link: (
                               <Link
-                                href={`/admin/users/${user.id}/settings`}
+                                href="/profile/settings"
                                 className="font-bold underline hover:text-red-300"
                               >
                                 <FormattedMessage
@@ -260,8 +331,8 @@ const UserProfile = () => {
                         />
                       ) : (
                         <FormattedMessage
-                          id="profile.accountExpiredMessage"
-                          defaultMessage="Your account access has expired. {trialPeriodEnabled, select, true {You can request an extension {link}.} other {Contact an administrator to extend your access.}}"
+                          id="profile.accountDeactivatedMessage"
+                          defaultMessage="Your account has been deactivated. {trialPeriodEnabled, select, true {You can request an access extension {link}.} other {Contact an administrator to restore your access.}}"
                           values={{
                             link: (
                               <Link

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -21,6 +21,7 @@ export interface User {
   updatedAt: Date;
   active?: boolean;
   accessRevokedAt?: Date | null;
+  accessRevokedReason?: 'trial_expired' | 'plex_removed' | null;
   inviteQuotaLimit?: number;
   inviteQuotaDays?: number;
   inviteCount?: number;

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -215,6 +215,9 @@
   "common.about": {
     "defaultMessage": "About"
   },
+  "common.accountDeactivated": {
+    "defaultMessage": "Account Deactivated"
+  },
   "common.accountExpired": {
     "defaultMessage": "Account Expired"
   },
@@ -325,6 +328,9 @@
   },
   "common.deactivate": {
     "defaultMessage": "Deactivate"
+  },
+  "common.deactivated": {
+    "defaultMessage": "Deactivated"
   },
   "common.declined": {
     "defaultMessage": "Declined"
@@ -1256,8 +1262,11 @@
   "expiredAccess.accountSettings": {
     "defaultMessage": "Account Settings"
   },
+  "expiredAccess.deactivatedTitle": {
+    "defaultMessage": "Account Deactivated"
+  },
   "expiredAccess.message": {
-    "defaultMessage": "Your account is currently expired. You can still access your profile and settings{isTrialEnabled, select, true { including trial extension request options.} other {. Please contact an administrator to reactivate your access.}}"
+    "defaultMessage": "Your account is currently {state, select, true {expired} other {deactivated}}. You can still access your profile and settings{isTrialEnabled, select, true { including trial extension request options.} other {. Please contact an administrator to reactivate your access.}}"
   },
   "expiredAccess.signOut": {
     "defaultMessage": "Sign Out"
@@ -3896,6 +3905,12 @@
   "notification.open": {
     "defaultMessage": "Open Notifications"
   },
+  "notification.plexAccessLost": {
+    "defaultMessage": "Plex Access Removed"
+  },
+  "notification.plexAccessLost.description": {
+    "defaultMessage": "Get notified when a user is removed from the Plex server and deactivated"
+  },
   "notification.readAllError": {
     "defaultMessage": "Error marking all notifications as read"
   },
@@ -4363,6 +4378,12 @@
   },
   "plexSettings.title": {
     "defaultMessage": "Plex Settings"
+  },
+  "profile.accountDeactivatedMessage": {
+    "defaultMessage": "Your account has been deactivated. {trialPeriodEnabled, select, true {You can request an access extension {link}.} other {Contact an administrator to restore your access.}}"
+  },
+  "profile.accountDeactivatedMessageAdmin": {
+    "defaultMessage": "This user's account has been deactivated. You can reactivate them from their settings {link}."
   },
   "profile.accountExpiredMessage": {
     "defaultMessage": "Your account access has expired. {trialPeriodEnabled, select, true {You can request an extension {link}.} other {Contact an administrator to extend your access.}}"
@@ -4985,6 +5006,21 @@
   "settings.plexAccessDescription": {
     "defaultMessage": "Changes will sync with Plex automatically on save."
   },
+  "settings.reinvite": {
+    "defaultMessage": "Reinvite"
+  },
+  "settings.reinviteError": {
+    "defaultMessage": "Failed to reinvite user."
+  },
+  "settings.reinviteFailed": {
+    "defaultMessage": "The Plex invite failed and the user remains deactivated."
+  },
+  "settings.reinviteSuccess": {
+    "defaultMessage": "User reinvited successfully!"
+  },
+  "settings.reinviting": {
+    "defaultMessage": "Reinviting…"
+  },
   "settings.restartRequired.failed": {
     "defaultMessage": "Restart failed. Please restart the server manually."
   },
@@ -4996,6 +5032,18 @@
   },
   "settings.saveError": {
     "defaultMessage": "Something went wrong while saving settings."
+  },
+  "settings.savedPlexSyncFailed": {
+    "defaultMessage": "Settings saved, but Plex sync failed."
+  },
+  "settings.savedPlexSyncFailedMessage": {
+    "defaultMessage": "Your changes were saved, but they could not be synced with Plex."
+  },
+  "settings.savedUserRemovedFromPlex": {
+    "defaultMessage": "Settings saved, but user not found in Plex."
+  },
+  "settings.savedUserRemovedFromPlexMessage": {
+    "defaultMessage": "This user was removed from the Plex server and their account has been deactivated."
   },
   "settings.trialPeriod": {
     "defaultMessage": "Trial Period"
@@ -5014,6 +5062,9 @@
   },
   "settings.user.resetOnboarding": {
     "defaultMessage": "Reset Onboarding"
+  },
+  "settings.userRemovedFromPlexWarning": {
+    "defaultMessage": "This user was removed from the Plex server and their account has been deactivated. You can reinvite them below."
   },
   "settingsBadge.advanced.tooltip": {
     "defaultMessage": "Incorrectly configuring this setting may result in broken functionality"

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -5932,6 +5932,10 @@ paths:
                   username:
                     type: string
                     example: 'Mr User'
+                  plexSync:
+                    type: string
+                    enum: [synced, removed, failed, skipped]
+                    description: Outcome of the Plex library sync attempted during save. `removed` means the user was not found in Plex and has been deactivated.
   /user/{userId}/settings/extension:
     post:
       summary: Request access extension
@@ -5981,6 +5985,10 @@ paths:
                   canFetchFromPlex:
                     type: boolean
                     description: Whether the system can fetch from Plex (false for non-Plex users)
+                  existsInPlex:
+                    type: boolean
+                    nullable: true
+                    description: False when the user is definitively absent from the Plex server's shared users list (omitted when verification was not possible)
                   permissions:
                     type: object
                     nullable: true
@@ -6232,6 +6240,61 @@ paths:
                   permissions:
                     type: number
                     example: 2
+  /user/{userId}/settings/reinvite:
+    post:
+      summary: Reactivate a deactivated user and re-invite them to Plex
+      description: |
+        Reactivates a deactivated Plex user and sends a new Plex invite using
+        their existing settings (shared libraries, downloads, and Plex Home).
+
+        The Plex invite is attempted first; if it fails, the user is left
+        unchanged (deactivated) and the response reports `plexInvite: failed`.
+        On success this endpoint:
+        - Sets the user back to active and clears their access revocation
+          date and reason
+        - Clears an already-expired trial period so the trial expiry job does
+          not immediately re-deactivate the user (a future trial is left untouched)
+        - Clears any pending access extension request
+        - Restores default Seerr permissions when Seerr is configured
+
+        Requires `MANAGE_USERS` permission. Cannot be used on yourself, the
+        owner, or non-Plex users.
+      tags:
+        - users
+      parameters:
+        - in: path
+          name: userId
+          required: true
+          schema:
+            type: number
+          description: User ID to reactivate
+      responses:
+        '200':
+          description: User reactivated; includes the Plex invite outcome
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  active:
+                    type: boolean
+                    example: true
+                  plexInvite:
+                    type: string
+                    enum: [invited, failed]
+                    description: Whether the Plex invite was sent successfully. When `failed`, the user remains deactivated.
+                  plexInviteError:
+                    type: string
+                    nullable: true
+                    description: Error message when the Plex invite failed
+        '400':
+          description: Bad request (already active, owner, or non-Plex user)
+        '403':
+          description: Forbidden - user lacks permission
+        '404':
+          description: User not found
+        '500':
+          description: Server error during reactivation
   /user/{userId}/settings/pin-libraries:
     post:
       summary: Pin libraries to user's Plex home screen


### PR DESCRIPTION
## Description
When a user was removed from the Plex server's shared list but still existed in Streamarr, the app had no awareness of it:
- The user's profile and settings showed no indication; their shared libraries displayed as if access was intact
- Saving library changes reported **"Libraries have been synced with Plex"** even though the sync silently failed (`User not found in Plex shared users list` was logged and swallowed)
- The user couldn't sign in and only saw a generic *"Login failed! Something went wrong"*
- An already-signed-in user could keep browsing indefinitely, since nothing re-validated Plex membership after login
- Admins were never notified

### What this does

**Detection.** A removed user is now detected and deactivated through five paths, all funneling into a single idempotent handler:
1. Admin views the user's profile or settings page
2. The user attempts to sign in (Plex OAuth **and** local password)
3. An admin saves the user's settings (sync failure is now typed via `PlexUserNotFoundError`)
4. A new **Plex Membership Check** job (default: every 15 min, configurable in Settings → Jobs) validates *all* active Plex users in a single plex.tv call — covering idle, logged-in sessions
5. Legacy backstop: the daily expiry flow

Detection only ever fires on a **definitive** "not in shared list" result. Transport errors, token problems, and suspiciously empty plex.tv responses never deactivate anyone.

**Deactivation.** The handler sets `active = false`, stamps a new `accessRevokedReason = 'plex_removed'` column, clears the now-moot trial period, revokes Seerr permissions, and notifies admins (new `PLEX_ACCESS_LOST` notification type for users with `MANAGE_USERS`, with email template) — exactly once per removal. Once inactive, the existing middleware restricts the user's live session to profile/settings on their next request.

**User experience.** Removed users can sign in to a restricted profile (matching trial-deactivation behavior) and see a new **"Account Deactivated"** modal/profile card explaining their access was removed — distinct from the trial-expiry **"Account Expired"** wording. They can still submit an access extension request; the admin notification now reads *"Account Deactivated: \<date removed\>"* instead of a misleading future trial date.

**Admin experience.** The settings page shows a warning under Plex Access, the user list and Account Type badges distinguish **Deactivated** vs **Expired**, and a new **Reinvite** button (+ `POST /user/{id}/settings/reinvite`) re-invites the user with their existing libraries, downloads, and Plex Home settings. The invite is attempted *first* — on failure the user is left unchanged and the response reports `plexInvite: failed`, so a failed reinvite can't trigger a spurious second removal notification. On success the user is reactivated, expired trials and pending extension requests are cleared, and Seerr permissions are restored.

**Honest sync reporting.** The settings save endpoint now returns the actual Plex outcome (`plexSync: synced | removed | failed | skipped`) and the toast reflects it instead of unconditionally claiming success.

### Schema change

Adds a nullable `accessRevokedReason` column to `user` (`'trial_expired' | 'plex_removed'`), set by both deactivation flows and cleared on every reactivation path. This replaces date-based inference, which was unreliable in both directions (a removed user's lapsed trial date read as "expired"; a genuine expiry cleared the date and read as "deactivated"). Pre-existing deactivated rows have a `null` reason and render as **Expired**, preserving prior behavior.

### Misc

- `expiredAccess` modal and notification copy are cause-aware via ICU selects
- Membership job logs outcomes only (no per-run heartbeat at the 15-min cadence); job exposes running state and cancel in the Jobs UI
- Auto-accept no longer warns "user must accept manually" when Plex already auto-accepted a re-share for a previously connected account
- Seerr "user not found" during revoke/restore is no longer logged as an error
- Per-recipient notification dispatch logs demoted to debug (one info line per notification)
- New `accent` button type; API spec updated for the new/changed endpoints

## Issues Resolved
- Fixes #398 

## Has This Been Tested?


- [x] Remove a user (with a future *promote* trial) in Plex → deactivated within one job interval or on first admin view/sign-in; shows **Deactivated** (not Expired) everywhere; trial cleared; admins notified once
- [x] Let a real trial expire → shows **Expired**; extension request notification says "Trial Ended: \<date\>"
- [x] Reinvite → invite arrives with prior libraries/permissions; extension badge clears; no follow-up removal notification
- [x] Reinvite during a Plex outage → error toast, user stays deactivated, retry works after recovery
- [x] Removed user signs in (OAuth + password) → lands on restricted profile with the deactivated modal
- [x] Simulate plex.tv outage → sign-ins 403 but **no one is deactivated**
- [x] Existing DB: migration applies; legacy inactive users still show Expired

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
