### PR TITLE
fix(newsletters): exclude expired and deactivated users from recipients

### DIFF
--- a/server/lib/newsletters/send.ts
+++ b/server/lib/newsletters/send.ts
@@ -66,10 +66,13 @@ export const sendNewsletter = async (
       recipients =
         newsletter.recipientMode === 'custom'
           ? await userRepository.find({
-              where: { id: In(newsletter.recipientIds ?? []) },
+              where: { id: In(newsletter.recipientIds ?? []), active: true },
               relations: ['settings'],
             })
-          : await userRepository.find({ relations: ['settings'] });
+          : await userRepository.find({
+              where: { active: true },
+              relations: ['settings'],
+            });
 
       if (!newsletter.isImportant) {
         recipients = recipients.filter(


### PR DESCRIPTION
## Description
Newsletter recipient selection in server/lib/newsletters/send.ts only excluded unsubscribed users (and only for non-important newsletters). It never checked account status, so trial-expired and deactivated users were still receiving newsletters.

## Has This Been Tested?

- [x] Newsletters now correctly exclude expired/deactivated users when sending.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
