### PR TITLE
fix(auth): survive Plex token rotation on abandoned sign-ins

### DIFF
--- a/server/lib/plexAuth/index.ts
+++ b/server/lib/plexAuth/index.ts
@@ -1,3 +1,6 @@
+import PlexTvAPI from '@server/api/plextv';
+import { getRepository } from '@server/datasource';
+import { User } from '@server/entity/User';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { getAppVersion } from '@server/utils/appVersion';
@@ -136,7 +139,7 @@ class PlexPinAuth {
     }
 
     if (Date.now() >= session.expiresAt) {
-      this.sessions.delete(id);
+      this.expireSession(id, session);
       return undefined;
     }
 
@@ -261,8 +264,68 @@ class PlexPinAuth {
     const now = Date.now();
     for (const [id, session] of this.sessions) {
       if (now >= session.expiresAt + CLEANUP_GRACE_MS) {
-        this.sessions.delete(id);
+        this.expireSession(id, session);
       }
+    }
+  }
+
+  private expireSession(id: string, session: PinSession): void {
+    this.sessions.delete(id);
+    void this.recoverOrphanedToken(session);
+  }
+
+  /**
+   * Plex keeps a single token per (account, client identifier): every
+   * completed pin authorization rotates the previous token out. If a user
+   * authorizes in the popup but the streamarr flow never claims the token
+   * (popup abandoned after authorizing, client stopped polling, browser
+   * closed before the login request), the freshly minted token is stranded
+   * — and the user's STORED token has already been invalidated by the
+   * rotation, breaking every server-side Plex call for them.
+   *
+   * On session expiry we persist the rotated token for the matching existing
+   * user so their stored credential stays valid.
+   *
+   * Deliberately conservative:
+   *   - Only acts on a token THIS session already captured via getStatus.
+   *     It never re-polls the pin status endpoint from this background path;
+   *     it only does a single plex.tv account lookup to map the token to a
+   *     user, so an expired session that was only ever `pending` does nothing.
+   *   - Only ever UPDATES an existing user matched by plexId. Never creates
+   *     users or sessions, never grants access, never touches permissions.
+   *   - A no-op for first-time sign-ins (no prior user row to repair).
+   */
+  private async recoverOrphanedToken(session: PinSession): Promise<void> {
+    const token = session.authToken;
+    if (!token) {
+      return;
+    }
+
+    try {
+      const account = await new PlexTvAPI(token).getUser();
+      const userRepository = getRepository(User);
+      const user = await userRepository
+        .createQueryBuilder('user')
+        .addSelect('user.plexToken')
+        .where('user.plexId = :plexId', { plexId: account.id })
+        .getOne();
+
+      if (!user || user.plexToken === token) {
+        return;
+      }
+
+      user.plexToken = token;
+      await userRepository.save(user);
+
+      logger.info(
+        'Recovered rotated Plex token from an abandoned sign-in attempt',
+        { label: 'Plex Pin Auth', userId: user.id }
+      );
+    } catch (e) {
+      logger.debug('Orphaned Plex token recovery skipped', {
+        label: 'Plex Pin Auth',
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
     }
   }
 }

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -93,23 +93,24 @@ const Layout = ({
     [user]
   );
 
-  // Set Plex token in localStorage after successful login
+  // Keep the Plex Web token in localStorage in sync with the user's current
+  // server-side token. Plex rotates tokens on re-authentication (one token
+  // per account + client identifier), so "set only if absent" can leave a
+  // dead token behind after a rotation, silently breaking the embedded
+  // /watch player until the user clears storage. Reconciling once per
+  // session keeps it self-healing.
   useEffect(() => {
     if (user && !loading && !tokenRef.current) {
       const setPlexToken = async () => {
         try {
-          // Check if token already exists
-          if (localStorage.getItem('myPlexAccessToken')) {
-            tokenRef.current = true;
-            return;
-          }
-
-          // Fetch user's Plex token
+          // Fetch the user's current Plex token
           const response = await axios.get('/api/v1/auth/plex/token');
           const { token } = response.data;
 
           if (token) {
-            localStorage.setItem('myPlexAccessToken', token);
+            if (localStorage.getItem('myPlexAccessToken') !== token) {
+              localStorage.setItem('myPlexAccessToken', token);
+            }
             tokenRef.current = true;
           }
         } catch {


### PR DESCRIPTION
## Description
Plex keeps a single token per (account, client identifier): every completed pin authorization rotates the previous token out. If a user authorizes in the popup but the streamarr flow never claims the resulting token — popup abandoned after authorizing, polling stopped, or browser closed mid-flow — the new token is stranded and the user's stored token has already been invalidated by the rotation, which 401s every server-side Plex call for that user until they sign in again.
This PR makes both the server and the embedded `/watch` player self-heal from that rotation.

### Changes
- Server `server/lib/plexAuth/index.ts`: on pin-session expiry, if the session already captured an auth token, persist it for the matching existing user so their stored credential stays valid. Deliberately conservative — it acts only on a token the session already observed (never re-polls plex.tv from this path), and only updates an existing user matched by plexId; it never creates users or sessions, grants access, or touches permissions. A no-op for first-time sign-ins.
- Client `src/components/Layout/index.tsx`: reconcile `localStorage.myPlexAccessToken` against the user's current server-side token instead of setting it only when absent, so the embedded `/watch` player picks up a rotated token on the next session load instead of holding a dead one.

### Linked Issues
- Refs #322 

## Has This Been Tested?

In theory, hard to reproduce exact situation in tests.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
