### PR TITLE
fix(newsletters): handle empty grandparent_rating_key in top streams

### DIFF
--- a/server/lib/newsletters/dataProviders.ts
+++ b/server/lib/newsletters/dataProviders.ts
@@ -74,6 +74,15 @@ const mapWithConcurrency = async <T, R>(
   return results;
 };
 
+const normalizeRatingKey = (value?: number | string): string | undefined => {
+  if (value == null) {
+    return undefined;
+  }
+
+  const str = String(value).trim();
+  return str === '' || str === '0' ? undefined : str;
+};
+
 // Library types that can contribute a "recently added" section, in the order
 // their sections should appear in the email.
 export const RECENTLY_ADDED_TYPES: NewsletterMediaType[] = [
@@ -373,8 +382,10 @@ const collectTopStreamsForType = async (
       break;
     }
 
-    const ratingKey = row.grandparent_rating_key ?? row.rating_key;
-    const key = ratingKey != null ? String(ratingKey) : row.title;
+    const ratingKey =
+      normalizeRatingKey(row.grandparent_rating_key) ??
+      normalizeRatingKey(row.rating_key);
+    const key = ratingKey ?? row.title;
 
     if (seen.has(key)) {
       continue;
@@ -386,10 +397,10 @@ const collectTopStreamsForType = async (
         title: row.title,
         year: row.year,
         mediaType: type,
-        ratingKey: ratingKey != null ? String(ratingKey) : undefined,
+        ratingKey,
         subtitle: `${row.total_plays} play${row.total_plays === 1 ? '' : 's'}`,
       },
-      ratingKey: ratingKey != null ? String(ratingKey) : undefined,
+      ratingKey,
     });
   }
 


### PR DESCRIPTION
## Description
Fixes Top Streams → Movies in newsletters, where only a single movie was ever returned and it always showed the placeholder poster. Changing "Past days" changed *which* single movie appeared rather than listing all of them. Top Streams → TV was unaffected.

- Add a `normalizeRatingKey` helper that treats empty/zero values as  absent.
- Prefer a normalized `grandparent_rating_key`, falling back to  `rating_key`, when building the de-dup key and resolving posters.

## Has This Been Tested?

- [x] Top Streams → Movies now lists all top movies for the selected window, each with its correct poster.
- [x] Top Streams → TV and Music unchanged.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
