### PR TITLE
fix(notifications): exclude inactive users from notification delivery

### DIFF
--- a/server/lib/notifications/index.ts
+++ b/server/lib/notifications/index.ts
@@ -61,6 +61,7 @@ export const shouldSendAdminNotification = (
   payload: NotificationPayload
 ): boolean => {
   return (
+    user.active &&
     user.id !== payload.notifyUser?.id &&
     user.hasPermission(getAdminPermission(type), { type: 'or' })
   );
@@ -81,8 +82,9 @@ export const PER_RECIPIENT_AGENT_KEYS: NotificationAgentKey[] = [
 ];
 
 /**
- * Returns true if the user has at least one notification agent enabled for
- * the given type. Users without saved settings are treated as fully opted-in.
+ * Returns true if the user is active and has at least one notification agent
+ * enabled for the given type. Active users without saved
+ * settings are treated as fully opted-in.
  *
  * By default only per-recipient agents are considered, because shared-channel
  * agents (Discord, Slack, Gotify, ntfy, webhook) cannot deliver to a single
@@ -94,6 +96,10 @@ export const userAcceptsNotificationType = (
   type: NotificationType,
   scope: NotificationDeliveryScope = NotificationDeliveryScope.Individual
 ): boolean => {
+  if (!user.active) {
+    return false;
+  }
+
   if (!user.settings) {
     return true;
   }
@@ -121,6 +127,10 @@ class NotificationManager {
     payload: NotificationPayload,
     scope: NotificationDeliveryScope = NotificationDeliveryScope.All
   ): Promise<boolean> {
+    if (payload.notifyUser && !payload.notifyUser.active) {
+      payload = { ...payload, notifyUser: undefined };
+    }
+
     const activeAgents = this.activeAgents.filter(
       (agent) =>
         agent.shouldSend() &&

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -177,6 +177,7 @@ userSettingsRoutes.post<{ id: string }>(
             admin: Permission.ADMIN,
           }
         )
+        .andWhere('user.active = :isActive', { isActive: true })
         .getMany();
 
       const isDeactivated =


### PR DESCRIPTION
## Description
Stops notifications from being delivered to inactive (disabled / trial-expired) users, bringing notification behaviour in line with newsletters.

- `shouldSendAdminNotification` — added `user.active` to the gate (it was already an eligibility check, so `active` belongs there). Covers all admin fan-out at once.
- `userAcceptsNotificationType` — early-returns `false` for inactive users, with the docstring updated to keep the contract honest. Covers all individual/group sites.
- `usersettings.ts` — added `.andWhere('user.active = :isActive', { isActive: true })`, matching the existing idiom in `trialExpiry.ts`.

## Has This Been Tested?

- [x] Verify a deactivated user no longer receives NEW_EVENT / LOCAL_MESSAGE notifications
- [x] Verify a deactivated admin no longer receives admin (NEW_INVITE / USER_CREATED / etc.) notifications
- [x] Verify active users are unaffected

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
