### PR TITLE
fix(seerr): update css styling to background div

### DIFF
--- a/public/request.css
+++ b/public/request.css
@@ -128,7 +128,7 @@ body>div.fixed.top-0.bottom-0.left-0.right-0.z-50.flex.items-center.justify-cent
   background: var(--overseerr-gradient)!important;
 }
 .bg-gray-800 {
-  background: rgba(31, 31, 31, .45);
+  background-color: rgba(31, 31, 31, 1);
 }
 body>div.fixed.top-0.bottom-0.left-0.right-0.z-50.flex.h-full.w-full.items-center.justify-center.bg-gray-800.bg-opacity-70.opacity-100>div>div.absolute.top-0.left-0.right-0.z-0.h-64.max-h-full.w-full>span>img {
   display: block!important;
@@ -156,4 +156,15 @@ body>div.fixed.top-0.bottom-0.left-0.right-0.z-50.flex.h-full.w-full.items-cente
 }
 .text-yellow-100 {
   color: var(--bs-text);
+}
+#__next>div, body {
+  background: revert;
+}
+body {
+  background: var(--main-bg-color);
+}
+.bg-gray-800\/70 {
+  background-color: #272829b3;
+  -webkit-backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
 }


### PR DESCRIPTION
## Description
Simple update to seerr (request) proxy css injection that broke with current seerr version. Updates the background colour on the parent div from hiding the app interface.

## Has This Been Tested?

- [x] Confirmed app styling corrected.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
