### PR TITLE
feat(users): allow bulk editing of shared libraries

### DIFF
--- a/docs/using-streamarr/users/README.md
+++ b/docs/using-streamarr/users/README.md
@@ -75,6 +75,17 @@ If the user is a Plex Home member, library access is managed through Plex Home. 
 
 Pin selected libraries to the user's Plex sidebar so they appear prominently when the user opens Plex.
 
+### Bulk Editing Users
+
+Select multiple users in the user list and click **Bulk Edit** to apply changes to all selected users at once. The bulk edit dialog has two tabs:
+
+- **Permissions** — Replace the permissions of all selected users. See [Permissions](#permissions) below.
+- **Plex Access** — Set shared library access (Server Default, All Libraries, or specific libraries), **Allow Downloads**, and **Allow Live TV Access** for all selected users. Leave the library selection empty or a toggle in its middle "No change" position to keep the users' current values; chosen fields sync with Plex automatically on save.
+
+{% hint style="info" %}
+Plex access changes only sync for active Plex users. Local users have the settings saved but are not synced. Live TV access only controls the Live TV menu within Streamarr and is never synced with Plex. If a selected user can no longer be found on the Plex server, their account is deactivated automatically — see [Removed from Plex](#removed-from-plex).
+{% endhint %}
+
 ### Deleting Users
 
 Admins can delete users from the user list or user settings page.

--- a/server/interfaces/api/userInterfaces.ts
+++ b/server/interfaces/api/userInterfaces.ts
@@ -13,6 +13,17 @@ export interface UserResultsResponse extends PaginatedResponse {
   results: User[];
 }
 
+export interface UserBulkUpdatePlexSyncSummary {
+  synced: number;
+  failed: number;
+  removed: number;
+}
+
+export interface UserBulkUpdateResponse {
+  users: Partial<User>[];
+  plexSync?: UserBulkUpdatePlexSyncSummary;
+}
+
 export interface UserInvitesResponse extends PaginatedResponse {
   results: Invite[];
 }

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -16,6 +16,7 @@ import type {
   UserInvitesResponse,
   UserResultsResponse,
   UserSummary,
+  UserBulkUpdateResponse,
 } from '@server/interfaces/api/userInterfaces';
 import { getAdminPlexToken } from '@server/lib/adminPlexToken';
 import { hasPermission, Permission } from '@server/lib/permissions';
@@ -33,9 +34,16 @@ import path from 'path';
 import crypto from 'crypto';
 import Invite from '@server/entity/Invite';
 import Notification from '@server/entity/Notification';
-import { plexSync } from '@server/lib/plexSync';
+import { plexSync, PlexUserNotFoundError } from '@server/lib/plexSync';
 import { handlePlexAccessLost } from '@server/lib/plexAccessLost';
 import { isOwnProfileOrAdmin } from '@server/utils/profileMiddleware';
+import { UserSettings } from '@server/entity/UserSettings';
+import {
+  isDefaultSentinel,
+  materializeDefaultSnapshot,
+  normalizeSharedLibrariesValue,
+  resolveSharedLibraryKeys,
+} from '@server/utils/sharedLibraries';
 
 const router = Router();
 
@@ -525,17 +533,77 @@ export const canMakePermissionsChange = (
 
 router.put<
   Record<string, never>,
-  Partial<User>[],
-  { ids: string[]; permissions: number }
+  UserBulkUpdateResponse,
+  {
+    ids: string[];
+    permissions?: number;
+    sharedLibraries?: string;
+    allowDownloads?: boolean;
+    allowLiveTv?: boolean;
+  }
 >('/', isAuthenticated(Permission.MANAGE_USERS), async (req, res, next) => {
   try {
     const isOwner = req.user?.id === 1;
+    const { permissions, sharedLibraries, allowDownloads, allowLiveTv } =
+      req.body;
 
-    if (!canMakePermissionsChange(req.body.permissions, req.user)) {
+    if (!Array.isArray(req.body.ids) || req.body.ids.length === 0) {
+      return next({
+        status: 400,
+        message: 'You must provide at least one user id.',
+      });
+    }
+
+    if (
+      permissions === undefined &&
+      sharedLibraries === undefined &&
+      allowDownloads === undefined &&
+      allowLiveTv === undefined
+    ) {
+      return next({
+        status: 400,
+        message:
+          'You must provide permissions, sharedLibraries, allowDownloads, or allowLiveTv to update.',
+      });
+    }
+
+    if (
+      permissions !== undefined &&
+      !canMakePermissionsChange(permissions, req.user)
+    ) {
       return next({
         status: 403,
         message: 'You do not have permission to grant this level of access',
       });
+    }
+
+    const settings = getSettings();
+    const enabledLibraries = settings.plex.libraries.filter(
+      (lib) => lib.enabled
+    );
+
+    let newSharedLibraries: string | null = null;
+    if (sharedLibraries !== undefined) {
+      newSharedLibraries = isDefaultSentinel(sharedLibraries)
+        ? materializeDefaultSnapshot({
+            adminDefault: settings.main.sharedLibraries,
+            enabledLibraries,
+          })
+        : normalizeSharedLibrariesValue(sharedLibraries);
+
+      if (
+        resolveSharedLibraryKeys({
+          value: newSharedLibraries,
+          adminDefault: settings.main.sharedLibraries,
+          enabledLibraries,
+        }).length === 0
+      ) {
+        return next({
+          status: 400,
+          message:
+            'The provided sharedLibraries value does not resolve to any enabled libraries.',
+        });
+      }
     }
 
     const userRepository = getRepository(User);
@@ -548,16 +616,119 @@ router.put<
       },
     });
 
-    const updatedUsers = await Promise.all(
+    const saveResults = await Promise.allSettled(
       users.map(async (user) => {
-        return userRepository.save(<User>{
-          ...user,
-          ...{ permissions: req.body.permissions },
-        });
+        if (permissions !== undefined) {
+          user.permissions = permissions;
+        }
+
+        if (sharedLibraries !== undefined) {
+          if (!user.settings) {
+            user.settings = new UserSettings({
+              user: { id: user.id } as User,
+              sharedLibraries: newSharedLibraries,
+            });
+          } else {
+            user.settings.sharedLibraries = newSharedLibraries;
+          }
+        }
+
+        if (allowDownloads !== undefined || allowLiveTv !== undefined) {
+          if (!user.settings) {
+            user.settings = new UserSettings({
+              // Reference by id to keep the response JSON-serializable
+              user: { id: user.id } as User,
+            });
+          }
+          if (allowDownloads !== undefined) {
+            user.settings.allowDownloads = allowDownloads;
+          }
+          if (allowLiveTv !== undefined) {
+            user.settings.allowLiveTv = allowLiveTv;
+          }
+        }
+
+        return userRepository.save(user);
       })
     );
 
-    res.status(200).json(updatedUsers);
+    saveResults.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        logger.error('Failed to save bulk user update', {
+          label: 'API',
+          userId: users[index].id,
+          error:
+            result.reason instanceof Error
+              ? result.reason.message
+              : String(result.reason),
+        });
+      }
+    });
+
+    const updatedUsers = saveResults
+      .filter(
+        (result): result is PromiseFulfilledResult<User> =>
+          result.status === 'fulfilled'
+      )
+      .map((result) => result.value);
+
+    if (updatedUsers.length === 0) {
+      return next({
+        status: 500,
+        message: 'Failed to save changes for the selected users.',
+      });
+    }
+
+    // Sync the new library access with Plex, a few users at a time to
+    // avoid hammering plex.tv under the single admin token
+    let plexSyncSummary: UserBulkUpdateResponse['plexSync'];
+    if (sharedLibraries !== undefined || allowDownloads !== undefined) {
+      const summary = { synced: 0, failed: 0, removed: 0 };
+      const queue = updatedUsers.filter(
+        (user) => user.userType === UserType.PLEX && user.active && user.email
+      );
+
+      const BULK_PLEX_SYNC_CONCURRENCY = 3;
+      await Promise.all(
+        Array.from(
+          { length: Math.min(BULK_PLEX_SYNC_CONCURRENCY, queue.length) },
+          async () => {
+            let user: User | undefined;
+            while ((user = queue.shift())) {
+              try {
+                // When libraries weren't part of this edit, re-apply the
+                // user's current value; omitted values stay unchanged on Plex
+                await plexSync.syncUserLibraries(
+                  user,
+                  sharedLibraries !== undefined
+                    ? newSharedLibraries
+                    : (user.settings?.sharedLibraries ?? null),
+                  { allowSync: allowDownloads }
+                );
+                summary.synced++;
+              } catch (e) {
+                if (e instanceof PlexUserNotFoundError) {
+                  // The user was removed from Plex out-of-band
+                  await handlePlexAccessLost(user);
+                  summary.removed++;
+                } else {
+                  summary.failed++;
+                }
+                logger.error('Failed to sync user libraries with Plex', {
+                  label: 'Plex Sync',
+                  userId: user.id,
+                  email: user.email,
+                  error: e instanceof Error ? e.message : String(e),
+                });
+              }
+            }
+          }
+        )
+      );
+      plexSyncSummary = summary;
+    }
+
+    res.status(200).json({ users: updatedUsers, plexSync: plexSyncSummary });
   } catch (e) {
     next({ status: 500, message: e.message });
   }

--- a/src/components/Admin/Users/BulkEditModal.tsx
+++ b/src/components/Admin/Users/BulkEditModal.tsx
@@ -1,13 +1,24 @@
 'use client';
 import Modal from '@app/components/Common/Modal';
+import Toggle from '@app/components/Common/Toggle';
+import LibrarySelector from '@app/components/LibrarySelector';
 import PermissionEdit from '@app/components/Admin/PermissionEdit';
 import type { User } from '@app/hooks/useUser';
-import { useUser } from '@app/hooks/useUser';
+import { Permission, useUser } from '@app/hooks/useUser';
+import type { UserBulkUpdatePlexSyncSummary } from '@server/interfaces/api/userInterfaces';
+import type { MainSettings } from '@server/lib/settings';
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import Toast from '@app/components/Toast';
-import { CheckBadgeIcon, XCircleIcon } from '@heroicons/react/24/solid';
-import { useIntl } from 'react-intl';
+import {
+  CheckBadgeIcon,
+  ExclamationTriangleIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/solid';
+import { FormattedMessage, useIntl } from 'react-intl';
+import useSWR from 'swr';
+
+type BulkEditTab = 'permissions' | 'libraries';
 
 interface BulkEditProps {
   selectedUserIds: number[];
@@ -26,10 +37,25 @@ const BulkEditModal = ({
   onComplete,
   onSaving,
 }: BulkEditProps) => {
-  const { user: currentUser } = useUser();
+  const { user: currentUser, hasPermission: currentHasPermission } = useUser();
   const intl = useIntl();
+  const [activeTab, setActiveTab] = useState<BulkEditTab>('permissions');
   const [currentPermission, setCurrentPermission] = useState(0);
+  const [currentSharedLibraries, setCurrentSharedLibraries] =
+    useState('unchanged');
+  const [currentAllowDownloads, setCurrentAllowDownloads] = useState<
+    boolean | null
+  >(null);
+  const [currentAllowLiveTv, setCurrentAllowLiveTv] = useState<boolean | null>(
+    null
+  );
   const [isSaving, setIsSaving] = useState(false);
+
+  const { data: mainSettings } = useSWR<MainSettings>(
+    show && currentHasPermission(Permission.ADMIN)
+      ? '/api/v1/settings/main'
+      : null
+  );
 
   useEffect(() => {
     if (onSaving) {
@@ -37,30 +63,115 @@ const BulkEditModal = ({
     }
   }, [isSaving, onSaving]);
 
+  const plexAccessPayload = {
+    ...(currentSharedLibraries !== 'unchanged' && {
+      sharedLibraries:
+        currentSharedLibraries === '' ? 'server' : currentSharedLibraries,
+    }),
+    ...(currentAllowDownloads !== null && {
+      allowDownloads: currentAllowDownloads,
+    }),
+    ...(currentAllowLiveTv !== null && {
+      allowLiveTv: currentAllowLiveTv,
+    }),
+  };
+  const hasPlexAccessChanges = Object.keys(plexAccessPayload).length > 0;
+
   const updateUsers = async () => {
     try {
       setIsSaving(true);
-      const { data: updated } = await axios.put<User[]>(`/api/v1/user`, {
-        ids: selectedUserIds,
-        permissions: currentPermission,
-      });
+      const { data } = await axios.put<{
+        users: User[];
+        plexSync?: UserBulkUpdatePlexSyncSummary;
+      }>(
+        `/api/v1/user`,
+        activeTab === 'permissions'
+          ? {
+              ids: selectedUserIds,
+              permissions: currentPermission,
+            }
+          : {
+              ids: selectedUserIds,
+              ...plexAccessPayload,
+            }
+      );
       if (onComplete) {
-        onComplete(updated);
+        onComplete(data.users);
       }
-      Toast({
-        title: intl.formatMessage({
-          id: 'userPermissions.success',
-          defaultMessage: 'User permissions saved successfully!',
-        }),
-        type: 'success',
-        icon: <CheckBadgeIcon className="size-7" />,
-      });
+      if (activeTab === 'permissions') {
+        Toast({
+          title: intl.formatMessage({
+            id: 'userPermissions.success',
+            defaultMessage: 'User permissions saved successfully!',
+          }),
+          type: 'success',
+          icon: <CheckBadgeIcon className="size-7" />,
+        });
+      } else if (data.plexSync?.removed) {
+        Toast({
+          title: intl.formatMessage({
+            id: 'userLibraries.savedUsersRemovedFromPlex',
+            defaultMessage:
+              'Settings saved, but some users were not found in Plex.',
+          }),
+          message: intl.formatMessage(
+            {
+              id: 'userLibraries.savedUsersRemovedFromPlexMessage',
+              defaultMessage:
+                '{count, plural, one {# user was} other {# users were}} removed from the Plex server and {count, plural, one {has} other {have}} been deactivated.',
+            },
+            { count: data.plexSync.removed }
+          ),
+          type: 'warning',
+          icon: <ExclamationTriangleIcon className="size-7" />,
+        });
+      } else if (data.plexSync?.failed) {
+        Toast({
+          title: intl.formatMessage({
+            id: 'userLibraries.savedPlexSyncFailed',
+            defaultMessage: 'Settings saved, but Plex sync failed.',
+          }),
+          message: intl.formatMessage(
+            {
+              id: 'userLibraries.savedPlexSyncFailedMessage',
+              defaultMessage:
+                'Changes were saved, but {count, plural, one {# user} other {# users}} could not be synced with Plex.',
+            },
+            { count: data.plexSync.failed }
+          ),
+          type: 'warning',
+          icon: <ExclamationTriangleIcon className="size-7" />,
+        });
+      } else {
+        Toast({
+          title: intl.formatMessage({
+            id: 'userLibraries.success',
+            defaultMessage: 'Plex access settings saved successfully!',
+          }),
+          message: data.plexSync?.synced
+            ? intl.formatMessage({
+                id: 'userLibraries.syncedWithPlex',
+                defaultMessage: 'Changes have been synced with Plex.',
+              })
+            : undefined,
+          type: 'success',
+          icon: <CheckBadgeIcon className="size-7" />,
+        });
+      }
     } catch {
       Toast({
-        title: intl.formatMessage({
-          id: 'userPermissions.error',
-          defaultMessage: 'Something went wrong while saving user permissions.',
-        }),
+        title:
+          activeTab === 'permissions'
+            ? intl.formatMessage({
+                id: 'userPermissions.error',
+                defaultMessage:
+                  'Something went wrong while saving user permissions.',
+              })
+            : intl.formatMessage({
+                id: 'userLibraries.error',
+                defaultMessage:
+                  'Something went wrong while saving Plex access settings.',
+              }),
         type: 'error',
         icon: <XCircleIcon className="size-7" />,
       });
@@ -69,17 +180,23 @@ const BulkEditModal = ({
     }
   };
 
-  // Seed the editable permission from the selected users when the selection changes
+  // Seed the editable values when the selection changes or the modal opens
   const [prevUsers, setPrevUsers] = useState(users);
   const [prevSelectedUserIds, setPrevSelectedUserIds] =
     useState(selectedUserIds);
-  if (prevUsers !== users || prevSelectedUserIds !== selectedUserIds) {
+  const [prevShow, setPrevShow] = useState(show);
+  if (
+    prevUsers !== users ||
+    prevSelectedUserIds !== selectedUserIds ||
+    (show && !prevShow)
+  ) {
     setPrevUsers(users);
     setPrevSelectedUserIds(selectedUserIds);
+    setPrevShow(show);
     if (users) {
       const selectedUsers = users.filter((u) => selectedUserIds.includes(u.id));
       if (selectedUsers.length > 0) {
-        const { permissions: allPermissionsEqual } = selectedUsers.reduce(
+        const { permissions: seededPermissions } = selectedUsers.reduce(
           ({ permissions: aPerms }, { permissions: bPerms }) => {
             return {
               permissions: aPerms === bPerms ? aPerms : NaN,
@@ -87,23 +204,55 @@ const BulkEditModal = ({
           },
           { permissions: selectedUsers[0].permissions }
         );
-        if (allPermissionsEqual) {
-          setCurrentPermission(allPermissionsEqual);
-        }
+        // Seed only when all selected users share the same permissions
+        // (including 0); otherwise reset to avoid applying stale values
+        setCurrentPermission(
+          Number.isNaN(seededPermissions) ? 0 : seededPermissions
+        );
+        setActiveTab('permissions');
+        setCurrentSharedLibraries('unchanged');
+        setCurrentAllowDownloads(null);
+        setCurrentAllowLiveTv(null);
       }
     }
   }
+  if (prevShow !== show) {
+    setPrevShow(show);
+  }
+
+  const tabs: { id: BulkEditTab; title: React.ReactNode }[] = [
+    {
+      id: 'permissions',
+      title: (
+        <FormattedMessage
+          id="settings.permissions"
+          defaultMessage="Permissions"
+        />
+      ),
+    },
+    {
+      id: 'libraries',
+      title: (
+        <FormattedMessage
+          id="settings.plexAccess"
+          defaultMessage="Plex Access"
+        />
+      ),
+    },
+  ];
 
   return (
     <Modal
       title={intl.formatMessage({
-        id: 'userPermissions.title',
-        defaultMessage: 'Edit User Permissions',
+        id: 'users.bulkEditTitle',
+        defaultMessage: 'Bulk Edit Users',
       })}
       onOk={() => {
         updateUsers();
       }}
-      okDisabled={isSaving}
+      okDisabled={
+        isSaving || (activeTab === 'libraries' && !hasPlexAccessChanges)
+      }
       okText={intl.formatMessage({
         id: 'common.saveChanges',
         defaultMessage: 'Save Changes',
@@ -111,12 +260,101 @@ const BulkEditModal = ({
       onCancel={onCancel}
       show={show}
     >
-      <div className="mb-6">
-        <PermissionEdit
-          actingUser={currentUser}
-          currentPermission={currentPermission}
-          onUpdate={(newPermission) => setCurrentPermission(newPermission)}
-        />
+      <div
+        role="tablist"
+        className="tabs-border border-neutral border-b"
+        onKeyDown={(e) => {
+          if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') {
+            return;
+          }
+          e.preventDefault();
+          const currentIndex = tabs.findIndex((tab) => tab.id === activeTab);
+          const nextIndex =
+            (currentIndex + (e.key === 'ArrowRight' ? 1 : -1) + tabs.length) %
+            tabs.length;
+          setActiveTab(tabs[nextIndex].id);
+          document
+            .getElementById(`bulk-edit-tab-${tabs[nextIndex].id}`)
+            ?.focus();
+        }}
+      >
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            onClick={(e) => {
+              e.preventDefault();
+              setActiveTab(tab.id);
+            }}
+            id={`bulk-edit-tab-${tab.id}`}
+            data-testid={`bulk-edit-tab-${tab.id}`}
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            aria-controls="bulk-edit-tabpanel"
+            tabIndex={activeTab === tab.id ? 0 : -1}
+            className={`tab [--tab-color:black] h-fit w-fit py-2 font-bold${activeTab === tab.id ? ' tab-active border-primary! text-primary' : ''}`}
+          >
+            {tab.title}
+          </button>
+        ))}
+      </div>
+      <div
+        id="bulk-edit-tabpanel"
+        className="my-6 flex flex-col gap-4"
+        role="tabpanel"
+        aria-labelledby={`bulk-edit-tab-${activeTab}`}
+      >
+        {activeTab === 'permissions' ? (
+          <PermissionEdit
+            actingUser={currentUser}
+            currentPermission={currentPermission}
+            onUpdate={(newPermission) => setCurrentPermission(newPermission)}
+          />
+        ) : (
+          <>
+            <p className="mb-2 text-sm">
+              <FormattedMessage
+                id="users.bulkEditLibrariesDescription"
+                defaultMessage="Changes will be applied to all selected users and synced with Plex automatically on save. Fields left unchanged are not modified. Local users will be updated but not synced."
+              />
+            </p>
+            <LibrarySelector
+              value={currentSharedLibraries}
+              serverValue={mainSettings?.sharedLibraries}
+              isUserSettings
+              allowUnchanged
+              setFieldValue={(_property, value) =>
+                setCurrentSharedLibraries(value)
+              }
+            />
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+              <Toggle
+                triState
+                id="bulkAllowDownloads"
+                valueOf={currentAllowDownloads}
+                onChange={setCurrentAllowDownloads}
+                title={
+                  <FormattedMessage
+                    id="invite.allowDownloads"
+                    defaultMessage="Allow Downloads"
+                  />
+                }
+              />
+              <Toggle
+                triState
+                id="bulkAllowLiveTv"
+                valueOf={currentAllowLiveTv}
+                onChange={setCurrentAllowLiveTv}
+                title={
+                  <FormattedMessage
+                    id="settings.allowLiveTv"
+                    defaultMessage="Allow Live TV Access"
+                  />
+                }
+              />
+            </div>
+          </>
+        )}
       </div>
     </Modal>
   );

--- a/src/components/Common/Toggle/index.tsx
+++ b/src/components/Common/Toggle/index.tsx
@@ -1,62 +1,187 @@
-import { XMarkIcon, CheckIcon } from '@heroicons/react/24/solid';
+import { CheckIcon, MinusIcon, XMarkIcon } from '@heroicons/react/24/solid';
+import { useIntl } from 'react-intl';
 
 interface ToggleProps {
   id: string;
-  valueOf: boolean;
-  onClick: () => void;
+  /** true = enabled, false = disabled, null = no change (triState only) */
+  valueOf: boolean | null;
+  onClick?: () => void;
+  /** Called with the chosen state when triState is enabled */
+  onChange?: (value: boolean | null) => void;
+  /** Renders a three-position toggle (left = disabled, middle = no
+   * change, right = enabled). With a mouse, click a third of the track
+   * to jump straight to that state; on touch, tap a half of the track
+   * to step one state in that direction. Arrow keys also step. */
+  triState?: boolean;
   title?: React.ReactNode;
   ariaLabel?: string;
 }
 
-const Toggle = ({ id, valueOf, onClick, title, ariaLabel }: ToggleProps) => {
+const Toggle = ({
+  id,
+  valueOf,
+  onClick,
+  onChange,
+  triState = false,
+  title,
+  ariaLabel,
+}: ToggleProps) => {
+  const intl = useIntl();
+
+  const stateLabel =
+    valueOf === null
+      ? intl.formatMessage({
+          id: 'toggle.noChange',
+          defaultMessage: 'No change',
+        })
+      : valueOf
+        ? intl.formatMessage({
+            id: 'toggle.enabled',
+            defaultMessage: 'Enabled',
+          })
+        : intl.formatMessage({
+            id: 'toggle.disabled',
+            defaultMessage: 'Disabled',
+          });
+
+  const step = (direction: -1 | 1) => {
+    if (direction === -1) {
+      onChange?.(valueOf === true ? null : false);
+    } else {
+      onChange?.(valueOf === false ? null : true);
+    }
+  };
+
+  const handleClick = (e: React.MouseEvent<HTMLSpanElement>) => {
+    if (!triState) {
+      return onClick?.();
+    }
+    const rect = e.currentTarget.getBoundingClientRect();
+    const fraction = (e.clientX - rect.left) / rect.width;
+
+    // Precise pointers jump straight to the tapped third; coarse (touch)
+    // pointers step one state toward the tapped half instead, so the
+    // narrow middle zone never has to be hit directly with a thumb
+    const nativeEvent = e.nativeEvent as MouseEvent | PointerEvent;
+    const isCoarse =
+      'pointerType' in nativeEvent && nativeEvent.pointerType
+        ? nativeEvent.pointerType === 'touch'
+        : typeof window !== 'undefined' &&
+          window.matchMedia('(pointer: coarse)').matches;
+
+    if (isCoarse) {
+      return step(fraction < 0.5 ? -1 : 1);
+    }
+    onChange?.(fraction < 1 / 3 ? false : fraction < 2 / 3 ? null : true);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLSpanElement>) => {
+    if (!triState) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick?.();
+      }
+      return;
+    }
+    if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      step(-1);
+    } else if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      step(1);
+    }
+  };
+
   return (
-    <div className="inline-flex items-center space-x-2">
-      <span
-        id={id}
-        role="checkbox"
-        tabIndex={0}
-        aria-checked={valueOf}
-        aria-label={
-          ariaLabel || (typeof title === 'string' ? title : undefined)
-        }
-        onClick={onClick}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === 'Space') {
-            e.preventDefault();
-            onClick();
-          }
-        }}
-        className={`${
-          valueOf ? 'bg-primary' : 'bg-neutral'
-        } relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ring-primary focus:ring`}
-      >
+    <div className="inline-flex items-start space-x-2">
+      <div className="flex flex-col items-center">
         <span
-          aria-hidden="true"
+          id={id}
+          role={triState ? 'slider' : 'checkbox'}
+          tabIndex={0}
+          aria-checked={triState ? undefined : !!valueOf}
+          aria-valuemin={triState ? 0 : undefined}
+          aria-valuemax={triState ? 2 : undefined}
+          aria-valuenow={
+            triState
+              ? valueOf === false
+                ? 0
+                : valueOf === null
+                  ? 1
+                  : 2
+              : undefined
+          }
+          aria-valuetext={triState ? stateLabel : undefined}
+          aria-label={
+            ariaLabel || (typeof title === 'string' ? title : undefined)
+          }
+          aria-labelledby={
+            !ariaLabel && title && typeof title !== 'string'
+              ? `${id}-label`
+              : undefined
+          }
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
           className={`${
-            valueOf ? 'translate-x-5' : 'translate-x-0'
-          } relative inline-block h-5 w-5 rounded-full bg-white shadow transition duration-200 ease-in-out`}
+            valueOf === null
+              ? 'bg-base-300'
+              : valueOf
+                ? 'bg-primary'
+                : 'bg-neutral'
+          } ${
+            triState ? 'w-16' : 'w-11'
+          } relative inline-flex h-6 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none ring-primary focus:ring`}
         >
           <span
+            aria-hidden="true"
             className={`${
-              valueOf
-                ? 'opacity-0 duration-100 ease-out'
-                : 'opacity-100 duration-200 ease-in'
-            } absolute inset-0 flex h-full w-full items-center justify-center transition-opacity`}
+              valueOf === null
+                ? 'translate-x-5'
+                : valueOf
+                  ? triState
+                    ? 'translate-x-10'
+                    : 'translate-x-5'
+                  : 'translate-x-0'
+            } relative inline-block h-5 w-5 rounded-full bg-white shadow transition duration-200 ease-in-out`}
           >
-            <XMarkIcon className="h-3 w-3 text-neutral" />
-          </span>
-          <span
-            className={`${
-              valueOf
-                ? 'opacity-100 duration-200 ease-in'
-                : 'opacity-0 duration-100 ease-out'
-            } absolute inset-0 flex h-full w-full items-center justify-center transition-opacity`}
-          >
-            <CheckIcon className="h-3 w-3 text-primary" />
+            <span
+              className={`${
+                valueOf === false
+                  ? 'opacity-100 duration-200 ease-in'
+                  : 'opacity-0 duration-100 ease-out'
+              } absolute inset-0 flex h-full w-full items-center justify-center transition-opacity`}
+            >
+              <XMarkIcon className="h-3 w-3 text-neutral" />
+            </span>
+            {triState && (
+              <span
+                className={`${
+                  valueOf === null
+                    ? 'opacity-100 duration-200 ease-in'
+                    : 'opacity-0 duration-100 ease-out'
+                } absolute inset-0 flex h-full w-full items-center justify-center transition-opacity`}
+              >
+                <MinusIcon className="h-3 w-3 text-neutral" />
+              </span>
+            )}
+            <span
+              className={`${
+                valueOf === true
+                  ? 'opacity-100 duration-200 ease-in'
+                  : 'opacity-0 duration-100 ease-out'
+              } absolute inset-0 flex h-full w-full items-center justify-center transition-opacity`}
+            >
+              <CheckIcon className="h-3 w-3 text-primary" />
+            </span>
           </span>
         </span>
-      </span>
-      {title && <label htmlFor={id}>{title}</label>}
+        {triState && (
+          <span aria-hidden="true" className="text-xs text-neutral">
+            ({stateLabel})
+          </span>
+        )}
+      </div>
+      {title && <span id={`${id}-label`}>{title}</span>}
     </div>
   );
 };

--- a/src/components/InviteList/InviteModal/index.tsx
+++ b/src/components/InviteList/InviteModal/index.tsx
@@ -753,7 +753,7 @@ const InviteModal = ({
                             </span>
                           </span>
                         </span>
-                        <label htmlFor="plexHome" className="ml-2">
+                        <label htmlFor="plexHome">
                           <FormattedMessage
                             id="invite.inviteToPlexHome"
                             defaultMessage="Invite to Plex Home"

--- a/src/components/LibrarySelector/index.tsx
+++ b/src/components/LibrarySelector/index.tsx
@@ -26,6 +26,8 @@ interface LibrarySelectorProps {
   setFieldValue: (property: string, value: string) => void;
   serverValue?: string;
   isUserSettings?: boolean;
+  /** Allows an empty selection, treated as 'unchanged' for bulk editing */
+  allowUnchanged?: boolean;
 }
 
 const LibrarySelector = ({
@@ -33,6 +35,7 @@ const LibrarySelector = ({
   setFieldValue,
   serverValue,
   isUserSettings = false,
+  allowUnchanged = false,
 }: LibrarySelectorProps) => {
   const { data: Libraries } = useSWR<Library[]>('/api/v1/libraries');
   const intl = useIntl();
@@ -68,10 +71,15 @@ const LibrarySelector = ({
             },
             { libraries: serverLibraryNames }
           )
-        : intl.formatMessage({
-            id: 'librarySelector.defaultLibrariesAll',
-            defaultMessage: 'Default Libraries (All)',
-          }),
+        : serverValue !== undefined
+          ? intl.formatMessage({
+              id: 'librarySelector.defaultLibrariesAll',
+              defaultMessage: 'Default Libraries (All)',
+            })
+          : intl.formatMessage({
+              id: 'librarySelector.defaultLibraries',
+              defaultMessage: 'Default Libraries',
+            }),
       isFixed: true,
     });
   }
@@ -109,7 +117,19 @@ const LibrarySelector = ({
       minMenuHeight={300}
       className="react-select-container"
       classNamePrefix="react-select"
+      placeholder={
+        allowUnchanged
+          ? intl.formatMessage({
+              id: 'librarySelector.noChange',
+              defaultMessage: 'No change',
+            })
+          : undefined
+      }
       value={(() => {
+        // An empty selection represents "no change" in bulk editing
+        if (allowUnchanged && value === 'unchanged') {
+          return [];
+        }
         // If 'all' is selected, only show 'all'
         if (
           (isUserSettings && value === 'all') ||
@@ -132,7 +152,7 @@ const LibrarySelector = ({
           ) as OptionType[];
       })()}
       onChange={(value, options) => {
-        // Remove 'all' or 'server' if another library is selected
+        // Remove other selections if 'all' or 'server' is selected
         if (
           options &&
           options.action === 'select-option' &&
@@ -148,9 +168,12 @@ const LibrarySelector = ({
                 : ''
           );
         }
-        // If all selected are 'server' or 'all', handle accordingly
+        // An empty selection means "no change" when bulk editing
         if (value.length === 0) {
-          return setFieldValue('sharedLibraries', '');
+          return setFieldValue(
+            'sharedLibraries',
+            allowUnchanged ? 'unchanged' : ''
+          );
         }
         if (value.every((v) => v.value === 'server')) {
           return setFieldValue('sharedLibraries', '');
@@ -158,7 +181,7 @@ const LibrarySelector = ({
         if (value.every((v) => v.value === 'all')) {
           return setFieldValue('sharedLibraries', isUserSettings ? 'all' : '');
         }
-        // Otherwise, set selected libraries (removing 'all' and 'server')
+        // Otherwise, set selected libraries (removing the special options)
         setFieldValue(
           'sharedLibraries',
           value

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -41,6 +41,7 @@ type NotificationAgentTypes = Record<NotificationAgentKey, number>;
 
 export interface UserSettings {
   locale?: string;
+  sharedLibraries?: string | null;
   trialPeriodOutcome?: 'promote' | 'deactivate' | null;
   notificationTypes: Partial<NotificationAgentTypes>;
   discordEnabled?: boolean;

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -3677,11 +3677,17 @@
   "library.watchlist": {
     "defaultMessage": "Watch List"
   },
+  "librarySelector.defaultLibraries": {
+    "defaultMessage": "Default Libraries"
+  },
   "librarySelector.defaultLibrariesAll": {
     "defaultMessage": "Default Libraries (All)"
   },
   "librarySelector.defaultLibrariesWith": {
     "defaultMessage": "Default Libraries ({libraries})"
+  },
+  "librarySelector.noChange": {
+    "defaultMessage": "No change"
   },
   "linkedAccounts.deleteFailed": {
     "defaultMessage": "Failed to delete linked account"
@@ -5390,6 +5396,15 @@
   "systemSettings.uptime": {
     "defaultMessage": "Uptime"
   },
+  "toggle.disabled": {
+    "defaultMessage": "Disabled"
+  },
+  "toggle.enabled": {
+    "defaultMessage": "Enabled"
+  },
+  "toggle.noChange": {
+    "defaultMessage": "No change"
+  },
   "tutorial.ready.description": {
     "defaultMessage": "We'll guide you through key features of {applicationTitle} with a quick tour."
   },
@@ -5422,6 +5437,27 @@
   },
   "userDropdown.startTutorial": {
     "defaultMessage": "Start Tutorial"
+  },
+  "userLibraries.error": {
+    "defaultMessage": "Something went wrong while saving Plex access settings."
+  },
+  "userLibraries.savedPlexSyncFailed": {
+    "defaultMessage": "Settings saved, but Plex sync failed."
+  },
+  "userLibraries.savedPlexSyncFailedMessage": {
+    "defaultMessage": "Changes were saved, but {count, plural, one {# user} other {# users}} could not be synced with Plex."
+  },
+  "userLibraries.savedUsersRemovedFromPlex": {
+    "defaultMessage": "Settings saved, but some users were not found in Plex."
+  },
+  "userLibraries.savedUsersRemovedFromPlexMessage": {
+    "defaultMessage": "{count, plural, one {# user was} other {# users were}} removed from the Plex server and {count, plural, one {has} other {have}} been deactivated."
+  },
+  "userLibraries.success": {
+    "defaultMessage": "Plex access settings saved successfully!"
+  },
+  "userLibraries.syncedWithPlex": {
+    "defaultMessage": "Changes have been synced with Plex."
   },
   "userPermissions.admin.description": {
     "defaultMessage": "Full administrator access. Bypasses all other permission checks."
@@ -5482,9 +5518,6 @@
   },
   "userPermissions.success": {
     "defaultMessage": "User permissions saved successfully!"
-  },
-  "userPermissions.title": {
-    "defaultMessage": "Edit User Permissions"
   },
   "userPermissions.viewInvites.description": {
     "defaultMessage": "Grants permission to view invites from other users."
@@ -5719,6 +5752,12 @@
   },
   "users.bulkEdit": {
     "defaultMessage": "Bulk Edit"
+  },
+  "users.bulkEditLibrariesDescription": {
+    "defaultMessage": "Changes will be applied to all selected users and synced with Plex automatically on save. Fields left unchanged are not modified. Local users will be updated but not synced."
+  },
+  "users.bulkEditTitle": {
+    "defaultMessage": "Bulk Edit Users"
   },
   "users.configurePasswordGeneration": {
     "defaultMessage": "Configure an application URL and enable email notifications to allow automatic password generation."

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -5304,6 +5304,8 @@ paths:
       description: |
         Update users with given IDs with the provided values. You cannot update users' Plex tokens through this request.
 
+        Provide any combination of `permissions`, `sharedLibraries`, `allowDownloads`, and `allowLiveTv`; omitted fields are left unchanged. When `sharedLibraries` or `allowDownloads` is provided, the new access is synced with Plex for all selected active Plex users and a sync summary is returned. `allowLiveTv` only gates Live TV within Streamarr and is not synced with Plex.
+
         Requires the `MANAGE_USERS` permission.
       tags:
         - users
@@ -5320,15 +5322,39 @@ paths:
                     type: integer
                 permissions:
                   type: integer
+                sharedLibraries:
+                  type: string
+                  description: A pipe-delimited list of library IDs, 'all', or 'server' for the server default
+                  example: '1|2|3'
+                allowDownloads:
+                  type: boolean
+                  description: Whether the users may download content (synced to Plex)
+                allowLiveTv:
+                  type: boolean
+                  description: Whether the users may access Live TV within Streamarr
       responses:
         '200':
           description: Successfully updated user details
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/User'
+                type: object
+                properties:
+                  users:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/User'
+                  plexSync:
+                    type: object
+                    nullable: true
+                    description: Plex sync summary, present when sharedLibraries or allowDownloads was updated
+                    properties:
+                      synced:
+                        type: integer
+                      failed:
+                        type: integer
+                      removed:
+                        type: integer
   /user/import-from-plex:
     post:
       summary: Import all users from Plex


### PR DESCRIPTION
## Description
Adds bulk editing of shared libraries to the admin user list, following the same pattern as the existing bulk permissions edit. Admins can now select multiple users, open **Bulk Edit**, and choose between two tabs:

- **Permissions** — replaces permissions for all selected users (existing behavior, unchanged)
- **Plex Access** — sets shared library access (Server Default, All Libraries, or specific libraries) for all selected users and syncs the change with Plex on save

- Closes #397

## Has This Been Tested?

- [x] Bulk library edit against a live Plex server

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
