### PR TITLE
fix(watch): restore tablet sidebar drawer inside Plex iframe

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -48,16 +48,16 @@ describe('Navigation', () => {
 
     it('should toggle mobile drawer', () => {
       cy.visit('/invites');
-      cy.get('label[aria-label="open sidebar"]').should('be.visible').click();
-      cy.get('.drawer-side').should('be.visible');
+      cy.get('[aria-label="open sidebar"]').should('be.visible').click();
+      cy.get('[data-testid="mobile-drawer"]').should('be.visible');
     });
 
     it('should close mobile drawer via overlay', () => {
       cy.visit('/invites');
-      cy.get('label[aria-label="open sidebar"]').should('be.visible').click();
-      cy.get('.drawer-side').should('be.visible');
-      cy.get('.drawer-overlay').click({ force: true });
-      cy.get('.drawer-side').should('not.be.visible');
+      cy.get('[aria-label="open sidebar"]').should('be.visible').click();
+      cy.get('[data-testid="mobile-drawer"]').should('be.visible');
+      cy.get('[data-testid="sidebar-overlay"]').click({ force: true });
+      cy.get('[data-testid="mobile-drawer"]').should('not.exist');
     });
   });
 });

--- a/cypress/e2e/responsive.cy.ts
+++ b/cypress/e2e/responsive.cy.ts
@@ -30,7 +30,7 @@ describe('Responsive Design', () => {
         if (width >= 1024) {
           cy.get('#sidebarMenu').should('be.visible');
         } else if (width >= 640) {
-          cy.get('label[aria-label="open sidebar"]').should('be.visible');
+          cy.get('[aria-label="open sidebar"]').should('be.visible');
         }
       });
     });

--- a/public/watch.base.css
+++ b/public/watch.base.css
@@ -27,86 +27,6 @@
     --default-transition-duration: 150ms;
     --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   }
-  .drawer-side {
-    :where(&) {
-              overflow-x: hidden;
-        overflow-y: hidden;
-          }
-          pointer-events: none;
-      visibility: hidden;
-      position: fixed;
-      inset-inline-start: calc(0.25rem * 0);
-      top: calc(0.25rem * 0);
-      z-index: 10;
-      grid-column-start: 1;
-      grid-row-start: 1;
-      display: grid;
-      width: 100%;
-      grid-template-columns: repeat(1, minmax(0, 1fr));
-      grid-template-rows: repeat(1, minmax(0, 1fr));
-      align-items: flex-start;
-      justify-items: start;
-      overscroll-behavior: contain;
-      background-color: transparent;
-      opacity: 0%;
-      transition: opacity 0.2s ease-out 0.1s allow-discrete, visibility 0.3s ease-out 0.1s allow-discrete;
-      height: 100vh;
-      height: 100dvh;
-      > .drawer-overlay {
-        position: sticky;
-        top: calc(0.25rem * 0);
-        cursor: pointer;
-        place-self: stretch;
-        background-color: oklch(0% 0 0 / 40%);
-      }
-      > * {
-        grid-column-start: 1;
-        grid-row-start: 1;
-      }
-      > :not(.drawer-overlay) {
-        will-change: transform;
-        transition: translate 0.3s ease-out, width 0.2s ease-out;
-        translate: -100%;
-        [dir="rtl"] & {
-          translate: 100%;
-        }
-      }
-      }
-  .drawer-toggle {
-          position: fixed;
-      height: calc(0.25rem * 0);
-      width: calc(0.25rem * 0);
-      appearance: none;
-      opacity: 0%;
-      :where(&:checked ~ .drawer-side) {
-        scrollbar-color: currentColor oklch(0 0 0 / calc(var(--page-has-backdrop, 0) * 0.4));
-        @supports (color: color-mix(in lab, red, red)) {
-          scrollbar-color: color-mix(in oklch, currentColor 35%, #0000) oklch(0 0 0 / calc(var(--page-has-backdrop, 0) * 0.4));
-        }
-      }
-      :where(:root:has(&:checked)) {
-        --page-has-backdrop: 1;
-        --page-overflow: hidden;
-        --page-scroll-bg: var(--page-scroll-bg-on);
-        --page-scroll-gutter: stable;
-        --page-scroll-transition: var(--page-scroll-transition-on);
-        animation: set-page-has-scroll forwards;
-        animation-timeline: scroll();
-      }
-              :where(&:checked ~ .drawer-side) {
-        pointer-events: auto;
-        visibility: visible;
-        overflow-y: auto;
-        opacity: 100%;
-        > :not(.drawer-overlay) {
-          translate: 0%;
-        }
-      }
-      &:focus-visible ~ .drawer-content label.drawer-button {
-        outline: 2px solid;
-        outline-offset: 2px;
-      }
-      }
   .tooltip {
           position: relative;
       display: inline-block;
@@ -645,12 +565,6 @@
         translate: var(--indicator-x, 50%) var(--indicator-y, -50%);
       }
       }
-  .drawer {
-          position: relative;
-      display: grid;
-      width: 100%;
-      grid-auto-columns: max-content auto;
-      }
   .absolute {
     position: absolute;
   }
@@ -659,6 +573,9 @@
   }
   .relative {
     position: relative;
+  }
+  .inset-0 {
+    inset: calc(var(--spacing) * 0);
   }
   .top-0 {
     top: calc(var(--spacing) * 0);
@@ -672,11 +589,11 @@
   .top-2 {
     top: calc(var(--spacing) * 2);
   }
+  .top-16 {
+    top: calc(var(--spacing) * 16);
+  }
   .top-\[0\.6rem\] {
     top: 0.6rem;
-  }
-  .top-\[4rem\] {
-    top: 4rem;
   }
   .top-auto {
     top: auto;
@@ -713,6 +630,9 @@
   }
   .z-1000 {
     z-index: 1000;
+  }
+  .z-1005 {
+    z-index: 1005;
   }
   .z-1006 {
     z-index: 1006;
@@ -813,9 +733,6 @@
   }
   .-mb-2 {
     margin-bottom: calc(var(--spacing) * -2);
-  }
-  .mb-0 {
-    margin-bottom: calc(var(--spacing) * 0);
   }
   .mb-1 {
     margin-bottom: calc(var(--spacing) * 1);
@@ -974,9 +891,6 @@
   .w-64 {
     width: calc(var(--spacing) * 64);
   }
-  .w-fit {
-    width: fit-content;
-  }
   .w-full {
     width: 100%;
   }
@@ -1108,6 +1022,9 @@
   .overflow-hidden {
     overflow: hidden;
   }
+  .overflow-y-auto {
+    overflow-y: auto;
+  }
   .rounded {
     border-radius: 0.25rem;
   }
@@ -1173,6 +1090,12 @@
   }
   .bg-base-300 {
     background-color: var(--color-base-300);
+  }
+  .bg-base-300\/30 {
+    background-color: var(--color-base-300);
+    @supports (color: color-mix(in lab, red, red)) {
+      background-color: color-mix(in oklab, var(--color-base-300) 30%, transparent);
+    }
   }
   .bg-base-content\/20 {
     background-color: var(--color-base-content);
@@ -1433,6 +1356,11 @@
   }
   .transition {
     transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .transition-opacity {
+    transition-property: opacity;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
     transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
@@ -1699,6 +1627,12 @@
       @supports (color: color-mix(in lab, red, red)) {
         background-color: color-mix(in oklab, var(--color-white) 15%, transparent) !important;
       }
+    }
+  }
+  .data-closed\:-translate-x-full {
+    &[data-closed] {
+      --tw-translate-x: -100%;
+      translate: var(--tw-translate-x) var(--tw-translate-y);
     }
   }
   .data-closed\:-translate-y-2 {
@@ -2073,12 +2007,6 @@ input[type='checkbox']:not(.drawer-toggle) {
 button {
   --tw-leading: calc(var(--spacing) * 5);
   line-height: calc(var(--spacing) * 5);
-}
-:where(.drawer-toggle:checked~.drawer-side) {
-  pointer-events: auto;
-  visibility: visible;
-  opacity: 1;
-  overflow-y: auto;
 }
   :where(:root),:root:has(input.theme-controller[value=light]:checked),[data-theme=light] {
     color-scheme: light;

--- a/src/components/Common/Modal/index.tsx
+++ b/src/components/Common/Modal/index.tsx
@@ -61,7 +61,7 @@ export default function Modal({
     <Dialog onClose={onCancel} open={show}>
       <DialogBackdrop
         transition
-        className="fixed inset-0 z-1050 w-full bg-base-300/30 backdrop-blur-sm transition-opacity data-closed:opacity-0"
+        className="fixed inset-0 z-1050 w-full bg-base-300/30 backdrop-blur-sm transition-opacity duration-300 ease-out data-closed:opacity-0"
       />
       <div className="fixed inset-0 z-1050 w-screen overflow-y-auto">
         <div className="flex min-h-full items-end justify-center p-1 text-center sm:items-center sm:p-0">

--- a/src/components/Layout/Notifications/index.tsx
+++ b/src/components/Layout/Notifications/index.tsx
@@ -196,7 +196,7 @@ const Notifications = () => {
       <TransitionChild>
         <div
           ref={ref}
-          className={`fixed flex flex-col top-0 bottom-0 max-sm:pb-14 right-0 z-50 bg-primary/30 backdrop-blur-md sm:border-l border-primary w-full sm:max-w-[30rem] max-sm:translate-y-0 sm:translate-x-0 transition-all duration-300 ease-in data-closed:max-sm:translate-y-full data-closed:sm:translate-x-full overflow-hidden text-primary-content`}
+          className={`fixed flex flex-col top-0 bottom-0 max-sm:pb-14 right-0 z-50 bg-primary/30 backdrop-blur-md sm:border-l border-primary w-full sm:max-w-120 max-sm:translate-y-0 sm:translate-x-0 transition-all duration-300 ease-in data-closed:max-sm:translate-y-full data-closed:sm:translate-x-full overflow-hidden text-primary-content`}
         >
           <div className="w-full h-20 content-center p-4 flex flex-wrap justify-between items-center gap-2">
             <span>

--- a/src/components/Layout/Sidebar/index.tsx
+++ b/src/components/Layout/Sidebar/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 import LibraryMenu, { SingleItem } from '@app/components/Layout/LibraryMenu';
 import DropDownMenu from '@app/components/Common/DropDownMenu';
+import { Dialog, DialogBackdrop, DialogPanel } from '@headlessui/react';
 import {
   HomeIcon,
   CalendarDateRangeIcon,
@@ -47,49 +48,48 @@ const Sidebar = () => {
 
   return (
     <>
-      <header
+      <div
         id="sidebar"
         data-tutorial="sidebar-nav"
-        className="w-fit transition duration-500 drawer font-bold z-1006 max-sm:hidden lg:hidden"
+        className={`flex-none relative z-1006 print:hidden max-sm:hidden lg:hidden pointer-events-auto ${currentUrl.match(/^\/watch\/web\/index\.html#?!?\/?(.*)?/) && 'my-3 mx-2'}`}
       >
-        <input
-          id="my-drawer-3"
-          type="checkbox"
-          className="drawer-toggle pointer-events-auto"
-          checked={isOpen}
-          onClick={() => setIsOpen(!isOpen)}
-          onChange={() => setIsOpen(!isOpen)}
-        />
-        <div
-          className={`flex-none print:hidden lg:hidden pointer-events-auto ${currentUrl.match(/^\/watch\/web\/index\.html#?!?\/?(.*)?/) && 'my-3 mx-2'}`}
+        <button
+          type="button"
+          onClick={() => setIsOpen(true)}
+          aria-label="open sidebar"
+          className="inline-flex h-10 min-h-10 shrink-0 flex-wrap items-center justify-center px-2 gap-1 text-center hover:text-primary! cursor-pointer"
         >
-          <label
-            htmlFor="my-drawer-3"
-            aria-label="open sidebar"
-            className="inline-flex h-10 min-h-10 shrink-0 flex-wrap items-center justify-center px-2 gap-1 text-center hover:text-primary! cursor-pointer"
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            className="inline-block h-7 w-7 stroke-current"
           >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              className="inline-block h-7 w-7 stroke-current"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M4 6h16M4 12h16M4 18h16"
-              ></path>
-            </svg>
-          </label>
-        </div>
-        <div className="drawer-side lg:hidden">
-          <label
-            htmlFor="my-drawer-3"
-            aria-label="close sidebar"
-            className={`drawer-overlay mb-0 ${isOpen && 'backdrop-blur-sm'}`}
-          />
-          <ul className="menu bg-primary/30 backdrop-blur-md min-h-full w-full max-w-64 p-2 border-r border-primary">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="2"
+              d="M4 6h16M4 12h16M4 18h16"
+            ></path>
+          </svg>
+        </button>
+      </div>
+      <Dialog
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        className="relative z-1006 lg:hidden"
+      >
+        <DialogBackdrop
+          transition
+          data-testid="sidebar-overlay"
+          className="fixed inset-0 z-1005 bg-base-300/30 backdrop-blur-sm transition-opacity duration-300 ease-out data-closed:opacity-0"
+        />
+        <div className="fixed inset-0 z-1006 flex">
+          <DialogPanel
+            transition
+            data-testid="mobile-drawer"
+            className="menu bg-primary/30 backdrop-blur-md min-h-full w-full max-w-64 p-2 border-r border-primary font-bold overflow-y-auto transition duration-300 ease-out data-closed:-translate-x-full"
+          >
             <div className="flex flex-row place-items-center place-content-between mb-2">
               <Image
                 src={logoSrc}
@@ -100,16 +100,16 @@ const Sidebar = () => {
                 className="my-2 mx-4 h-auto w-44"
               />
               <button
-                onClick={() => setIsOpen(!isOpen)}
+                onClick={() => setIsOpen(false)}
                 aria-label="close sidebar"
                 className="text-zinc-300 hover:text-white hover:cursor-pointer"
               >
                 <XMarkIcon className="w-7 h-7" />
               </button>
             </div>
-            <SidebarMenu isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} />
+            <SidebarMenu isOpen={isOpen} onClick={() => setIsOpen(false)} />
             <div className="mt-auto w-full">
-              <VersionStatus onClick={() => setIsOpen(!isOpen)} />
+              <VersionStatus onClick={() => setIsOpen(false)} />
               {currentUrl.includes('/watch/web/index.html') && (
                 <>
                   <div className="bg-zinc-300/40 h-0.5 my-4"></div>
@@ -131,7 +131,7 @@ const Sidebar = () => {
                       }
                     >
                       <DropDownMenu.Item
-                        onClick={() => setIsOpen(!isOpen)}
+                        onClick={() => setIsOpen(false)}
                         href="/watch/web/index.html#!/settings/web/general"
                       >
                         <FormattedMessage
@@ -140,7 +140,7 @@ const Sidebar = () => {
                         />
                       </DropDownMenu.Item>
                       <DropDownMenu.Item
-                        onClick={() => setIsOpen(!isOpen)}
+                        onClick={() => setIsOpen(false)}
                         href="/watch/web/index.html#!/settings/web/quality"
                       >
                         <FormattedMessage
@@ -149,7 +149,7 @@ const Sidebar = () => {
                         />
                       </DropDownMenu.Item>
                       <DropDownMenu.Item
-                        onClick={() => setIsOpen(!isOpen)}
+                        onClick={() => setIsOpen(false)}
                         href="/watch/web/index.html#!/settings/web/player"
                       >
                         <FormattedMessage
@@ -158,7 +158,7 @@ const Sidebar = () => {
                         />
                       </DropDownMenu.Item>
                       <DropDownMenu.Item
-                        onClick={() => setIsOpen(!isOpen)}
+                        onClick={() => setIsOpen(false)}
                         href="/watch/web/index.html#!/settings/privacy"
                       >
                         <FormattedMessage
@@ -167,7 +167,7 @@ const Sidebar = () => {
                         />
                       </DropDownMenu.Item>
                       <DropDownMenu.Item
-                        onClick={() => setIsOpen(!isOpen)}
+                        onClick={() => setIsOpen(false)}
                         href="/watch/web/index.html#!/settings/online-media-sources"
                         divide="before"
                       >
@@ -177,7 +177,7 @@ const Sidebar = () => {
                         />
                       </DropDownMenu.Item>
                       <DropDownMenu.Item
-                        onClick={() => setIsOpen(!isOpen)}
+                        onClick={() => setIsOpen(false)}
                         href="/watch/web/index.html#!/settings/devices/all"
                       >
                         <FormattedMessage
@@ -186,7 +186,7 @@ const Sidebar = () => {
                         />
                       </DropDownMenu.Item>
                       <DropDownMenu.Item
-                        onClick={() => setIsOpen(!isOpen)}
+                        onClick={() => setIsOpen(false)}
                         href="/watch/web/index.html#!/settings/streaming-services"
                       >
                         <FormattedMessage
@@ -195,7 +195,7 @@ const Sidebar = () => {
                         />
                       </DropDownMenu.Item>
                       <DropDownMenu.Item
-                        onClick={() => setIsOpen(!isOpen)}
+                        onClick={() => setIsOpen(false)}
                         href="/watch/web/index.html#!/settings/manage-library-access"
                       >
                         <FormattedMessage
@@ -208,9 +208,9 @@ const Sidebar = () => {
                 </>
               )}
             </div>
-          </ul>
+          </DialogPanel>
         </div>
-      </header>
+      </Dialog>
       {currentUrl.match(/^\/watch\/web\/index\.html#?!?\/?(.*)?/) && (
         <div className="fixed top-0 right-0 mt-2 me-2 z-1000 lg:flex lg:shrink-0 flex-nowrap pointer-events-none">
           <div className="mt-1 mr-28 pointer-events-auto max-lg:hidden">
@@ -293,7 +293,7 @@ const Sidebar = () => {
       )}
       <ul
         id="sidebarMenu"
-        className={`menu w-56 p-2 max-lg:hidden fixed top-[4rem] bottom-0 left-0 flex flex-col flex-1 flex-nowrap overflow-auto border-r border-neutral font-base`}
+        className={`menu w-56 p-2 max-lg:hidden fixed top-16 bottom-0 left-0 flex flex-col flex-1 flex-nowrap overflow-auto border-r border-neutral font-base`}
       >
         <SidebarMenu />
         {hasPermission([Permission.ADMIN]) && (

--- a/src/components/TutorialWizard/index.tsx
+++ b/src/components/TutorialWizard/index.tsx
@@ -180,7 +180,7 @@ const TutorialWizard: React.FC = () => {
       <Dialog onClose={handleClose} open={showPrompt}>
         <DialogBackdrop
           transition
-          className="fixed inset-0 z-1050 w-full bg-base-300/30 backdrop-blur-sm transition-opacity data-closed:opacity-0"
+          className="fixed inset-0 z-1050 w-full bg-base-300/30 backdrop-blur-sm transition-opacity duration-300 ease-out data-closed:opacity-0"
         />
         <div className="fixed inset-0 z-1050 w-screen overflow-y-auto">
           <div className="flex min-h-full items-center justify-center p-2 sm:p-0">
@@ -258,7 +258,7 @@ const TutorialWizard: React.FC = () => {
                 </span>
               </button>
             )}
-            <div className="min-h-[400px] sm:min-h-[450px] flex flex-col">
+            <div className="min-h-100 sm:min-h-112.5 flex flex-col">
               {isFullWizardMode ? (
                 <Carousel
                   ref={carouselRef}

--- a/src/components/WelcomeModal/index.tsx
+++ b/src/components/WelcomeModal/index.tsx
@@ -66,7 +66,7 @@ const WelcomeModal: React.FC = () => {
     <Dialog onClose={handleClose} open={showWelcome}>
       <DialogBackdrop
         transition
-        className="fixed inset-0 z-1050 w-full bg-base-300/30 backdrop-blur-sm transition-opacity data-closed:opacity-0"
+        className="fixed inset-0 z-1050 w-full bg-base-300/30 backdrop-blur-sm transition-opacity duration-300 ease-out data-closed:opacity-0"
       />
       <div className="fixed inset-0 z-1050 w-screen overflow-y-auto">
         <div className="flex min-h-full items-center justify-center p-1 sm:p-0">
@@ -86,7 +86,7 @@ const WelcomeModal: React.FC = () => {
                 </span>
               </button>
             )}
-            <div className="min-h-[400px] sm:min-h-[450px] flex flex-col">
+            <div className="min-h-100 sm:min-h-112.5 flex flex-col">
               <Carousel
                 ref={carouselRef}
                 showArrows={false}


### PR DESCRIPTION
## Description
Fixes the tablet (md-screen) sidebar drawer not opening on the `/watch` proxy route. Regression from the Tailwind CSS v4 / daisyUI v5 upgrade.

Fixes #409

## Has This Been Tested?

Confirmed drawer opens correctly again.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
