### PR TITLE
feat(auth): move Plex pin exchange server-side

### DIFF
--- a/cypress/e2e/plex-pin-auth.cy.ts
+++ b/cypress/e2e/plex-pin-auth.cy.ts
@@ -1,0 +1,150 @@
+describe('Plex Pin Authentication', () => {
+  // Server contract tests — none of these reach plex.tv, so they are safe
+  // for CI without network access to Plex.
+  describe('Pin session contract', () => {
+    it('should report unknown pin sessions as expired', () => {
+      cy.request(
+        '/api/v1/auth/plex/pin/00000000-0000-4000-8000-000000000000'
+      ).then((resp) => {
+        expect(resp.status).to.eq(200);
+        expect(resp.body.status).to.eq('expired');
+      });
+    });
+
+    it('should reject login with an unknown pin session id', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/auth/plex',
+        body: { pinId: '00000000-0000-4000-8000-000000000000' },
+        failOnStatusCode: false,
+      }).then((resp) => {
+        expect(resp.status).to.eq(401);
+      });
+    });
+
+    it('should reject signup with an unknown pin session id', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/signup/plexauth',
+        body: {
+          pinId: '00000000-0000-4000-8000-000000000000',
+          icode: 'invalid',
+        },
+        failOnStatusCode: false,
+      }).then((resp) => {
+        expect(resp.status).to.be.within(400, 401);
+        expect(resp.body).to.have.property('success', false);
+      });
+    });
+
+    it('should still reject login without a token or pin id', () => {
+      cy.request({
+        method: 'POST',
+        url: '/api/v1/auth/plex',
+        body: {},
+        failOnStatusCode: false,
+      }).then((resp) => {
+        expect(resp.status).to.eq(400);
+      });
+    });
+
+    it('should never expose an auth token from the pin status endpoint', () => {
+      cy.request(
+        '/api/v1/auth/plex/pin/00000000-0000-4000-8000-000000000000'
+      ).then((resp) => {
+        expect(JSON.stringify(resp.body)).to.not.contain('authToken');
+        expect(Object.keys(resp.body)).to.deep.eq(['status']);
+      });
+    });
+  });
+
+  // Full UI flow with every external interaction stubbed: the streamarr pin
+  // endpoints are intercepted (same-origin, so cy.intercept works) and
+  // window.open is stubbed so no real popup or plex.tv navigation occurs.
+  describe('UI sign-in flow (stubbed)', () => {
+    const PIN_ID = '11111111-1111-4111-8111-111111111111';
+
+    it('should sign in through the pin lifecycle', () => {
+      cy.intercept('POST', '/api/v1/auth/plex/pin', {
+        statusCode: 200,
+        body: {
+          id: PIN_ID,
+          authUrl: 'https://app.plex.tv/auth/#!?code=stubbed',
+          expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        },
+      }).as('createPin');
+
+      cy.intercept('GET', `/api/v1/auth/plex/pin/${PIN_ID}`, {
+        statusCode: 200,
+        body: { status: 'authorized' },
+      }).as('pinStatus');
+
+      cy.intercept('POST', '/api/v1/auth/plex', (req) => {
+        expect(req.body.pinId).to.eq(PIN_ID);
+        expect(req.body).to.not.have.property('authToken');
+        req.reply({ statusCode: 200, body: { id: 1 } });
+      }).as('login');
+
+      cy.intercept('GET', '/api/v1/auth/me', { statusCode: 403, body: {} }).as(
+        'me'
+      );
+
+      cy.visit('/signin', {
+        onBeforeLoad(win) {
+          // Fake popup: never "closed", absorbs the auth URL navigation.
+          const fakePopup = {
+            closed: false,
+            focus: () => undefined,
+            close: () => undefined,
+            location: { href: '' },
+          };
+          cy.stub(win, 'open').returns(fakePopup);
+        },
+      });
+
+      cy.get('[data-testid="plex-login-button"]').click();
+
+      cy.wait('@createPin');
+      cy.wait('@pinStatus');
+      // Allow for the client poll interval (~2s) plus the follow-up POST.
+      cy.wait('@login', { timeout: 15000 })
+        .its('request.body')
+        .should('deep.include', { pinId: PIN_ID });
+    });
+
+    it('should surface an error when the pin session expires', () => {
+      cy.intercept('POST', '/api/v1/auth/plex/pin', {
+        statusCode: 200,
+        body: {
+          id: PIN_ID,
+          authUrl: 'https://app.plex.tv/auth/#!?code=stubbed',
+          expiresAt: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+        },
+      });
+
+      cy.intercept('GET', `/api/v1/auth/plex/pin/${PIN_ID}`, {
+        statusCode: 200,
+        body: { status: 'expired' },
+      });
+
+      cy.visit('/signin', {
+        onBeforeLoad(win) {
+          const fakePopup = {
+            closed: false,
+            focus: () => undefined,
+            close: () => undefined,
+            location: { href: '' },
+          };
+          cy.stub(win, 'open').returns(fakePopup);
+        },
+      });
+
+      cy.get('[data-testid="plex-login-button"]').click();
+
+      // The flow must end back on an idle sign-in button, not hang polling.
+      cy.get('[data-testid="plex-login-button"]', { timeout: 15000 }).should(
+        'not.be.disabled'
+      );
+    });
+  });
+});

--- a/docs/using-streamarr/users/linked-accounts.md
+++ b/docs/using-streamarr/users/linked-accounts.md
@@ -67,9 +67,9 @@ If you try to view another user's linked accounts without the **Manage Users** p
 
 ## API Reference
 
-| Endpoint                                          | Method | Description                                                  |
-| ------------------------------------------------- | ------ | ------------------------------------------------------------ |
-| `/api/v1/user/{id}/settings/linked-accounts/plex` | POST   | Link a Plex account (requires an auth token from Plex OAuth) |
-| `/api/v1/user/{id}/settings/linked-accounts/plex` | DELETE | Unlink the user's Plex account                               |
+| Endpoint                                          | Method | Description                                                                                                                  |
+| ------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `/api/v1/user/{id}/settings/linked-accounts/plex` | POST   | Link a Plex account (provide a `pinId` from the server-side Plex pin exchange; a raw `authToken` is accepted but deprecated) |
+| `/api/v1/user/{id}/settings/linked-accounts/plex` | DELETE | Unlink the user's Plex account                                                                                               |
 
 These endpoints act on the authenticated user's own account. Viewing another user's account information requires the **Manage Users** permission.

--- a/server/lib/plexAuth/index.ts
+++ b/server/lib/plexAuth/index.ts
@@ -1,0 +1,316 @@
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+import { getAppVersion } from '@server/utils/appVersion';
+import axios from 'axios';
+import { randomUUID } from 'crypto';
+
+/**
+ * Server-side Plex PIN authentication.
+ *
+ * Moves the Plex OAuth pin lifecycle (creation, polling, token exchange) from
+ * the browser to the server. The browser only ever sees:
+ *   - an opaque pin session id (single-use, short TTL)
+ *   - the app.plex.tv auth URL to open in the popup
+ *
+ * The resulting Plex auth token is held server-side and consumed exactly once
+ * by a login/signup/link handler via `consumeToken()`. Tokens never transit
+ * the browser.
+ *
+ * Sessions are kept in memory: streamarr runs as a single process, pin
+ * sessions are short-lived (<= 15 minutes), and an interrupted sign-in simply
+ * starts over.
+ */
+
+const PIN_SESSION_TTL_MS = 15 * 60 * 1000;
+const CLEANUP_GRACE_MS = 60 * 1000;
+
+export type PlexPinStatus = 'pending' | 'authorized' | 'expired';
+
+export interface PlexPinClientInfo {
+  platform?: string;
+  platformVersion?: string;
+  device?: string;
+  screenResolution?: string;
+}
+
+export interface PlexPinCreationResponse {
+  id: string;
+  authUrl: string;
+  expiresAt: string;
+}
+
+interface PinSession {
+  plexPinId: number;
+  headers: Record<string, string>;
+  authToken?: string;
+  expiresAt: number;
+}
+
+interface PlexPinResponse {
+  id: number;
+  code: string;
+  authToken?: string | null;
+  expiresAt?: string;
+}
+
+const sanitizeClientValue = (value?: string): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+  const cleaned = value
+    .replace(/[^\w .()/:-]/g, '')
+    .slice(0, 64)
+    .trim();
+  return cleaned || undefined;
+};
+
+class PlexPinAuth {
+  private sessions = new Map<string, PinSession>();
+
+  constructor() {
+    // An authorized-but-unconsumed session holds a live Plex auth token in
+    // memory. createPin() sweeps expired sessions on demand, but on a quiet
+    // instance it may not run for a long time, so also sweep on a timer to
+    // bound how long a token can linger regardless of traffic. unref() so the
+    // sweep never keeps the process alive on its own (matters for CLI/tests).
+    const sweep = setInterval(() => this.cleanup(), CLEANUP_GRACE_MS);
+    if (typeof sweep.unref === 'function') {
+      sweep.unref();
+    }
+  }
+
+  /**
+   * Creates a Plex pin and returns the opaque session id plus the
+   * app.plex.tv auth URL the client should open in its popup.
+   *
+   * Optional client hints (browser/OS names reported by the frontend) are
+   * sanitized and forwarded so the entry in the user's Plex device list keeps
+   * its current, recognizable naming (e.g. "Chrome (Streamarr)").
+   */
+  public async createPin(
+    client?: PlexPinClientInfo
+  ): Promise<PlexPinCreationResponse> {
+    this.cleanup();
+
+    const headers = this.buildHeaders(client);
+    const response = await axios.post<PlexPinResponse>(
+      'https://plex.tv/api/v2/pins?strong=true',
+      undefined,
+      { headers, timeout: 15000 }
+    );
+
+    const id = randomUUID();
+    const plexExpiry = response.data.expiresAt
+      ? Date.parse(response.data.expiresAt)
+      : NaN;
+    const expiresAt = Math.min(
+      Number.isNaN(plexExpiry) ? Infinity : plexExpiry,
+      Date.now() + PIN_SESSION_TTL_MS
+    );
+
+    this.sessions.set(id, {
+      plexPinId: response.data.id,
+      headers,
+      expiresAt,
+    });
+
+    return {
+      id,
+      authUrl: this.buildAuthUrl(headers, response.data.code),
+      expiresAt: new Date(expiresAt).toISOString(),
+    };
+  }
+
+  /**
+   * Looks up a session and enforces its TTL: if it has passed `expiresAt` the
+   * session is deleted eagerly and `undefined` is returned. Centralizing expiry
+   * here guarantees no read path (`getStatus`/`peekToken`/`consumeToken`) can
+   * hand back a token — or report `authorized` — for a session that has
+   * outlived its short TTL before the periodic sweep happens to run.
+   */
+  private getLiveSession(id: string): PinSession | undefined {
+    const session = this.sessions.get(id);
+
+    if (!session) {
+      return undefined;
+    }
+
+    if (Date.now() >= session.expiresAt) {
+      this.sessions.delete(id);
+      return undefined;
+    }
+
+    return session;
+  }
+
+  /**
+   * Polls plex.tv for the pin's authorization state. Once authorized, the
+   * token is stored server-side; the status response never includes it.
+   */
+  public async getStatus(id: string): Promise<PlexPinStatus> {
+    const session = this.getLiveSession(id);
+
+    if (!session) {
+      return 'expired';
+    }
+
+    if (session.authToken) {
+      return 'authorized';
+    }
+
+    try {
+      const response = await axios.get<PlexPinResponse>(
+        `https://plex.tv/api/v2/pins/${session.plexPinId}`,
+        { headers: session.headers, timeout: 15000 }
+      );
+
+      if (response.data.authToken) {
+        session.authToken = response.data.authToken;
+        return 'authorized';
+      }
+    } catch (e) {
+      // Transient plex.tv errors shouldn't abort the sign-in; the client
+      // will poll again. The session TTL bounds how long this can go on.
+      logger.debug('Failed to poll Plex pin status; will retry', {
+        label: 'Plex Pin Auth',
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    return 'pending';
+  }
+
+  /**
+   * Returns the auth token for an authorized pin session exactly once and
+   * destroys the session. Returns null for unknown, expired, unauthorized,
+   * or already-consumed sessions.
+   */
+  public consumeToken(id: string): string | null {
+    const session = this.getLiveSession(id);
+
+    if (!session?.authToken) {
+      return null;
+    }
+
+    this.sessions.delete(id);
+    return session.authToken;
+  }
+
+  /**
+   * Returns the auth token for an authorized session WITHOUT destroying it.
+   * Lets a handler validate the token against plex.tv before committing the
+   * single-use consumption, so a transient failure doesn't discard an
+   * otherwise-valid session and force the user to restart the popup flow.
+   * Callers MUST call `consumeToken()` once the token is confirmed usable.
+   * Returns null for unknown, expired, or unauthorized sessions (an expired
+   * session is deleted eagerly via getLiveSession).
+   */
+  public peekToken(id: string): string | null {
+    return this.getLiveSession(id)?.authToken ?? null;
+  }
+
+  private buildHeaders(client?: PlexPinClientInfo): Record<string, string> {
+    const settings = getSettings();
+    const applicationTitle = settings.main.applicationTitle;
+    const platform = sanitizeClientValue(client?.platform);
+
+    return {
+      Accept: 'application/json',
+      'X-Plex-Product': applicationTitle,
+      'X-Plex-Version': getAppVersion(),
+      'X-Plex-Client-Identifier': settings.clientId,
+      'X-Plex-Model': 'Plex OAuth',
+      'X-Plex-Platform': platform ?? 'Web',
+      'X-Plex-Platform-Version':
+        sanitizeClientValue(client?.platformVersion) ?? '',
+      'X-Plex-Device': sanitizeClientValue(client?.device) ?? 'Browser',
+      'X-Plex-Device-Name': `${platform ?? 'Browser'} (${applicationTitle})`,
+      'X-Plex-Device-Screen-Resolution':
+        sanitizeClientValue(client?.screenResolution) ?? '',
+      'X-Plex-Language': 'en',
+    };
+  }
+
+  private buildAuthUrl(
+    headers: Record<string, string>,
+    pinCode: string
+  ): string {
+    const params: Record<string, string> = {
+      clientID: headers['X-Plex-Client-Identifier'],
+      'context[device][product]': headers['X-Plex-Product'],
+      'context[device][version]': headers['X-Plex-Version'],
+      'context[device][platform]': headers['X-Plex-Platform'],
+      'context[device][platformVersion]': headers['X-Plex-Platform-Version'],
+      'context[device][device]': headers['X-Plex-Device'],
+      'context[device][deviceName]': headers['X-Plex-Device-Name'],
+      'context[device][model]': headers['X-Plex-Model'],
+      'context[device][screenResolution]':
+        headers['X-Plex-Device-Screen-Resolution'],
+      'context[device][layout]': 'desktop',
+      code: pinCode,
+    };
+
+    const encoded = Object.entries(params)
+      .map(([key, value]) => [key, value].map(encodeURIComponent).join('='))
+      .join('&');
+
+    return `https://app.plex.tv/auth/#!?${encoded}`;
+  }
+
+  private cleanup(): void {
+    const now = Date.now();
+    for (const [id, session] of this.sessions) {
+      if (now >= session.expiresAt + CLEANUP_GRACE_MS) {
+        this.sessions.delete(id);
+      }
+    }
+  }
+}
+
+const plexPinAuth = new PlexPinAuth();
+
+export interface ResolvedPlexAuth {
+  /** The resolved Plex auth token, or null if it couldn't be resolved. */
+  token: string | null;
+  /**
+   * Finalizes a pin-based resolution. Call with `true` once the token has been
+   * confirmed usable (e.g. after a successful plex.tv lookup) to consume the
+   * single-use pin session. If it is never called with `true` (a transient
+   * error, failed validation, etc.) the session is left intact so the request
+   * can be retried with the same `pinId`, and the periodic sweep will reclaim
+   * it at TTL. No-op for the legacy raw-`authToken` path.
+   */
+  commit: (success: boolean) => void;
+}
+
+/**
+ * Resolves the Plex auth token for a login-style request body. Prefers the
+ * server-side pin exchange (`pinId`); falls back to a raw `authToken` for
+ * backward compatibility (deprecated — will be removed once all clients use
+ * the pin flow).
+ *
+ * For the pin path the token is read non-destructively; the caller must invoke
+ * the returned `commit(true)` to consume the single-use session once the token
+ * is known to be good. This avoids destroying a valid session on a transient
+ * downstream failure.
+ */
+export const resolvePlexAuthToken = (body: {
+  authToken?: string;
+  pinId?: string;
+}): ResolvedPlexAuth => {
+  if (body.pinId) {
+    const pinId = body.pinId;
+    return {
+      token: plexPinAuth.peekToken(pinId),
+      commit: (success: boolean) => {
+        if (success) {
+          plexPinAuth.consumeToken(pinId);
+        }
+      },
+    };
+  }
+
+  return { token: body.authToken ?? null, commit: () => undefined };
+};
+
+export default plexPinAuth;

--- a/server/lib/rateLimiters.ts
+++ b/server/lib/rateLimiters.ts
@@ -7,6 +7,30 @@ export const arrAuthLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+export const plexPinLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+export const plexAuthLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
+export const plexPinStatusLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  // The client polls this endpoint roughly every 2s during an active
+  // sign-in (~30/min). 120/min/IP leaves ample headroom for legitimate
+  // polling while bounding abuse of this outbound-request-triggering route.
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 export const resetPasswordLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 5, // limit each IP to 5 requests per window

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -8,7 +8,16 @@ import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import { handlePlexAccessLost } from '@server/lib/plexAccessLost';
 import logger from '@server/logger';
-import { resetPasswordLimiter } from '@server/lib/rateLimiters';
+import {
+  resetPasswordLimiter,
+  plexPinLimiter,
+  plexPinStatusLimiter,
+  plexAuthLimiter,
+} from '@server/lib/rateLimiters';
+import plexPinAuth, {
+  resolvePlexAuthToken,
+  type PlexPinClientInfo,
+} from '@server/lib/plexAuth';
 import { isAuthenticated } from '@server/middleware/auth';
 import ImageProxy from '@server/lib/imageproxy';
 import { Router } from 'express';
@@ -50,18 +59,53 @@ authRoutes.get('/me', isAuthenticated(), async (req, res) => {
   });
 });
 
-authRoutes.post('/plex', async (req, res, next) => {
+authRoutes.post('/plex/pin', plexPinLimiter, async (req, res, next) => {
+  try {
+    const body = req.body as { client?: PlexPinClientInfo } | undefined;
+    const pin = await plexPinAuth.createPin(body?.client);
+    res.status(200).json(pin);
+  } catch (e) {
+    logger.error('Failed to create Plex sign-in pin', {
+      label: 'API',
+      ip: req.ip,
+      errorMessage: e instanceof Error ? e.message : String(e),
+    });
+    return next({ status: 500, message: 'Unable to begin Plex sign-in.' });
+  }
+});
+
+authRoutes.get<{ pinId: string }>(
+  '/plex/pin/:pinId',
+  plexPinStatusLimiter,
+  async (req, res) => {
+    const status = await plexPinAuth.getStatus(req.params.pinId);
+    res.status(200).json({ status });
+  }
+);
+
+authRoutes.post('/plex', plexAuthLimiter, async (req, res, next) => {
   const settings = getSettings();
   const userRepository = getRepository(User);
-  const body = req.body as { authToken?: string };
+  const body = req.body as { authToken?: string; pinId?: string };
+  const { token: authToken, commit: commitPlexAuth } =
+    resolvePlexAuthToken(body);
 
-  if (!body.authToken) {
-    return next({ status: 500, message: 'Authentication token required.' });
+  if (!authToken) {
+    return next({
+      status: body.pinId ? 401 : 400,
+      message: body.pinId
+        ? 'Plex sign-in session is invalid or has expired. Please try again.'
+        : 'Authentication token required.',
+    });
   }
   try {
     // First we need to use this auth token to get the user's email from plex.tv
-    const plextv = new PlexTvAPI(body.authToken);
+    const plextv = new PlexTvAPI(authToken);
     const account = await plextv.getUser();
+    // The token authenticated against plex.tv, so it's good. Consume the
+    // single-use pin session now; a transient failure above would have thrown
+    // before reaching here, leaving the session intact for a retry.
+    commitPlexAuth(true);
 
     // Next let's see if the user already exists
     let user = await userRepository
@@ -155,7 +199,7 @@ authRoutes.post('/plex', async (req, res, next) => {
           }
 
           const previousAvatar = user.avatar;
-          user.plexToken = body.authToken;
+          user.plexToken = authToken;
           user.plexId = account.id;
           user.avatar = account.thumb;
           user.email = account.email;

--- a/server/routes/signup.ts
+++ b/server/routes/signup.ts
@@ -9,6 +9,8 @@ import { InviteStatus } from '@server/constants/invite';
 import { UserType } from '@server/constants/user';
 import { Permission } from '@server/lib/permissions';
 import { plexSync } from '@server/lib/plexSync';
+import { resolvePlexAuthToken } from '@server/lib/plexAuth';
+import { plexAuthLimiter } from '@server/lib/rateLimiters';
 import {
   isDefaultSentinel,
   materializeDefaultSnapshot,
@@ -50,13 +52,23 @@ signupRoutes.get('/validate/:icode', async (req, res, next) => {
 });
 
 // Step 2: Plex authentication and user creation
-signupRoutes.post('/plexauth', async (req, res) => {
+signupRoutes.post('/plexauth', plexAuthLimiter, async (req, res) => {
   try {
-    const { authToken, icode } = req.body;
+    const { icode, pinId } = req.body as {
+      authToken?: string;
+      icode?: string;
+      pinId?: string;
+    };
+    const { token: authToken, commit: commitPlexAuth } = resolvePlexAuthToken(
+      req.body
+    );
     if (!authToken || !icode) {
-      res.status(400).json({
+      res.status(pinId && !authToken ? 401 : 400).json({
         success: false,
-        message: 'Auth token and invite code required.',
+        message:
+          pinId && !authToken
+            ? 'Plex sign-in session is invalid or has expired. Please try again.'
+            : 'Auth token and invite code required.',
       });
       return;
     }
@@ -92,6 +104,10 @@ signupRoutes.post('/plexauth', async (req, res) => {
     // Authenticate with Plex
     const plextv = new PlexTvAPI(authToken);
     const plexUser = await plextv.getUser();
+    // Token authenticated against plex.tv; consume the single-use pin session.
+    // Invite-code validation above runs first, so an invalid/expired invite
+    // leaves the session intact for a retry.
+    commitPlexAuth(true);
     const userRepository = getRepository(User);
 
     // Check if user is already a member of Plex server

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -9,6 +9,7 @@ import type {
 import { Permission } from '@server/lib/permissions';
 import { getSettings } from '@server/lib/settings';
 import { plexSync, PlexUserNotFoundError } from '@server/lib/plexSync';
+import { resolvePlexAuthToken } from '@server/lib/plexAuth';
 import { handlePlexAccessLost } from '@server/lib/plexAccessLost';
 import {
   NotificationSeverity,
@@ -31,7 +32,10 @@ import {
   isOwnProfile,
   isOwnProfileOrAdmin,
 } from '@server/utils/profileMiddleware';
-import { trialExtensionRequestLimiter } from '@server/lib/rateLimiters';
+import {
+  trialExtensionRequestLimiter,
+  plexAuthLimiter,
+} from '@server/lib/rateLimiters';
 import moment from '@server/utils/momentWithLocale';
 import { sendGroupNotification } from '@server/lib/notifications/dispatch';
 
@@ -752,16 +756,35 @@ userSettingsRoutes.post<
   }
 });
 
-userSettingsRoutes.post<{ id: string }, unknown, { authToken: string }>(
+userSettingsRoutes.post<
+  { id: string },
+  unknown,
+  { authToken?: string; pinId?: string }
+>(
   '/linked-accounts/plex',
+  plexAuthLimiter,
   isOwnProfile(),
   async (req, res, next) => {
     const userRepository = getRepository(User);
 
+    const { token: authToken, commit: commitPlexAuth } = resolvePlexAuthToken(
+      req.body
+    );
+    if (!authToken) {
+      return next({
+        status: req.body.pinId ? 401 : 400,
+        message: req.body.pinId
+          ? 'Plex sign-in session is invalid or has expired. Please try again.'
+          : 'Authentication token required.',
+      });
+    }
+
     let account: Awaited<ReturnType<PlexTvAPI['getUser']>>;
     try {
-      const plextv = new PlexTvAPI(req.body.authToken);
+      const plextv = new PlexTvAPI(authToken);
       account = await plextv.getUser();
+      // Token authenticated against plex.tv; consume the single-use pin session.
+      commitPlexAuth(true);
     } catch {
       return next({ status: 401, message: 'Invalid or expired Plex token.' });
     }
@@ -888,7 +911,7 @@ userSettingsRoutes.post<{ id: string }, unknown, { authToken: string }>(
             libraries: librarySectionIds,
             allowSync: getSettings().main.downloads ?? false,
             plexHome: user.settings?.allowPlexHome ?? false,
-            userTokenOverride: req.body.authToken || user.plexToken,
+            userTokenOverride: authToken || user.plexToken,
           });
         } catch (e) {
           logger.warn('Plex account link invite failed', {

--- a/src/components/PlexLoginBtn/index.tsx
+++ b/src/components/PlexLoginBtn/index.tsx
@@ -6,24 +6,23 @@ import { FormattedMessage } from 'react-intl';
 const plexOAuth = new PlexOAuth();
 
 interface PlexLoginButtonProps {
-  onAuthToken: (authToken: string) => void;
+  onComplete: (pinId: string) => void;
   isProcessing?: boolean;
   onError?: (message: string) => void;
 }
 
 const PlexLoginButton = ({
-  onAuthToken,
+  onComplete,
   onError,
   isProcessing,
 }: PlexLoginButtonProps) => {
   const [loading, setLoading] = useState(false);
 
   const getPlexLogin = async () => {
-    setLoading(true);
     try {
-      const authToken = await plexOAuth.login();
+      const pinId = await plexOAuth.login();
       setLoading(false);
-      onAuthToken(authToken);
+      onComplete(pinId);
     } catch (e) {
       if (onError) {
         onError(e.message);
@@ -37,6 +36,10 @@ const PlexLoginButton = ({
         type="button"
         data-testid="plex-login-button"
         onClick={() => {
+          if (loading || isProcessing) {
+            return;
+          }
+          setLoading(true);
           plexOAuth.preparePopup();
           setTimeout(() => getPlexLogin(), 1500);
         }}

--- a/src/components/Setup/SigninWithPlex.tsx
+++ b/src/components/Setup/SigninWithPlex.tsx
@@ -13,14 +13,14 @@ interface LoginWithPlexProps {
 
 const LoginWithPlex = ({ onComplete }: LoginWithPlexProps) => {
   const intl = useIntl();
-  const [authToken, setAuthToken] = useState<string | undefined>(undefined);
+  const [pinId, setPinId] = useState<string | undefined>(undefined);
   const { user, revalidate } = useUser();
   const { currentSettings } = useSettings();
 
   useEffect(() => {
     const login = async () => {
       try {
-        const response = await axios.post('/api/v1/auth/plex', { authToken });
+        const response = await axios.post('/api/v1/auth/plex', { pinId });
 
         if (response.data?.id) {
           const { data: authenticatedUser } =
@@ -38,13 +38,13 @@ const LoginWithPlex = ({ onComplete }: LoginWithPlexProps) => {
           type: 'error',
           icon: <XCircleIcon className="size-7" />,
         });
-        setAuthToken(undefined);
+        setPinId(undefined);
       }
     };
-    if (authToken) {
+    if (pinId) {
       login();
     }
-  }, [authToken, intl, onComplete, revalidate]);
+  }, [pinId, intl, onComplete, revalidate]);
 
   useEffect(() => {
     if (user) {
@@ -68,7 +68,7 @@ const LoginWithPlex = ({ onComplete }: LoginWithPlexProps) => {
         />
       </div>
       <div className="flex items-center justify-center">
-        <PlexLoginButton onAuthToken={(authToken) => setAuthToken(authToken)} />
+        <PlexLoginButton onComplete={(pinId) => setPinId(pinId)} />
       </div>
     </form>
   );

--- a/src/components/SignIn/index.tsx
+++ b/src/components/SignIn/index.tsx
@@ -15,19 +15,20 @@ import { FormattedMessage } from 'react-intl';
 const SignIn = () => {
   const [error, setError] = useState('');
   const [isProcessing, setProcessing] = useState(false);
-  const [authToken, setAuthToken] = useState<string | undefined>(undefined);
+  const [pinId, setPinId] = useState<string | undefined>(undefined);
   const { user, revalidate } = useUser();
   const router = useRouter();
   const { currentSettings } = useSettings();
 
-  // Effect that is triggered when the `authToken` comes back from the Plex OAuth
-  // We take the token and attempt to sign in. If we get a success message, we will
-  // ask swr to revalidate the user which _should_ come back with a valid user.
+  // Effect that is triggered when the pin session id comes back from the Plex
+  // OAuth popup. The server exchanges the pin for the Plex token internally.
+  // If we get a success message, we will ask swr to revalidate the user which
+  // _should_ come back with a valid user.
   useEffect(() => {
     const login = async () => {
       setProcessing(true);
       try {
-        const response = await axios.post('/api/v1/auth/plex', { authToken });
+        const response = await axios.post('/api/v1/auth/plex', { pinId });
 
         if (response.data?.id) {
           const { data: authenticatedUser } =
@@ -37,15 +38,17 @@ const SignIn = () => {
           );
         }
       } catch (e) {
-        setError(e.response.data.message);
-        setAuthToken(undefined);
+        setError(
+          e.response?.data?.message ?? 'Something went wrong. Please try again.'
+        );
+        setPinId(undefined);
         setProcessing(false);
       }
     };
-    if (authToken) {
+    if (pinId) {
       login();
     }
-  }, [authToken, revalidate, router]);
+  }, [pinId, revalidate, router]);
 
   // Effect that is triggered whenever `useUser`'s user changes. If we get a new
   // valid user, we redirect the user to the home page as the login was successful.
@@ -115,7 +118,7 @@ const SignIn = () => {
                   </div>
                   <PlexLoginButton
                     isProcessing={isProcessing}
-                    onAuthToken={(authToken) => setAuthToken(authToken)}
+                    onComplete={(pinId) => setPinId(pinId)}
                   />
                 </div>
               </AccordionContent>

--- a/src/components/SignUp/Forms/SignUpAuthForm.tsx
+++ b/src/components/SignUp/Forms/SignUpAuthForm.tsx
@@ -21,7 +21,7 @@ const SignUpAuthForm = ({
   inviteCode: string;
 }) => {
   const intl = useIntl();
-  const [authToken, setAuthToken] = useState<string | undefined>(undefined);
+  const [pinId, setPinId] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
   const router = useRouter();
@@ -29,7 +29,7 @@ const SignUpAuthForm = ({
   const { currentSettings } = useSettings(); // Handle Plex authentication
   useEffect(() => {
     const doAuth = async () => {
-      if (!authToken || !inviteCode) return;
+      if (!pinId || !inviteCode) return;
       setLoading(true);
       try {
         const response = await axios.post<{
@@ -37,7 +37,7 @@ const SignUpAuthForm = ({
           message?: string;
           alreadyHasAccess?: boolean;
         }>('/api/v1/signup/plexauth', {
-          authToken,
+          pinId,
           icode: inviteCode,
         });
         if (response.status === 200 && response.data.user) {
@@ -69,7 +69,7 @@ const SignUpAuthForm = ({
       }
     };
     doAuth();
-  }, [authToken, inviteCode, onComplete, router, revalidate, intl]); // Handle local signup
+  }, [pinId, inviteCode, onComplete, router, revalidate, intl]); // Handle local signup
   const handleLocalSignup = async (values: {
     email: string;
     username: string;
@@ -128,12 +128,8 @@ const SignUpAuthForm = ({
               className={`p-3 place-content-center border border-secondary bg-secondary/50 ${currentSettings.localLogin ? '' : 'rounded-b-lg'}`}
             >
               <PlexLoginButton
-                onAuthToken={(token) => {
-                  if (
-                    !token ||
-                    typeof token !== 'string' ||
-                    token.length < 10
-                  ) {
+                onComplete={(pinId) => {
+                  if (!pinId || typeof pinId !== 'string') {
                     Toast({
                       title: intl.formatMessage({
                         id: 'signUp.plexLoginIncomplete',
@@ -149,7 +145,7 @@ const SignUpAuthForm = ({
                     });
                     return;
                   }
-                  setAuthToken(token);
+                  setPinId(pinId);
                 }}
                 onError={(msg) => {
                   Toast({

--- a/src/components/UserProfile/UserSettings/UserSettingsAccounts/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsAccounts/index.tsx
@@ -49,11 +49,11 @@ const UserSettingsAccounts = () => {
   const linkPlexAccount = async () => {
     setError(null);
     try {
-      const authToken = await plexOAuth.login();
+      const pinId = await plexOAuth.login();
       await axios.post(
         `/api/v1/user/${user?.id}/settings/linked-accounts/plex`,
         {
-          authToken,
+          pinId,
         }
       );
       await revalidateUser();

--- a/src/utils/plex.ts
+++ b/src/utils/plex.ts
@@ -1,114 +1,46 @@
-import type { PublicSettingsResponse } from '@server/interfaces/api/settingsInterfaces';
 import axios from 'axios';
 import Bowser from 'bowser';
 
-interface PlexHeaders extends Record<string, string> {
-  Accept: string;
-  'X-Plex-Product': string;
-  'X-Plex-Version': string;
-  'X-Plex-Client-Identifier': string;
-  'X-Plex-Model': string;
-  'X-Plex-Platform': string;
-  'X-Plex-Platform-Version': string;
-  'X-Plex-Device': string;
-  'X-Plex-Device-Name': string;
-  'X-Plex-Device-Screen-Resolution': string;
-  'X-Plex-Language': string;
+export type PlexPinStatus = 'pending' | 'authorized' | 'expired';
+
+interface PlexPinSession {
+  id: string;
+  authUrl: string;
+  expiresAt: string;
 }
 
-export interface PlexPin {
-  id: number;
-  code: string;
-}
-
+/**
+ * Client side of the server-driven Plex sign-in flow.
+ *
+ * The server owns the entire pin lifecycle (creation, plex.tv polling, token
+ * exchange); this class only manages the popup and polls streamarr for the
+ * pin status. `login()` resolves with an opaque pin session id, which the
+ * caller passes to the relevant endpoint (`/auth/plex`, `/signup/plexauth`,
+ * `/user/:id/settings/linked-accounts/plex`) as `pinId`. The Plex auth token
+ * itself never reaches the browser.
+ */
 class PlexOAuth {
-  private plexHeaders?: PlexHeaders;
-  private pin?: PlexPin;
+  private pin?: PlexPinSession;
   private popup?: Window;
-  private authToken?: string;
-
-  public initializeHeaders(
-    applicationTitle: string,
-    plexClientIdentifier: string
-  ): void {
-    if (typeof window === 'undefined') {
-      throw new Error(
-        'Window is not defined. Are you calling this in the browser?'
-      );
-    }
-
-    if (!plexClientIdentifier) {
-      throw new Error(
-        'Plex client identifier missing. Reload the page and try again.'
-      );
-    }
-
-    const browser = Bowser.getParser(window.navigator.userAgent);
-    this.plexHeaders = {
-      Accept: 'application/json',
-      'X-Plex-Product': applicationTitle,
-      'X-Plex-Version': '0.00.1',
-      'X-Plex-Client-Identifier': plexClientIdentifier,
-      'X-Plex-Model': 'Plex OAuth',
-      'X-Plex-Platform': browser.getBrowserName(),
-      'X-Plex-Platform-Version': browser.getBrowserVersion(),
-      'X-Plex-Device': browser.getOSName(),
-      'X-Plex-Device-Name': `${browser.getBrowserName()} (${applicationTitle})`,
-      'X-Plex-Device-Screen-Resolution':
-        window.screen.width + 'x' + window.screen.height,
-      'X-Plex-Language': 'en',
-    };
-  }
-
-  public async getPin(): Promise<PlexPin> {
-    if (!this.plexHeaders) {
-      throw new Error(
-        'You must initialize the plex headers client side to login'
-      );
-    }
-    const response = await axios.post(
-      'https://plex.tv/api/v2/pins?strong=true',
-      undefined,
-      { headers: this.plexHeaders }
-    );
-
-    this.pin = { id: response.data.id, code: response.data.code };
-
-    return this.pin;
-  }
 
   public preparePopup(): void {
+    // Close any popup left over from a previous attempt before opening a new
+    // one, so repeated sign-ins on the shared instance don't leak a window.
+    this.closePopup();
     this.openPopup({ title: 'Plex Auth', w: 600, h: 700 });
   }
 
   public async login(): Promise<string> {
-    const res = await fetch(`/api/v1/settings/public`, { cache: 'no-store' });
-    const currentSettings: PublicSettingsResponse = await res.json();
-    this.initializeHeaders(
-      currentSettings.applicationTitle,
-      currentSettings.plexClientIdentifier
-    );
-    await this.getPin();
-
-    if (!this.plexHeaders || !this.pin) {
-      throw new Error('Unable to call login if class is not initialized.');
-    }
-
-    const params = {
-      clientID: this.plexHeaders['X-Plex-Client-Identifier'],
-      'context[device][product]': this.plexHeaders['X-Plex-Product'],
-      'context[device][version]': this.plexHeaders['X-Plex-Version'],
-      'context[device][platform]': this.plexHeaders['X-Plex-Platform'],
-      'context[device][platformVersion]':
-        this.plexHeaders['X-Plex-Platform-Version'],
-      'context[device][device]': this.plexHeaders['X-Plex-Device'],
-      'context[device][deviceName]': this.plexHeaders['X-Plex-Device-Name'],
-      'context[device][model]': this.plexHeaders['X-Plex-Model'],
-      'context[device][screenResolution]':
-        this.plexHeaders['X-Plex-Device-Screen-Resolution'],
-      'context[device][layout]': 'desktop',
-      code: this.pin.code,
-    };
+    const browser = Bowser.getParser(window.navigator.userAgent);
+    const response = await axios.post<PlexPinSession>('/api/v1/auth/plex/pin', {
+      client: {
+        platform: browser.getBrowserName(),
+        platformVersion: browser.getBrowserVersion(),
+        device: browser.getOSName(),
+        screenResolution: window.screen.width + 'x' + window.screen.height,
+      },
+    });
+    this.pin = response.data;
 
     if (!this.popup || this.popup.closed) {
       throw new Error(
@@ -116,9 +48,7 @@ class PlexOAuth {
       );
     }
 
-    this.popup.location.href = `https://app.plex.tv/auth/#!?${this.encodeData(
-      params
-    )}`;
+    this.popup.location.href = this.pin.authUrl;
 
     return this.pinPoll();
   }
@@ -129,44 +59,48 @@ class PlexOAuth {
     const deadline = Date.now() + 15 * 60 * 1000;
 
     const executePoll = async (
-      resolve: (authToken: string) => void,
+      resolve: (pinId: string) => void,
       reject: (e: Error) => void
     ) => {
-      try {
-        if (!this.pin) {
-          throw new Error('Unable to poll when pin is not initialized.');
-        }
-
-        // Check if popup was manually closed by user (before any cross-origin navigation)
-        if (this.popup?.closed) {
-          reject(new Error('Popup closed without completing login'));
-          return;
-        }
-
-        const response = await axios.get(
-          `https://plex.tv/api/v2/pins/${this.pin.id}`,
-          { headers: this.plexHeaders }
-        );
-
-        if (response.data?.authToken) {
-          this.authToken = response.data.authToken as string;
-          this.closePopup();
-          resolve(this.authToken);
-        } else {
-          const expiresAt = response.data?.expiresAt
-            ? Date.parse(response.data.expiresAt as string)
-            : deadline;
-          if (Date.now() >= Math.min(expiresAt, deadline)) {
-            this.closePopup();
-            reject(new Error('Plex PIN expired before login completed.'));
-            return;
-          }
-          setTimeout(executePoll, 1000, resolve, reject);
-        }
-      } catch (e) {
+      if (!this.pin) {
         this.closePopup();
-        reject(e);
+        reject(new Error('Unable to poll when pin is not initialized.'));
+        return;
       }
+      const pinId = this.pin.id;
+
+      let status: PlexPinStatus | undefined;
+      try {
+        const response = await axios.get<{ status: PlexPinStatus }>(
+          `/api/v1/auth/plex/pin/${pinId}`
+        );
+        status = response.data.status;
+      } catch {
+        // A transient status-endpoint failure (network blip, rate limit, brief
+        // 5xx) shouldn't abort the whole sign-in. Leave `status` undefined and
+        // fall through; the popup-closed and deadline checks below still bound
+        // the loop, and the next tick will retry.
+      }
+
+      if (status === 'authorized') {
+        this.closePopup();
+        resolve(pinId);
+        return;
+      }
+
+      if (this.popup?.closed) {
+        this.closePopup();
+        reject(new Error('Popup closed without completing login'));
+        return;
+      }
+
+      if (status === 'expired' || Date.now() >= deadline) {
+        this.closePopup();
+        reject(new Error('Plex sign-in expired before login completed.'));
+        return;
+      }
+
+      setTimeout(executePoll, 2000, resolve, reject);
     };
 
     return new Promise(executePoll);
@@ -227,14 +161,6 @@ class PlexOAuth {
       this.popup = newWindow;
       return this.popup;
     }
-  }
-
-  private encodeData(data: Record<string, string>): string {
-    return Object.keys(data)
-      .map(function (key) {
-        return [key, data[key]].map(encodeURIComponent).join('=');
-      })
-      .join('&');
   }
 }
 

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -5050,8 +5050,8 @@ paths:
                 $ref: '#/components/schemas/User'
   /auth/plex:
     post:
-      summary: Sign in using a Plex token
-      description: Takes an `authToken` (Plex token) to log the user in. Generates a session cookie for use in further invites. If the user does not exist, and there are no other users, then a user will be created with full admin privileges. If a user logs in with access to the main Plex server, they will also have an account created, but without any permissions.
+      summary: Sign in using a Plex pin session
+      description: Takes a `pinId` from a completed server-side Plex pin exchange (see `/auth/plex/pin`) and logs the user in. Generates a session cookie for use in further invites. If the user does not exist, and there are no other users, then a user will be created with full admin privileges. If a user logs in with access to the main Plex server, they will also have an account created, but without any permissions. A raw `authToken` is still accepted for backward compatibility but is deprecated.
       security: []
       tags:
         - auth
@@ -5069,10 +5069,80 @@ paths:
             schema:
               type: object
               properties:
+                pinId:
+                  type: string
+                  description: Pin session id from `/auth/plex/pin` once its status is `authorized`.
                 authToken:
                   type: string
-              required:
-                - authToken
+                  deprecated: true
+                  description: Raw Plex auth token (legacy client-side flow). Prefer `pinId`.
+  /auth/plex/pin:
+    post:
+      summary: Begin a server-side Plex sign-in
+      description: Creates a Plex pin server-side and returns an opaque pin session id together with the `app.plex.tv` auth URL to open in a popup. The Plex auth token resulting from the authorization is held server-side and never returned to the browser; pass the `pinId` to `/auth/plex`, `/signup/plexauth`, or `/user/{userId}/settings/linked-accounts/plex` to complete the relevant flow.
+      security: []
+      tags:
+        - auth
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                client:
+                  type: object
+                  description: Optional browser hints used to label the device in the user's Plex device list.
+                  properties:
+                    platform:
+                      type: string
+                    platformVersion:
+                      type: string
+                    device:
+                      type: string
+                    screenResolution:
+                      type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Opaque pin session id (single-use).
+                  authUrl:
+                    type: string
+                    description: app.plex.tv URL to open in the sign-in popup.
+                  expiresAt:
+                    type: string
+                    format: date-time
+  /auth/plex/pin/{pinId}:
+    get:
+      summary: Poll a Plex pin session
+      description: Returns the authorization status of a pin session created via `/auth/plex/pin`. The Plex auth token is never included in the response.
+      security: []
+      tags:
+        - auth
+      parameters:
+        - in: path
+          name: pinId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    enum: [pending, authorized, expired]
   /auth/local:
     post:
       summary: Sign in using a local account
@@ -6086,7 +6156,7 @@ paths:
   /user/{userId}/settings/linked-accounts/plex:
     post:
       summary: Link a Plex account to the logged-in user
-      description: Links a Plex account to the logged-in user using a provided Plex token. Requires an active session.
+      description: Links a Plex account to the logged-in user. Pass a `pinId` from a completed server-side Plex pin exchange (see `/auth/plex/pin`); a raw `authToken` is also accepted but deprecated. Requires an active session.
       tags:
         - users
       parameters:
@@ -6102,15 +6172,20 @@ paths:
             schema:
               type: object
               properties:
+                pinId:
+                  type: string
+                  description: Pin session id from `/auth/plex/pin` once its status is `authorized`.
                 authToken:
                   type: string
-              required:
-                - authToken
+                  deprecated: true
+                  description: Raw Plex auth token (legacy client-side flow). Prefer `pinId`.
       responses:
         '204':
           description: Plex account successfully linked
+        '400':
+          description: Request body is missing both `pinId` and `authToken`
         '401':
-          description: Invalid or expired Plex token
+          description: Plex sign-in session is invalid or expired, or the Plex token is invalid or expired
         '422':
           description: Plex account already linked to another user, or email mismatch
         '500':
@@ -7887,14 +7962,17 @@ paths:
             schema:
               type: object
               properties:
+                pinId:
+                  type: string
+                  description: Pin session id from `/auth/plex/pin` once its status is `authorized`.
                 authToken:
                   type: string
-                  description: Plex authentication token
+                  deprecated: true
+                  description: Raw Plex auth token (legacy client-side flow). Prefer `pinId`.
                 icode:
                   type: string
                   description: Invite code
               required:
-                - authToken
                 - icode
       responses:
         '200':


### PR DESCRIPTION
## Description
The Plex OAuth pin lifecycle (pin creation, polling plex.tv for authorization, and token exchange) currently runs in the browser, which means the Plex auth token transits the client before being POSTed back to the server. This PR moves that entire lifecycle server-side so the Plex auth token never reaches the browser.

Clients now receive an opaque, single-use pin session id and pass it to the `login/signup/account-link` endpoints as `pinId`. The server owns pin creation, polls plex.tv, holds the resulting token, and consumes it exactly once when completing the relevant flow.

This is the first piece of the broader auth modernization tracked in #322 and is valuable on its own — it's a self-contained security improvement with no dependency on the later JWT work.

### Changes
- New server`/lib/plexAuth` module managing the pin session lifecycle: `createPin` (creates a strong pin on plex.tv with sanitized client hints so the device name in the user's Plex device list stays recognizable, e.g. "Chrome (Streamarr)"), `getStatus` (polls plex.tv on demand; never returns the token), and `consumeToken` (single-use retrieval that destroys the session).
- New endpoints: POST `/auth/plex/pin` (rate-limited) and GET `/auth/plex/pin/:id`.
- Updated flows — POST `/auth/plex`, POST `/signup/plexauth`, and POST `/user/:id/settings/linked-accounts/plex` now resolve the credential server-side from `pinId`. A raw `authToken` body is still accepted but deprecated for backward compatibility.
- Client (`src/utils/plex.ts`) reduced to popup management plus polling the server's status endpoint; login() resolves with the pin session id. The five consumers (`PlexLoginBtn`, `SignIn`, `Setup`, `SignUpAuthForm`, `UserSettingsAccounts`) are updated accordingly.
- OpenAPI (`streamarr-api.yml`) documents the two new endpoints and marks the legacy `authToken` body deprecated.
- Cypress coverage: server-contract tests (single-use rejection, unknown/expired sessions, and a guarantee that no token ever appears in a client-visible response) plus a fully stubbed UI sign-in flow.

### Linked Issues

- Refs #322 

## Has This Been Tested?

- [x] New Cypress spec passes.
- [x] Manual verification of all four entry points against a real Plex account: sign-in, first-run setup, invite signup, and account re-link — confirming the token is absent from all browser-visible network traffic.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
