### PR TITLE
fix(theme): update gradient colors and improve variable usage in DynamicFrame

### DIFF
--- a/public/request.css
+++ b/public/request.css
@@ -20,7 +20,7 @@
   --color-text-on-accent: inherit;
   --zIndex-overlay: 1009;
   --transparency-light-15: inherit;
-  --overseerr-gradient: inherit;
+  --overseerr-gradient: linear-gradient(180deg, rgba(var(--accent-color), 0.47) 0%, var(--color-base-300) 100%) !important;
   --label-text-color: inherit;
   --tw-ring-color: inherit;
 }
@@ -45,7 +45,7 @@
   --color-text-on-accent: #fff;
   --zIndex-overlay: 1009;
   --transparency-light-15: rgba(127, 17, 224, .15);
-  --overseerr-gradient: linear-gradient(180deg, var(--color-primary) 0%, var(--color-secondary) 100%);
+  --overseerr-gradient: linear-gradient(180deg, rgba(var(--accent-color), 0.47) 0%, var(--color-base-300) 100%) !important;
   --label-text-color: #fff;
   --tw-ring-color: var(--color-primary)!important;
 }
@@ -167,4 +167,27 @@ body {
   background-color: #272829b3;
   -webkit-backdrop-filter: blur(5px);
   backdrop-filter: blur(5px);
+}
+.bg-gray-800\/50 {
+  background-color: rgba(var(--accent-color), 0.37) !important;
+  -webkit-backdrop-filter: blur(5px);
+  backdrop-filter: blur(5px);
+}
+div[style*="linear-gradient(rgba(31, 41, 55"] {
+  background-image: var(--overseerr-gradient) !important;
+}
+.bg-indigo-500\/80:not(:hover) {
+    background-color: rgba(var(--accent-color), 0.8) !important;
+}
+.hover\:bg-indigo-600:hover {
+    background-color: rgb(var(--accent-color)) !important;
+}
+.bg-indigo-600\/80:not(:hover) {
+    background-color: rgba(var(--accent-color), 0.8) !important;
+}
+.focus\:border-indigo-700:focus {
+    border-color: rgb(var(--accent-color)) !important;
+}
+.hover\:border-indigo-500:hover {
+    border-color: rgb(var(--accent-color)) !important;
 }

--- a/server/lib/proxy/seerrProxy.ts
+++ b/server/lib/proxy/seerrProxy.ts
@@ -74,8 +74,8 @@ function buildSeerrThemeCss(theme: Theme): string {
   const primaryChannels = hexToRgb(
     parseColorToHex(theme.primary) ?? theme.primary
   );
-  const neutralChannels = hexToRgb(
-    parseColorToHex(theme.neutral) ?? theme.neutral
+  const base300Channels = hexToRgb(
+    parseColorToHex(theme['base-300']) ?? theme['base-300']
   );
 
   const vars: Record<string, string> = {
@@ -83,7 +83,7 @@ function buildSeerrThemeCss(theme: Theme): string {
     '--accent-color': primaryChannels,
     '--color-brand-accent': theme.secondary,
     '--bs-primary': theme.primary,
-    '--color-background-accent-focus': theme.secondary,
+    '--color-background-accent-focus': theme.primary,
     '--color-text-accent': theme.secondary,
     '--main-bg-color': theme['base-300'],
     '--modal-bg-color': theme['base-100'],
@@ -96,7 +96,7 @@ function buildSeerrThemeCss(theme: Theme): string {
     '--button-color-hover': theme.secondary,
     '--plex-poster-unwatched': theme['base-content'],
     '--transparency-light-15': `rgba(${primaryChannels}, 0.15)`,
-    '--overseerr-gradient': `linear-gradient(180deg, rgba(${primaryChannels}, 0.47) 0%, rgba(${neutralChannels}, 1) 100%)`,
+    '--overseerr-gradient': `linear-gradient(180deg, rgba(${primaryChannels}, 0.47) 0%, rgba(${base300Channels}, 1) 100%)`,
     '--label-text-color': theme['base-content'],
     '--tw-ring-color': theme.primary,
   };

--- a/src/components/Common/DynamicFrame/index.tsx
+++ b/src/components/Common/DynamicFrame/index.tsx
@@ -140,7 +140,7 @@ const DynamicFrame = ({
         : '0,0,0';
     };
     const primaryHex = parseColorToHex(theme.primary) ?? theme.primary;
-    const neutralHex = parseColorToHex(theme.neutral) ?? theme.neutral;
+    const base300Hex = parseColorToHex(theme['base-300']) ?? theme['base-300'];
     const primaryChannels = hexToRgb(primaryHex);
 
     mountNode.style.setProperty('--logo-image-url', `url("${logoSrc}")`);
@@ -154,7 +154,7 @@ const DynamicFrame = ({
       '--accent-color': primaryChannels,
       '--color-brand-accent': theme.secondary,
       '--bs-primary': theme.primary,
-      '--color-background-accent-focus': theme.secondary,
+      '--color-background-accent-focus': theme.primary,
       '--color-text-accent': theme.secondary,
       '--main-bg-color': theme['base-300'],
       '--modal-bg-color': theme['base-100'],
@@ -167,7 +167,7 @@ const DynamicFrame = ({
       '--button-color-hover': theme.secondary,
       '--plex-poster-unwatched': theme['base-content'],
       '--transparency-light-15': `rgba(${primaryChannels}, 0.15)`,
-      '--overseerr-gradient': `linear-gradient(180deg, rgba(${primaryChannels}, 0.47) 0%, rgba(${hexToRgb(neutralHex)}, 1) 100%)`,
+      '--overseerr-gradient': `linear-gradient(180deg, rgba(${primaryChannels}, 0.47) 0%, rgba(${hexToRgb(base300Hex)}, 1) 100%)`,
       '--label-text-color': theme['base-content'],
       '--tw-ring-color': theme.primary,
     };


### PR DESCRIPTION
## Description
This pull request updates the theming and gradient logic for the application, focusing on improving color variables and gradients. The changes affect both the CSS and the React component responsible for dynamic theming, ensuring that gradients and accent colors are derived from the correct theme variables.

**Theming and Gradient Updates:**

* Updated the `--overseerr-gradient` CSS variable in `public/request.css` to use a linear gradient based on `rgba(var(--color-primary), 0.47)` and `rgba(var(--color-base-300))`, ensuring consistency across light and dark themes. (`public/request.css`) [[1]](diffhunk://#diff-803f628b4570584ee8bc404382e1d63705fab3f2d1b9be01ddab6d6f7289be8fL23-R23) [[2]](diffhunk://#diff-803f628b4570584ee8bc404382e1d63705fab3f2d1b9be01ddab6d6f7289be8fL48-R48)
* Updated the dynamic style application in `DynamicFrame` to use `base-300` instead of `neutral` for gradients, and ensured the gradient matches the new CSS definition. (`src/components/Common/DynamicFrame/index.tsx`) [[1]](diffhunk://#diff-e4469888e335b130faaf06d2bde34c27a64390f17d274857342428867d53a148L143-R143) [[2]](diffhunk://#diff-e4469888e335b130faaf06d2bde34c27a64390f17d274857342428867d53a148L170-R170)

**Accent and Background Color Consistency:**

* Standardized the use of `primary` and `secondary` theme variables for accent and background colors, including fixing the `--color-background-accent-focus` variable to use `primary` instead of `secondary`. (`src/components/Common/DynamicFrame/index.tsx`)
* Added and updated CSS utility classes in `public/request.css` to use the correct accent color variables for backgrounds, borders, and hover/focus states, improving visual consistency and maintainability. (`public/request.css`)

## Has This Been Tested?

Visual changes only.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
