### PR TITLE
feat(auth): experimental per-user Plex JWT provisioning

### DIFF
--- a/docs/using-streamarr/settings/README.md
+++ b/docs/using-streamarr/settings/README.md
@@ -234,6 +234,20 @@ When enabled, users can sign up for an account using an [invite code](../invites
 
 This setting is **disabled** by default.
 
+### Plex JWT Authentication (Experimental)
+
+When enabled, Streamarr provisions a short-lived Plex **JWT** (JSON Web Token) for each user alongside their existing Plex token when they sign in, and prefers the JWT for calls to Plex's account service (`plex.tv`). JWTs are valid for 7 days and are refreshed automatically in the background.
+
+This is a security improvement: JWTs are short-lived and independently revocable, unlike the long-lived Plex tokens they sit beside.
+
+{% hint style="info" %}
+This setting is **experimental** and **disabled** by default. It is safe to enable or disable at any time — existing sign-ins are unaffected, and provisioning is non-fatal, so a user always continues to work on their existing Plex token if a JWT cannot be issued.
+{% endhint %}
+
+{% hint style="warning" %}
+JWTs are currently used **only** for `plex.tv` account operations. Your Plex Media Server does not yet validate JWTs, so all communication with the media server itself — library scanning, image proxying, and the embedded Plex Web player — continues to use the legacy Plex token. Enabling this setting does not change media-server behaviour.
+{% endhint %}
+
 ### Default Permissions
 
 Select the permissions assigned to new users by default upon account creation.

--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -43,7 +43,13 @@ export class User {
     return users.map((u) => u.filter(showFiltered));
   }
 
-  static readonly filteredFields: string[] = ['email', 'plexId'];
+  static readonly filteredFields: string[] = [
+    'email',
+    'plexId',
+    'plexToken',
+    'plexJwt',
+    'plexJwtDevice',
+  ];
 
   public displayName: string;
 
@@ -83,6 +89,15 @@ export class User {
 
   @Column({ type: 'text', nullable: true, select: false })
   public plexToken?: string;
+
+  @Column({ type: 'text', nullable: true, select: false })
+  public plexJwt?: string | null;
+
+  @Column({ type: 'datetime', nullable: true })
+  public plexJwtExpiresAt?: Date | null;
+
+  @Column({ type: 'text', nullable: true, select: false })
+  public plexJwtDevice?: string | null;
 
   @Column({ type: 'integer', default: 32 })
   public permissions = 32;

--- a/server/lib/adminPlexToken.ts
+++ b/server/lib/adminPlexToken.ts
@@ -1,6 +1,12 @@
 import { getRepository } from '@server/datasource';
 import { User } from '@server/entity/User';
 
+/**
+ * Returns the admin's LEGACY Plex token. This is the credential for
+ * PMS-bound calls (PlexAPI: scanner, health check, image proxy) and the
+ * /watch token injection — PMS does not validate JWTs yet. For plex.tv
+ * calls, prefer `getAdminPlexTvCredential()` from plexAuth/credentials.
+ */
 export async function getAdminPlexToken(): Promise<string | null> {
   const admin = await getRepository(User).findOne({
     select: { id: true, plexToken: true },

--- a/server/lib/plexAccessLost.ts
+++ b/server/lib/plexAccessLost.ts
@@ -8,10 +8,10 @@ import { UserType } from '@server/constants/user';
 import { getRepository } from '@server/datasource';
 import { User } from '@server/entity/User';
 import { UserSettings } from '@server/entity/UserSettings';
-import { getAdminPlexToken } from '@server/lib/adminPlexToken';
 import { userAcceptsNotificationType } from '@server/lib/notifications';
 import { sendGroupNotification } from '@server/lib/notifications/dispatch';
 import { Permission } from '@server/lib/permissions';
+import { getAdminPlexTvCredential } from '@server/lib/plexAuth/credentials';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 
@@ -195,7 +195,7 @@ const runMembershipValidation = async (
 ): Promise<void> => {
   const settings = getSettings();
   const machineId = settings.plex.machineId;
-  const adminToken = await getAdminPlexToken();
+  const adminToken = await getAdminPlexTvCredential();
 
   if (!adminToken || !machineId) {
     logger.warn(

--- a/server/lib/plexAuth/credentials.ts
+++ b/server/lib/plexAuth/credentials.ts
@@ -1,0 +1,64 @@
+import { getRepository } from '@server/datasource';
+import { User } from '@server/entity/User';
+import { getSettings } from '@server/lib/settings';
+
+/**
+ * Credential selection for plex.tv API calls.
+ *
+ * When `main.experimentalJwtAuth` is enabled and the user holds a fresh JWT,
+ * plex.tv calls prefer it; otherwise they fall back to the legacy token.
+ * Falling back is always safe — every plex.tv endpoint streamarr uses
+ * accepts both credential types.
+ *
+ * SCOPE: plex.tv ONLY. PMS does not validate JWTs yet, so everything that
+ * talks to the media server itself (PlexAPI consumers: scanner, health
+ * check, image proxy) and the /watch token injection MUST continue to use
+ * the legacy token. Do not route those through these helpers.
+ */
+
+const JWT_FRESHNESS_MARGIN_MS = 60 * 1000;
+
+type CredentialFields = Pick<
+  User,
+  'plexToken' | 'plexJwt' | 'plexJwtExpiresAt'
+>;
+
+/**
+ * Returns the preferred plex.tv credential for an already-loaded user.
+ * Note: `plexToken` and the JWT fields are `select: false`, so callers must
+ * explicitly select at least `plexToken` (and optionally the JWT fields) for
+ * this to return anything other than `null`.
+ */
+export const preferPlexJwt = (
+  user: Partial<CredentialFields> | null | undefined
+): string | null => {
+  if (!user) {
+    return null;
+  }
+
+  const settings = getSettings();
+  if (
+    settings.main.experimentalJwtAuth &&
+    user.plexJwt &&
+    user.plexJwtExpiresAt &&
+    user.plexJwtExpiresAt.getTime() > Date.now() + JWT_FRESHNESS_MARGIN_MS
+  ) {
+    return user.plexJwt;
+  }
+
+  return user.plexToken ?? null;
+};
+
+/**
+ * Loads the admin user and returns the preferred plex.tv credential.
+ * For PMS-bound calls use `getAdminPlexToken()` instead.
+ */
+export const getAdminPlexTvCredential = async (): Promise<string | null> => {
+  const admin = await getRepository(User)
+    .createQueryBuilder('user')
+    .addSelect(['user.plexToken', 'user.plexJwt', 'user.plexJwtExpiresAt'])
+    .where('user.id = :id', { id: 1 })
+    .getOne();
+
+  return preferPlexJwt(admin);
+};

--- a/server/lib/plexAuth/jwt.ts
+++ b/server/lib/plexAuth/jwt.ts
@@ -1,0 +1,311 @@
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+import { getAppVersion } from '@server/utils/appVersion';
+import axios from 'axios';
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  createPrivateKey,
+  sign as cryptoSign,
+  generateKeyPairSync,
+  randomBytes,
+  randomUUID,
+} from 'crypto';
+
+/**
+ * Plex JWT device identity & lifecycle.
+ *
+ * Implements the flow:
+ * one user-visible sign-in yields a legacy token (device = the shared
+ * `settings.clientId`, used for PMS + the embedded /watch player), and the
+ * server then silently provisions a SEPARATE per-user JWT device:
+ *
+ *   1. generate a per-user device identity (uuid + Ed25519 keypair)
+ *   2. create a strong pin with the device's public JWK embedded
+ *   3. authorize the pin server-side via PUT plex.tv/api/v2/pins/link,
+ *      using the user's fresh legacy token (no browser interaction)
+ *   4. exchange the pin with a signed deviceJWT -> 7-day Plex JWT
+ *
+ * HARD RULES:
+ *   - NEVER call POST /api/v2/auth/jwk: it binds the key to the *token's*
+ *     device regardless of the X-Plex-Client-Identifier header, which would
+ *     target the shared legacy device.
+ *   - NEVER mint a JWT under the shared `settings.clientId`: Plex
+ *     invalidates a device's legacy token the moment a JWT is issued for
+ *     that device, which would break PMS access and /watch for the user.
+ *   - Always sign device JWTs with `iss` = the per-user device clientId;
+ *     plex.tv enforces this strictly (error 1097 on mismatch).
+ */
+
+const JWT_SCOPE = 'username,email,friendly_name';
+const DEVICE_JWT_TTL_SECONDS = 5 * 60;
+const PIN_LINK_TIMEOUT_MS = 15000;
+const ENCRYPTION_VERSION = 'v1';
+
+export interface PlexJwtDevice {
+  clientId: string;
+  kid: string;
+  privateKeyPem: string;
+  publicJwk: {
+    kty: string;
+    crv: string;
+    x: string;
+    use: string;
+    alg: string;
+    kid: string;
+  };
+}
+
+export interface PlexJwtResult {
+  jwt: string;
+  expiresAt: Date;
+}
+
+const b64u = (data: Buffer | string): string =>
+  Buffer.from(data).toString('base64url');
+
+export const generateDeviceIdentity = (): PlexJwtDevice => {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const jwk = publicKey.export({ format: 'jwk' }) as {
+    kty: string;
+    crv: string;
+    x: string;
+  };
+
+  // RFC 7638 thumbprint over the canonical {crv, kty, x} members
+  const kid = b64u(
+    createHash('sha256')
+      .update(JSON.stringify({ crv: jwk.crv, kty: jwk.kty, x: jwk.x }))
+      .digest()
+  );
+
+  return {
+    clientId: randomUUID(),
+    kid,
+    privateKeyPem: privateKey
+      .export({ type: 'pkcs8', format: 'pem' })
+      .toString(),
+    publicJwk: {
+      kty: jwk.kty,
+      crv: jwk.crv,
+      x: jwk.x,
+      use: 'sig',
+      alg: 'EdDSA',
+      kid,
+    },
+  };
+};
+
+const signDeviceJwt = (
+  device: PlexJwtDevice,
+  extraClaims: Record<string, unknown> = {}
+): string => {
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: 'EdDSA', typ: 'JWT', kid: device.kid };
+  const payload = {
+    aud: 'plex.tv',
+    iss: device.clientId,
+    iat: now,
+    exp: now + DEVICE_JWT_TTL_SECONDS,
+    scope: JWT_SCOPE,
+    ...extraClaims,
+  };
+
+  const signingInput = `${b64u(JSON.stringify(header))}.${b64u(
+    JSON.stringify(payload)
+  )}`;
+  const signature = cryptoSign(
+    null,
+    Buffer.from(signingInput),
+    createPrivateKey(device.privateKeyPem)
+  );
+
+  return `${signingInput}.${b64u(signature)}`;
+};
+
+export const decodeJwtExpiry = (jwt: string): Date | null => {
+  const parts = jwt.split('.');
+  if (parts.length !== 3) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1], 'base64url').toString()
+    ) as { exp?: number };
+    return payload.exp ? new Date(payload.exp * 1000) : null;
+  } catch {
+    return null;
+  }
+};
+
+const looksLikeJwt = (token: unknown): token is string =>
+  typeof token === 'string' && token.split('.').length === 3;
+
+const deviceHeaders = (clientId: string): Record<string, string> => {
+  const settings = getSettings();
+  return {
+    Accept: 'application/json',
+    'X-Plex-Product': settings.main.applicationTitle,
+    'X-Plex-Version': getAppVersion(),
+    'X-Plex-Client-Identifier': clientId,
+    'X-Plex-Platform': 'Streamarr',
+    'X-Plex-Device': 'Server',
+    'X-Plex-Device-Name': `${settings.main.applicationTitle} (Secure Auth)`,
+  };
+};
+
+/**
+ * Provisions a JWT for a user from their freshly obtained legacy token.
+ * The legacy token remains valid: the pin (and therefore the JWT) is bound
+ * to the brand-new per-user device, not the shared legacy device.
+ */
+export const provisionJwt = async (
+  legacyToken: string
+): Promise<{ device: PlexJwtDevice } & PlexJwtResult> => {
+  const settings = getSettings();
+  const device = generateDeviceIdentity();
+  const headers = deviceHeaders(device.clientId);
+
+  // 1. Strong pin with the device's public JWK embedded
+  const pinResponse = await axios.post<{ id: number; code: string }>(
+    'https://clients.plex.tv/api/v2/pins',
+    { jwk: device.publicJwk, strong: true },
+    {
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      timeout: PIN_LINK_TIMEOUT_MS,
+    }
+  );
+
+  // 2. Authorize the pin server-side with the user's legacy token. The
+  //    authorizing device is the shared legacy device (settings.clientId),
+  //    matching the device the legacy token is bound to.
+  await axios.put(
+    'https://plex.tv/api/v2/pins/link',
+    new URLSearchParams({ code: pinResponse.data.code }).toString(),
+    {
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Plex-Product': settings.main.applicationTitle,
+        'X-Plex-Version': getAppVersion(),
+        'X-Plex-Client-Identifier': settings.clientId,
+        'X-Plex-Token': legacyToken,
+      },
+      timeout: PIN_LINK_TIMEOUT_MS,
+    }
+  );
+
+  // 3. Exchange the linked pin with a signed deviceJWT for the Plex JWT
+  const exchangeResponse = await axios.get<{ authToken?: string | null }>(
+    `https://clients.plex.tv/api/v2/pins/${pinResponse.data.id}`,
+    {
+      headers,
+      params: { deviceJWT: signDeviceJwt(device) },
+      timeout: PIN_LINK_TIMEOUT_MS,
+    }
+  );
+
+  const jwt = exchangeResponse.data.authToken;
+  if (!looksLikeJwt(jwt)) {
+    throw new Error(
+      'Plex pin exchange did not return a JWT after server-side link.'
+    );
+  }
+
+  const expiresAt = decodeJwtExpiry(jwt);
+  if (!expiresAt) {
+    throw new Error('Unable to determine expiry of the issued Plex JWT.');
+  }
+
+  return { device, jwt, expiresAt };
+};
+
+/**
+ * Refreshes a device's JWT via the nonce exchange. Works before and after
+ * expiry of the previous JWT.
+ */
+export const refreshJwt = async (
+  device: PlexJwtDevice
+): Promise<PlexJwtResult> => {
+  const headers = deviceHeaders(device.clientId);
+
+  const nonceResponse = await axios.get<{ nonce: string }>(
+    'https://clients.plex.tv/api/v2/auth/nonce',
+    { headers, timeout: PIN_LINK_TIMEOUT_MS }
+  );
+
+  const tokenResponse = await axios.post<{
+    auth_token?: string;
+    authToken?: string;
+  }>(
+    'https://clients.plex.tv/api/v2/auth/token',
+    { jwt: signDeviceJwt(device, { nonce: nonceResponse.data.nonce }) },
+    {
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      timeout: PIN_LINK_TIMEOUT_MS,
+    }
+  );
+
+  const jwt = tokenResponse.data.auth_token ?? tokenResponse.data.authToken;
+  if (!looksLikeJwt(jwt)) {
+    throw new Error('Plex JWT refresh did not return a JWT.');
+  }
+
+  const expiresAt = decodeJwtExpiry(jwt);
+  if (!expiresAt) {
+    throw new Error('Unable to determine expiry of the refreshed Plex JWT.');
+  }
+
+  return { jwt, expiresAt };
+};
+
+/**
+ * Device identity encryption at rest (AES-256-GCM, key derived from the
+ * session secret). If the secret changes, decryption fails and the device is
+ * treated as missing — the user keeps working on their legacy token and is
+ * re-provisioned at next sign-in.
+ */
+const encryptionKey = (): Buffer =>
+  createHash('sha256').update(getSettings().sessionSecret).digest();
+
+export const encryptDevice = (device: PlexJwtDevice): string => {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', encryptionKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(device), 'utf8'),
+    cipher.final(),
+  ]);
+  return [
+    ENCRYPTION_VERSION,
+    iv.toString('base64url'),
+    cipher.getAuthTag().toString('base64url'),
+    ciphertext.toString('base64url'),
+  ].join(':');
+};
+
+export const decryptDevice = (encrypted: string): PlexJwtDevice | null => {
+  try {
+    const [version, iv, tag, ciphertext] = encrypted.split(':');
+    if (version !== ENCRYPTION_VERSION || !iv || !tag || !ciphertext) {
+      return null;
+    }
+    const decipher = createDecipheriv(
+      'aes-256-gcm',
+      encryptionKey(),
+      Buffer.from(iv, 'base64url')
+    );
+    decipher.setAuthTag(Buffer.from(tag, 'base64url'));
+    const plaintext = Buffer.concat([
+      decipher.update(Buffer.from(ciphertext, 'base64url')),
+      decipher.final(),
+    ]).toString('utf8');
+    return JSON.parse(plaintext) as PlexJwtDevice;
+  } catch (e) {
+    logger.debug('Failed to decrypt Plex JWT device identity', {
+      label: 'Plex JWT',
+      errorMessage: e instanceof Error ? e.message : String(e),
+    });
+    return null;
+  }
+};

--- a/server/lib/plexAuth/provision.ts
+++ b/server/lib/plexAuth/provision.ts
@@ -1,0 +1,73 @@
+import { getRepository } from '@server/datasource';
+import { User } from '@server/entity/User';
+import { encryptDevice, provisionJwt } from '@server/lib/plexAuth/jwt';
+import { getSettings } from '@server/lib/settings';
+import logger from '@server/logger';
+
+/**
+ * Provisions a per-user Plex JWT device after a successful legacy sign-in
+ * gated behind `main.experimentalJwtAuth`.
+ *
+ * Designed to be called fire-and-forget from login/signup/link handlers:
+ * any failure is non-fatal — the user is already signed in and their legacy
+ * token covers every current consumer. Provisioning is retried at their
+ * next sign-in.
+ */
+export const maybeProvisionPlexJwt = async (
+  userId: number,
+  legacyToken: string
+): Promise<void> => {
+  const settings = getSettings();
+  if (!settings.main.experimentalJwtAuth) {
+    return;
+  }
+
+  try {
+    const userRepository = getRepository(User);
+    const user = await userRepository
+      .createQueryBuilder('user')
+      .addSelect([
+        'user.plexJwt',
+        'user.plexJwtDevice',
+        'user.plexJwtExpiresAt',
+      ])
+      .where('user.id = :id', { id: userId })
+      .getOne();
+
+    if (!user) {
+      return;
+    }
+
+    // A user with a healthy, unexpired JWT doesn't need re-provisioning.
+    if (
+      user.plexJwtDevice &&
+      user.plexJwt &&
+      user.plexJwtExpiresAt &&
+      user.plexJwtExpiresAt.getTime() > Date.now()
+    ) {
+      return;
+    }
+
+    const { device, jwt, expiresAt } = await provisionJwt(legacyToken);
+
+    user.plexJwtDevice = encryptDevice(device);
+    user.plexJwt = jwt;
+    user.plexJwtExpiresAt = expiresAt;
+    await userRepository.save(user);
+
+    logger.info('Provisioned Plex JWT device for user', {
+      label: 'Plex JWT',
+      userId,
+      jwtExpiresAt: expiresAt.toISOString(),
+    });
+  } catch (e) {
+    logger.warn(
+      'Plex JWT provisioning failed; user continues on legacy token and will be re-provisioned at next sign-in',
+      {
+        label: 'Plex JWT',
+        userId,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      }
+    );
+  }
+};

--- a/server/lib/plexSync.ts
+++ b/server/lib/plexSync.ts
@@ -6,7 +6,10 @@ import type {
   PlexSharePermissions,
   PlexUserIdentity,
 } from '@server/interfaces/api/plexInterfaces';
-import { getAdminPlexToken } from '@server/lib/adminPlexToken';
+import {
+  getAdminPlexTvCredential,
+  preferPlexJwt,
+} from '@server/lib/plexAuth/credentials';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import AsyncLock from '@server/utils/asyncLock';
@@ -56,11 +59,11 @@ class PlexSync {
   private lock = new AsyncLock();
 
   private async getAdminApi(): Promise<PlexTvAPI> {
-    const plexToken = await getAdminPlexToken();
-    if (!plexToken) {
-      throw new Error('Admin Plex token is missing');
+    const credential = await getAdminPlexTvCredential();
+    if (!credential) {
+      throw new Error('Admin Plex credential is missing');
     }
-    return new PlexTvAPI(plexToken);
+    return new PlexTvAPI(credential);
   }
 
   private getIdentity(user: User): PlexUserIdentity {
@@ -310,7 +313,7 @@ class PlexSync {
   ): void {
     const settings = getSettings();
     const serverName = settings.plex.name || undefined;
-    const userToken = options.userTokenOverride || user.plexToken;
+    const userToken = options.userTokenOverride || preferPlexJwt(user);
 
     if (userToken) {
       logger.info('Attempting background auto-accept of Plex invite', {

--- a/server/lib/refreshToken.ts
+++ b/server/lib/refreshToken.ts
@@ -1,7 +1,26 @@
 import PlexTvAPI from '@server/api/plextv';
 import { getRepository } from '@server/datasource';
 import { User } from '@server/entity/User';
+import { decryptDevice, refreshJwt } from '@server/lib/plexAuth/jwt';
+import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import { isAxiosError } from 'axios';
+
+/**
+ * Plex credential maintenance job.
+ *
+ * Two responsibilities per user:
+ *   1. Legacy tokens: best-effort keep-alive ping (unchanged behavior).
+ *      Legacy tokens remain required for PMS access and the embedded /watch
+ *      player until Plex ships PMS-side JWT validation.
+ *   2. JWTs (experimental): refresh any JWT within REFRESH_THRESHOLD of
+ *      expiry via the nonce exchange. The exchange also works after expiry,
+ *      so a missed run is recoverable. On a terminal rejection (4xx) the
+ *      JWT state is cleared — the user silently falls back to their legacy
+ *      token everywhere and is re-provisioned at their next sign-in.
+ */
+
+const JWT_REFRESH_THRESHOLD_MS = 2 * 24 * 60 * 60 * 1000;
 
 class RefreshToken {
   private isRunning = false;
@@ -31,8 +50,14 @@ class RefreshToken {
 
     const users = await userRepository
       .createQueryBuilder('user')
-      .addSelect('user.plexToken')
+      .addSelect([
+        'user.plexToken',
+        'user.plexJwt',
+        'user.plexJwtDevice',
+        'user.plexJwtExpiresAt',
+      ])
       .where("user.plexToken != ''")
+      .orWhere('user.plexJwtDevice IS NOT NULL')
       .getMany();
 
     for (const user of users) {
@@ -42,18 +67,15 @@ class RefreshToken {
         });
         return;
       }
-      await this.refreshUserToken(user);
+      this.refreshUserLegacyToken(user);
+      await this.refreshUserJwt(user);
     }
 
     this.isRunning = false;
   }
 
-  private async refreshUserToken(user: User) {
+  private refreshUserLegacyToken(user: User) {
     if (!user.plexToken) {
-      logger.warn('Skipping user refresh token for user without plex token', {
-        label: 'Plex Refresh Token',
-        user: user.displayName,
-      });
       return;
     }
 
@@ -62,6 +84,70 @@ class RefreshToken {
       // Failures are already logged inside pingToken; keep-alive pings are
       // best-effort and must not become unhandled rejections.
     });
+  }
+
+  private async refreshUserJwt(user: User) {
+    const settings = getSettings();
+    if (!settings.main.experimentalJwtAuth || !user.plexJwtDevice) {
+      return;
+    }
+
+    const expiresAtMs = user.plexJwtExpiresAt?.getTime() ?? 0;
+    if (expiresAtMs - Date.now() > JWT_REFRESH_THRESHOLD_MS) {
+      return;
+    }
+
+    const device = decryptDevice(user.plexJwtDevice);
+    if (!device) {
+      // Session secret changed or data corrupted: clear and let the next
+      // sign-in re-provision. Legacy token keeps everything working.
+      logger.warn(
+        'Unable to decrypt Plex JWT device identity; clearing JWT state for re-provisioning',
+        { label: 'Plex JWT', userId: user.id }
+      );
+      await this.clearJwtState(user);
+      return;
+    }
+
+    try {
+      const { jwt, expiresAt } = await refreshJwt(device);
+      user.plexJwt = jwt;
+      user.plexJwtExpiresAt = expiresAt;
+      await getRepository(User).save(user);
+      logger.debug('Refreshed Plex JWT for user', {
+        label: 'Plex JWT',
+        userId: user.id,
+        jwtExpiresAt: expiresAt.toISOString(),
+      });
+    } catch (e) {
+      const status = isAxiosError(e) ? e.response?.status : undefined;
+      const terminal = !!status && status >= 400 && status < 500;
+
+      if (terminal) {
+        logger.warn(
+          'Plex rejected JWT refresh; clearing JWT state for re-provisioning at next sign-in',
+          {
+            label: 'Plex JWT',
+            userId: user.id,
+            status,
+          }
+        );
+        await this.clearJwtState(user);
+      } else {
+        logger.debug('Transient Plex JWT refresh failure; will retry', {
+          label: 'Plex JWT',
+          userId: user.id,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+  }
+
+  private async clearJwtState(user: User) {
+    user.plexJwt = null;
+    user.plexJwtExpiresAt = null;
+    user.plexJwtDevice = null;
+    await getRepository(User).save(user);
   }
 }
 

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -169,6 +169,7 @@ export interface MainSettings {
   trialPeriodOutcome: 'promote' | 'deactivate';
   enableHelpCentre: boolean;
   theme: Theme;
+  experimentalJwtAuth: boolean;
 }
 
 interface PublicSettings {
@@ -429,6 +430,7 @@ class Settings {
         extendedHome: true,
         libraryCounts: true,
         enableTrialPeriod: false,
+        experimentalJwtAuth: false,
         trialPeriodDays: 30,
         trialPeriodOutcome: 'promote',
         enableHelpCentre: true,

--- a/server/lib/trialExpiry.ts
+++ b/server/lib/trialExpiry.ts
@@ -3,6 +3,7 @@ import SeerrAPI from '@server/api/seerr';
 import { getRepository } from '@server/datasource';
 import { User } from '@server/entity/User';
 import { Permission } from '@server/lib/permissions';
+import { preferPlexJwt } from '@server/lib/plexAuth/credentials';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 
@@ -89,11 +90,11 @@ class TrialExpiry {
 
       const admin = await userRepository
         .createQueryBuilder('user')
-        .addSelect('user.plexToken')
+        .addSelect(['user.plexToken', 'user.plexJwt', 'user.plexJwtExpiresAt'])
         .where('user.id = :id', { id: 1 })
         .getOne();
 
-      const adminToken = admin?.plexToken;
+      const adminToken = preferPlexJwt(admin);
       const machineId = settings.plex.machineId;
 
       if (!adminToken || !machineId) {

--- a/server/migration/1784417075730-PlexJwtAuth.ts
+++ b/server/migration/1784417075730-PlexJwtAuth.ts
@@ -1,0 +1,24 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class PlexJwtAuth1784417075730 implements MigrationInterface {
+  name = 'PlexJwtAuth1784417075730';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ADD COLUMN "plexJwt" text`);
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD COLUMN "plexJwtExpiresAt" datetime`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD COLUMN "plexJwtDevice" text`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Requires SQLite >= 3.35 (bundled with the sqlite3 driver in use)
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "plexJwtDevice"`);
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP COLUMN "plexJwtExpiresAt"`
+    );
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "plexJwt"`);
+  }
+}

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -11,6 +11,8 @@ import plexPinAuth, {
   resolvePlexAuthToken,
   type PlexPinClientInfo,
 } from '@server/lib/plexAuth';
+import { preferPlexJwt } from '@server/lib/plexAuth/credentials';
+import { maybeProvisionPlexJwt } from '@server/lib/plexAuth/provision';
 import {
   plexAuthLimiter,
   plexPinLimiter,
@@ -128,10 +130,17 @@ authRoutes.post('/plex', plexAuthLimiter, async (req, res, next) => {
       await userRepository.save(user);
     } else {
       const mainUser = await userRepository.findOneOrFail({
-        select: { id: true, plexToken: true, plexId: true, email: true },
+        select: {
+          id: true,
+          plexToken: true,
+          plexId: true,
+          email: true,
+          plexJwt: true,
+          plexJwtExpiresAt: true,
+        },
         where: { id: 1 },
       });
-      const mainPlexTv = new PlexTvAPI(mainUser.plexToken ?? '');
+      const mainPlexTv = new PlexTvAPI(preferPlexJwt(mainUser) ?? '');
 
       if (!account.id) {
         logger.error('Plex ID was missing from Plex.tv response', {
@@ -265,6 +274,9 @@ authRoutes.post('/plex', plexAuthLimiter, async (req, res, next) => {
       req.session.userId = user.id;
     }
 
+    // Silently provision a per-user Plex JWT device (experimental, non-fatal)
+    void maybeProvisionPlexJwt(user.id, authToken);
+
     res.status(200).json(user?.filter() ?? {});
   } catch (e) {
     logger.error('Something went wrong authenticating with Plex account', {
@@ -316,10 +328,16 @@ authRoutes.post('/local', async (req, res, next) => {
     }
 
     const mainUser = await userRepository.findOneOrFail({
-      select: { id: true, plexToken: true, plexId: true },
+      select: {
+        id: true,
+        plexToken: true,
+        plexId: true,
+        plexJwt: true,
+        plexJwtExpiresAt: true,
+      },
       where: { id: 1 },
     });
-    const mainPlexTv = new PlexTvAPI(mainUser.plexToken ?? '');
+    const mainPlexTv = new PlexTvAPI(preferPlexJwt(mainUser) ?? '');
 
     if (
       user.active &&

--- a/server/routes/signup.ts
+++ b/server/routes/signup.ts
@@ -7,6 +7,8 @@ import { User } from '@server/entity/User';
 import { UserSettings } from '@server/entity/UserSettings';
 import { Permission } from '@server/lib/permissions';
 import { resolvePlexAuthToken } from '@server/lib/plexAuth';
+import { preferPlexJwt } from '@server/lib/plexAuth/credentials';
+import { maybeProvisionPlexJwt } from '@server/lib/plexAuth/provision';
 import { plexSync } from '@server/lib/plexSync';
 import { plexAuthLimiter } from '@server/lib/rateLimiters';
 import { getSettings } from '@server/lib/settings';
@@ -113,13 +115,14 @@ signupRoutes.post('/plexauth', plexAuthLimiter, async (req, res) => {
     // Check if user is already a member of Plex server
     const mainUser = await userRepository
       .createQueryBuilder('user')
-      .addSelect('user.plexToken')
+      .addSelect(['user.plexToken', 'user.plexJwt', 'user.plexJwtExpiresAt'])
       .where('user.id = :id', { id: 1 })
       .getOne();
     let alreadyOnPlex = false;
-    if (mainUser && mainUser.plexToken) {
+    const mainCredential = preferPlexJwt(mainUser);
+    if (mainCredential) {
       try {
-        const plexTvApi = new PlexTvAPI(mainUser.plexToken);
+        const plexTvApi = new PlexTvAPI(mainCredential);
         alreadyOnPlex = await plexTvApi.checkUserAccess(plexUser.id);
       } catch (e) {
         {
@@ -240,7 +243,7 @@ signupRoutes.post('/plexauth', plexAuthLimiter, async (req, res) => {
     if (user.settings.sharedLibraries) {
       const mainUser = await userRepository
         .createQueryBuilder('user')
-        .addSelect('user.plexToken')
+        .addSelect(['user.plexToken', 'user.plexJwt', 'user.plexJwtExpiresAt'])
         .where('user.id = :id', { id: 1 })
         .getOne();
 
@@ -259,8 +262,8 @@ signupRoutes.post('/plexauth', plexAuthLimiter, async (req, res) => {
         return;
       }
 
-      // Validate the admin token before proceeding
-      const plexTvApi = new PlexTvAPI(mainUser.plexToken);
+      // Validate the admin credential before proceeding
+      const plexTvApi = new PlexTvAPI(preferPlexJwt(mainUser) ?? '');
       try {
         await plexTvApi.pingToken();
       } catch (error) {
@@ -373,6 +376,9 @@ signupRoutes.post('/plexauth', plexAuthLimiter, async (req, res) => {
     if (req.session) {
       req.session.userId = user.id;
     }
+
+    // Silently provision a per-user Plex JWT device (experimental, non-fatal)
+    void maybeProvisionPlexJwt(user.id, authToken);
 
     res.status(200).json({
       success: true,

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -21,6 +21,7 @@ import type {
 import { getAdminPlexToken } from '@server/lib/adminPlexToken';
 import ImageProxy from '@server/lib/imageproxy';
 import { hasPermission, Permission } from '@server/lib/permissions';
+import { preferPlexJwt } from '@server/lib/plexAuth/credentials';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
@@ -846,10 +847,15 @@ router.post(
 
       // taken from auth.ts
       const mainUser = await userRepository.findOneOrFail({
-        select: { id: true, plexToken: true },
+        select: {
+          id: true,
+          plexToken: true,
+          plexJwt: true,
+          plexJwtExpiresAt: true,
+        },
         where: { id: 1 },
       });
-      const mainPlexTv = new PlexTvAPI(mainUser.plexToken ?? '');
+      const mainPlexTv = new PlexTvAPI(preferPlexJwt(mainUser) ?? '');
 
       const plexUsersResponse = await mainPlexTv.getUsers();
       const createdUsers: User[] = [];

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -19,6 +19,8 @@ import { sendGroupNotification } from '@server/lib/notifications/dispatch';
 import { Permission } from '@server/lib/permissions';
 import { handlePlexAccessLost } from '@server/lib/plexAccessLost';
 import { resolvePlexAuthToken } from '@server/lib/plexAuth';
+import { preferPlexJwt } from '@server/lib/plexAuth/credentials';
+import { maybeProvisionPlexJwt } from '@server/lib/plexAuth/provision';
 import { plexSync, PlexUserNotFoundError } from '@server/lib/plexSync';
 import {
   plexAuthLimiter,
@@ -390,7 +392,7 @@ userSettingsRoutes.post<
 
       const admin = await getRepository(User)
         .createQueryBuilder('user')
-        .addSelect('user.plexToken')
+        .addSelect(['user.plexToken', 'user.plexJwt', 'user.plexJwtExpiresAt'])
         .where('user.id = :id', { id: 1 })
         .getOne();
 
@@ -401,7 +403,7 @@ userSettingsRoutes.post<
         });
       } else {
         try {
-          const plexTvApi = new PlexTvAPI(admin.plexToken);
+          const plexTvApi = new PlexTvAPI(preferPlexJwt(admin) ?? '');
           if (previousState && !plexHomeChanged) {
             try {
               await plexTvApi.deprovisionUser(
@@ -819,7 +821,7 @@ userSettingsRoutes.post<
 
       const adminUser = await userRepository
         .createQueryBuilder('user')
-        .addSelect('user.plexToken')
+        .addSelect(['user.plexToken', 'user.plexJwt', 'user.plexJwtExpiresAt'])
         .where('user.id = :id', { id: 1 })
         .getOne();
 
@@ -867,6 +869,9 @@ userSettingsRoutes.post<
 
       await userRepository.save(user);
 
+      // Silently provision a per-user Plex JWT device (experimental, non-fatal)
+      void maybeProvisionPlexJwt(user.id, authToken);
+
       if (!adminUser || !adminUser.plexToken) {
         logger.error(
           'Missing Plex admin token — skipping Plex invitation for linked account',
@@ -876,7 +881,7 @@ userSettingsRoutes.post<
       }
 
       // Check whether the user already has access to the Plex server.
-      const mainPlexTv = new PlexTvAPI(adminUser.plexToken);
+      const mainPlexTv = new PlexTvAPI(preferPlexJwt(adminUser) ?? '');
       let alreadyOnServer = false;
       try {
         alreadyOnServer = await mainPlexTv.checkUserAccess(account.id);
@@ -1327,7 +1332,7 @@ userSettingsRoutes.post<{ id: string }>(
     try {
       const user = await userRepository
         .createQueryBuilder('user')
-        .addSelect('user.plexToken')
+        .addSelect(['user.plexToken', 'user.plexJwt', 'user.plexJwtExpiresAt'])
         .where('user.id = :id', { id: Number(req.params.id) })
         .leftJoinAndSelect('user.settings', 'settings')
         .getOne();
@@ -1352,7 +1357,7 @@ userSettingsRoutes.post<{ id: string }>(
 
       const adminUser = await userRepository
         .createQueryBuilder('user')
-        .addSelect('user.plexToken')
+        .addSelect(['user.plexToken', 'user.plexJwt', 'user.plexJwtExpiresAt'])
         .where('user.id = :id', { id: 1 })
         .getOne();
 
@@ -1386,7 +1391,7 @@ userSettingsRoutes.post<{ id: string }>(
           type: lib.type,
         }));
       } else {
-        const adminApi = new PlexTvAPI(adminUser.plexToken);
+        const adminApi = new PlexTvAPI(preferPlexJwt(adminUser) ?? '');
         const share = await adminApi.getUserShare(
           {
             plexId: user.plexId,
@@ -1439,7 +1444,7 @@ userSettingsRoutes.post<{ id: string }>(
         return;
       }
 
-      const userApi = new PlexTvAPI(user.plexToken);
+      const userApi = new PlexTvAPI(preferPlexJwt(user) ?? '');
       const result = await userApi.pinServerLibraries({
         machineId: plexSettings.machineId,
         serverName: plexSettings.name || 'Streamarr',

--- a/src/components/Admin/Settings/Users/index.tsx
+++ b/src/components/Admin/Settings/Users/index.tsx
@@ -17,6 +17,7 @@ import axios from 'axios';
 import { Field, Form, Formik } from 'formik';
 import { FormattedMessage, useIntl } from 'react-intl';
 import useSWR, { mutate } from 'swr';
+import SettingsBadge from '@app/components/Admin/Settings/SettingsBadge';
 
 const UserSettings = () => {
   const intl = useIntl();
@@ -48,6 +49,7 @@ const UserSettings = () => {
         initialValues={{
           localLogin: data?.localLogin,
           newPlexLogin: data?.newPlexLogin,
+          experimentalJwtAuth: data?.experimentalJwtAuth ?? false,
           inviteQuotaLimit: data?.defaultQuotas.invites.quotaLimit ?? 3,
           inviteQuotaDays: data?.defaultQuotas.invites.quotaDays ?? 0,
           defaultPermissions: data?.defaultPermissions ?? 0,
@@ -69,6 +71,7 @@ const UserSettings = () => {
             await axios.post('/api/v1/settings/main', {
               localLogin: values.localLogin,
               newPlexLogin: values.newPlexLogin,
+              experimentalJwtAuth: values.experimentalJwtAuth,
               defaultQuotas: {
                 invites: {
                   quotaLimit: values.inviteQuotaLimit,
@@ -157,6 +160,38 @@ const UserSettings = () => {
                     name="newPlexLogin"
                     onChange={() => {
                       setFieldValue('newPlexLogin', !values.newPlexLogin);
+                    }}
+                    className="checkbox checkbox-primary rounded-md"
+                  />
+                </div>
+                <label
+                  htmlFor="experimentalJwtAuth"
+                  className="font-bold block"
+                >
+                  <span className="mr-2">
+                    <FormattedMessage
+                      id="userSettings.experimentalJwtAuth"
+                      defaultMessage="Plex JWT Authentication"
+                    />
+                  </span>
+                  <SettingsBadge badgeType="experimental" />
+                  <span className="text-sm block font-light text-neutral">
+                    <FormattedMessage
+                      id="userSettings.experimentalJwtAuthDescription"
+                      defaultMessage="Provision short-lived Plex JWT credentials for users alongside their existing token when they sign in. Safe to enable or disable at any time; existing sign-ins are unaffected."
+                    />
+                  </span>
+                </label>
+                <div className="col-span-2">
+                  <Field
+                    type="checkbox"
+                    id="experimentalJwtAuth"
+                    name="experimentalJwtAuth"
+                    onChange={() => {
+                      setFieldValue(
+                        'experimentalJwtAuth',
+                        !values.experimentalJwtAuth
+                      );
                     }}
                     className="checkbox checkbox-primary rounded-md"
                   />

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -5852,6 +5852,12 @@
   "userSettings.engine": {
     "defaultMessage": "Engine"
   },
+  "userSettings.experimentalJwtAuth": {
+    "defaultMessage": "Plex JWT Authentication"
+  },
+  "userSettings.experimentalJwtAuthDescription": {
+    "defaultMessage": "Provision short-lived Plex JWT credentials for users alongside their existing token when they sign in. Safe to enable or disable at any time; existing sign-ins are unaffected."
+  },
   "userSettings.inviteLimit": {
     "defaultMessage": "Default Invite Limit"
   },


### PR DESCRIPTION
## Description
Adds opt-in per-user Plex JWT credentials behind an admin-togglable flag (main.experimentalJwtAuth, default off). Plex's newer auth model issues short-lived (7-day) JWTs in place of long-lived static tokens, which is a meaningful security improvement for an app that stores many users' Plex credentials. This PR provisions and maintains those JWTs and prefers them for plex.tv API calls, while deliberately keeping legacy tokens for everything the media server itself touches.
This builds on the server-side pin exchange (#406) and is the JWT phase of #322. It is intentionally low-risk: with the flag off, behavior is unchanged; with it on, JWTs are provisioned and used for plex.tv only, and every path degrades safely to the legacy token.

### How it works
After a successful sign-in, the server silently provisions a separate per-user JWT device using the flow: a strong pin with an embedded JWK under a fresh device identity, authorized server-side via PUT /api/v2/pins/link with the user's legacy token, then exchanged for a JWT. The legacy token survives because the JWT is bound to a new device identity rather than the shared client identifier — Plex invalidates a device's legacy token only when a JWT is issued for that device.
Provisioning is fire-and-forget and non-fatal: if it fails, the user is already signed in on their legacy token and is retried at next sign-in.

### Why hybrid (legacy retained for PMS)
Plex Media Server does not yet validate JWTs — only plex.tv does. This was confirmed against the current PMS build (1.43.3.10828) and matches Plex's developer forum, where the reference python-plexapi library makes the identical split — using the JWT for plex.tv and the per-server legacy token for the media server. So legacy tokens remain the credential for all PMS-bound paths (library scanner, health check, image proxy) and the embedded /watch player. plex.tv calls (sign-in checks, invite/share management, watchlists, trial deprovisioning, membership validation) prefer the JWT when fresh.

### Changes

- JWT service (server/lib/plexAuth/jwt.ts): Ed25519 device-identity generation, the provisioning flow, nonce-based refresh, and AES-256-GCM encryption of the device identity at rest (keyed off sessionSecret).
- Provisioning orchestrator (provision.ts): flag-gated, fire-and-forget, idempotent; hooked into login, invite signup, and account re-link.
- Credential resolver (credentials.ts): preferPlexJwt returns a fresh JWT when present and degrades to legacy otherwise; PMS-bound consumers are explicitly excluded and documented.
- Refresh job (refreshToken.ts): existing legacy token refresh retained, plus JWT renewal for credentials within 2 days of expiry (background job, daily); terminal (4xx) rejections clear JWT state for re-provisioning at next sign-in, transient errors retry.
- Call sites flipped to prefer JWT: auth.ts, signup.ts, user/index.ts, usersettings.ts, plexSync.ts, trialExpiry.ts, plexAccessLost.ts.
- Schema: additive migration adding plexJwt, plexJwtExpiresAt, plexJwtDevice to user (secrets are select: false).
- Admin UI: "Plex JWT Authentication (Experimental)" toggle under Settings → Users, with i18n messages.
- Documentation: new "Plex JWT Authentication (Experimental)" section under Settings → Users in the admin settings docs, including the plex.tv-only / PMS-hybrid limitation.

### Linked Issues
- Refs #322 
- Builds on #406 (merged)

## Has This Been Tested?

- [x] Admin sign-in
- [x] JWT device is provisioned
- [x] Visible as a "Secure Auth" device in plex account device list
- [x] Verified plex.tv api calls use the new JWT
- [x] Verified PMS calls continue to use legacy token
- [x] Confirmed experimental flag correctly switches behaviour

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
