### PR TITLE
fix(seerr): prefix the login popup's window.open under the proxy base

### DIFF
--- a/server/lib/proxy/seerrProxy.ts
+++ b/server/lib/proxy/seerrProxy.ts
@@ -139,18 +139,40 @@ function buildSeerrShim(base: string, nonce: string): string {
       return f.call(this,input,init);
     };
   }
+  // Prefix a root-relative path with BASE. No-op for relative, absolute,
+  // protocol-relative, or already-prefixed URLs. Shared by the history and
+  // window.open wraps below (unlike pre(), which only prefixes API/asset paths).
+  function full(u){
+    if(typeof u!=='string'||!u)return u;
+    if(u.charAt(0)!=='/'||u.charAt(1)==='/')return u;
+    if(u===BASE||u.indexOf(BASE+'/')===0)return u;
+    return BASE+u;
+  }
   // Keep the iframe address bar under BASE so reloads + Streamarr nav-sync work.
   // Seerr's router stores its own (unprefixed) "as" in history.state, so
   // back/forward still resolve correctly off state, not the URL.
   function wrapHistory(fn){
     return function(state,title,url){
       var a=[state,title,url];
-      try{if(typeof url==='string'&&url.charAt(0)==='/'&&url.charAt(1)!=='/'&&url!==BASE&&url.indexOf(BASE+'/')!==0)a[2]=BASE+url;}catch(e){}
+      try{a[2]=full(url);}catch(e){}
       return fn.apply(this,a);
     };
   }
   history.pushState=wrapHistory(history.pushState);
   history.replaceState=wrapHistory(history.replaceState);
+  // Seerr's Plex login opens a popup via window.open('/<loading route>') and
+  // then points it at plex.tv. That path is root-relative, so without a prefix
+  // the popup lands on the Streamarr origin root (a 404) before the redirect to
+  // Plex. Prefix it with BASE; the absolute plex.tv URL set afterwards via
+  // popup.location is left untouched.
+  if(window.open){
+    var wopen=window.open;
+    window.open=function(url){
+      var a=[].slice.call(arguments);
+      try{if(typeof url==='string')a[0]=full(url);}catch(e){}
+      return wopen.apply(this,a);
+    };
+  }
   // Active links + asPath-based navigation: Seerr's sidebar keys off
   // router.pathname (route table -> always unprefixed/correct), but several
   // hooks read router.asPath (useSearchInput stores it then router.push()es it


### PR DESCRIPTION
## Description
This pull request enhances the URL handling logic in the `seerrProxy.ts` shim to ensure that all root-relative navigation and popup URLs are properly prefixed with the application base path. This prevents navigation issues, such as popups opening to incorrect locations or history state inconsistencies, especially when the app is hosted under a subpath.

URL prefixing improvements:

* Added a new `full` function that prefixes root-relative URLs with `BASE`, ensuring consistent navigation and preventing accidental navigation to the wrong path. This function is now used for both history state changes and popup windows.
* Updated the `wrapHistory` function to use the new `full` function, standardizing how URLs are prefixed when updating browser history.
* Wrapped `window.open` to use the `full` function, so that popups (such as those used for Plex login) open with the correct prefixed path, avoiding 404 errors when the app is not hosted at the root.

## Has This Been Tested?

- [x] Plex login popup on seerr correctly renders the loading page before forwarding to plex auth

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
