### PR TITLE
fix(notifications): log a single "Sending notification(s)" entry per dispatch

### DIFF
--- a/server/lib/notifications/dispatch.ts
+++ b/server/lib/notifications/dispatch.ts
@@ -29,6 +29,11 @@ export const sendGroupNotification = async (
   recipients: User[],
   buildContent: (intl: IntlShape) => GroupNotificationContent
 ): Promise<void> => {
+  logger.info(`Sending notification(s) for ${NotificationType[type]}`, {
+    label: 'Notifications',
+    recipients: recipients.length,
+  });
+
   try {
     await notificationManager.sendNotification(
       type,

--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -121,11 +121,6 @@ class NotificationManager {
     payload: NotificationPayload,
     scope: NotificationDeliveryScope = NotificationDeliveryScope.All
   ): Promise<boolean> {
-    logger.info(`Sending notification(s) for ${NotificationType[type]}`, {
-      label: 'Notifications',
-      subject: payload.subject,
-    });
-
     const activeAgents = this.activeAgents.filter(
       (agent) =>
         agent.shouldSend() &&
@@ -143,6 +138,13 @@ class NotificationManager {
         return false;
       }
       return true;
+    }
+
+    if (scope === NotificationDeliveryScope.All) {
+      logger.info(`Sending notification(s) for ${NotificationType[type]}`, {
+        label: 'Notifications',
+        subject: payload.subject,
+      });
     }
 
     const results = await Promise.all(

--- a/server/routes/notification.ts
+++ b/server/routes/notification.ts
@@ -176,6 +176,14 @@ notificationRoutes.post<
       });
     }
 
+    logger.info(
+      `Sending notification(s) for ${NotificationType[req.body.type]}`,
+      {
+        label: 'Notifications',
+        recipients: eligibleUsers.length,
+      }
+    );
+
     const createdNotifications: NotificationCreationResult[] = [];
     await Promise.all(
       eligibleUsers.map(async (user) => {


### PR DESCRIPTION
## Description
Notification dispatches were emitting duplicate `Sending notification(s) for <TYPE>` INFO log lines — two identical entries per event for `NEW_INVITE`, `PLEX_ACCESS_LOST`, and any other group notification.

- Move the header in `sendNotification` below the `activeAgents.length === 0` early return so it only logs when there's something to deliver, and gate it to `scope === All` (standalone single-recipient dispatches).
- Emit one header at each multi-delivery boundary instead:
  - `sendGroupNotification` logs once per event, with a `recipients` count.
  - The `/notification` route logs once before the per-recipient loop.

## Has This Been Tested?

- [x] Triggered `NEW_INVITE` and `PLEX_ACCESS_LOST` with one eligible admin → one INFO line each (previously two).
- [x] Added a second eligible admin → still one header line (`recipients: 2`), with per-recipient delivery and per-agent debug logs intact.
- [x] Verified single-recipient events (`INVITE_REDEEMED`, `INVITE_EXPIRED`) still log their one header line.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
