### PR TITLE
feat(downloads): folder tree, bulk selection & column sorting for file contents

### DIFF
--- a/src/components/Admin/Downloads/TorrentDetailsModal.tsx
+++ b/src/components/Admin/Downloads/TorrentDetailsModal.tsx
@@ -722,7 +722,7 @@ const TorrentDetailsModal: React.FC<TorrentDetailsModalProps> = ({
                         setShouldLoadFiles(true);
                       }
                     }}
-                    className={`bg-base-200 hover:text-primary hover:bg-base-300 mb-1 flex w-full items-center justify-between text-lg font-semibold transition-all ${openIndexes.includes(0) ? 'rounded-t-xl' : 'rounded-xl'} px-2 py-1`}
+                    className={`bg-base-200 hover:text-primary hover:bg-base-300 mb-1 flex w-full items-center justify-between text-lg font-semibold transition-all hover:cursor-pointer ${openIndexes.includes(0) ? 'rounded-t-xl' : 'rounded-xl'} px-2 py-1`}
                   >
                     <FormattedMessage
                       id="downloads.content"
@@ -741,6 +741,7 @@ const TorrentDetailsModal: React.FC<TorrentDetailsModalProps> = ({
                       </div>
                     ) : files.length > 0 ? (
                       <TorrentFileList
+                        key={torrent.hash}
                         files={files}
                         clientType={torrent.clientType}
                         onSetPriority={handleSetFilePriority}

--- a/src/components/Admin/Downloads/TorrentFileList.tsx
+++ b/src/components/Admin/Downloads/TorrentFileList.tsx
@@ -1,25 +1,134 @@
 import ProgressBar from '@app/components/Common/ProgressBar';
+import SortableColumnHeader from '@app/components/Common/SortableColumnHeader';
 import { formatBytes } from '@app/utils/numberHelper';
+import { ChevronDownIcon } from '@heroicons/react/24/solid';
 import type { TorrentFile } from '@server/interfaces/api/downloadsInterfaces';
-import React, { useState } from 'react';
-import { FormattedMessage } from 'react-intl';
+import React, { useCallback, useMemo, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
 
 interface TorrentFileListProps {
   files: TorrentFile[];
   clientType: 'qbittorrent' | 'deluge' | 'transmission';
   onSetPriority: (fileIds: number[], priority: number) => Promise<void>;
-  isUpdating?: boolean;
 }
+
+// Sentinel used by folder / bulk selects to represent a mixed set of priorities.
+const MIXED = -1;
+
+interface FileNode {
+  type: 'file';
+  file: TorrentFile;
+}
+
+interface FolderNode {
+  type: 'folder';
+  name: string;
+  path: string;
+  depth: number;
+  children: TreeNode[];
+  fileIndices: number[];
+  size: number;
+}
+
+type TreeNode = FileNode | FolderNode;
+
+type SortField = 'name' | 'size' | 'progress' | 'priority';
+
+interface FlatRow {
+  depth: number;
+  node: TreeNode;
+}
+
+const buildTree = (files: TorrentFile[]): TreeNode[] => {
+  const root: TreeNode[] = [];
+  // Lookup of folder path -> FolderNode so we can attach children as we go.
+  const folderMap = new Map<string, FolderNode>();
+
+  for (const file of files) {
+    const segments = file.name.split('/').filter(Boolean);
+    // Files that live at the torrent root have no folder segments.
+    const fileName = segments.pop() ?? file.name;
+
+    let currentLevel = root;
+    let currentPath = '';
+    let depth = 0;
+
+    for (const segment of segments) {
+      currentPath = currentPath ? `${currentPath}/${segment}` : segment;
+      let folder = folderMap.get(currentPath);
+      if (!folder) {
+        folder = {
+          type: 'folder',
+          name: segment,
+          path: currentPath,
+          depth,
+          children: [],
+          fileIndices: [],
+          size: 0,
+        };
+        folderMap.set(currentPath, folder);
+        currentLevel.push(folder);
+      }
+      folder.fileIndices.push(file.index);
+      folder.size += file.size;
+      currentLevel = folder.children;
+      depth += 1;
+    }
+
+    currentLevel.push({
+      type: 'file',
+      file: { ...file, name: fileName },
+    });
+  }
+
+  return root;
+};
+
+/**
+ * Smart default: if the torrent is a single top-level folder (the common
+ * season-pack / release-folder case), expand that folder and any single-child
+ * folder chain beneath it. Otherwise start fully collapsed.
+ */
+const computeDefaultExpanded = (tree: TreeNode[]): Set<string> => {
+  const expanded = new Set<string>();
+  if (tree.length === 1 && tree[0].type === 'folder') {
+    let node: FolderNode | null = tree[0];
+    while (node) {
+      expanded.add(node.path);
+      const childFolders = node.children.filter(
+        (c): c is FolderNode => c.type === 'folder'
+      );
+      // Keep walking only while the chain stays single (avoid auto-opening
+      // a folder that branches into many sub-folders).
+      node = childFolders.length === 1 ? childFolders[0] : null;
+    }
+  }
+  return expanded;
+};
 
 const TorrentFileList: React.FC<TorrentFileListProps> = ({
   files,
   clientType,
   onSetPriority,
-  isUpdating = false,
 }) => {
+  const intl = useIntl();
   const [updatingFiles, setUpdatingFiles] = useState<Set<number>>(new Set());
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [expanded, setExpanded] = useState<Set<string>>(() =>
+    computeDefaultExpanded(buildTree(files))
+  );
+  const [currentSort, setCurrentSort] = useState<SortField>('name');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+
+  const tree = useMemo(() => buildTree(files), [files]);
+
+  const filesByIndex = useMemo(
+    () => new Map(files.map((f) => [f.index, f])),
+    [files]
+  );
 
   const getPriorityLabel = (priority: number): string => {
+    if (priority === MIXED) return 'Mixed';
     if (clientType === 'deluge') {
       // Deluge uses: 0=skip, 1=low, 2=normal, 5=high
       switch (priority) {
@@ -35,7 +144,7 @@ const TorrentFileList: React.FC<TorrentFileListProps> = ({
           return 'Mixed';
       }
     } else if (clientType === 'transmission') {
-      // Transmission uses: 0=skip, 1=normal, 6=high (we map -1 to 1 for low)
+      // Transmission uses: 0=skip, 1=low, 2=normal, 6=high
       switch (priority) {
         case 0:
           return 'Skip';
@@ -65,20 +174,181 @@ const TorrentFileList: React.FC<TorrentFileListProps> = ({
     }
   };
 
-  const handlePriorityChange = async (
-    fileIndex: number,
-    newPriority: number
-  ) => {
-    setUpdatingFiles((prev) => new Set(prev).add(fileIndex));
+  // Selectable priority values for the active client.
+  const priorityOptions = useMemo<number[]>(() => {
+    if (clientType === 'deluge') return [0, 1, 2, 5];
+    if (clientType === 'transmission') return [0, 1, 2, 6];
+    return [0, 1, 6, 7];
+  }, [clientType]);
+
+  const applyPriority = async (fileIds: number[], priority: number) => {
+    if (fileIds.length === 0) return;
+    setUpdatingFiles((prev) => {
+      const next = new Set(prev);
+      fileIds.forEach((id) => next.add(id));
+      return next;
+    });
     try {
-      await onSetPriority([fileIndex], newPriority);
+      await onSetPriority(fileIds, priority);
     } finally {
       setUpdatingFiles((prev) => {
         const next = new Set(prev);
-        next.delete(fileIndex);
+        fileIds.forEach((id) => next.delete(id));
         return next;
       });
     }
+  };
+
+  const toggleFolder = (path: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const toggleSelection = (fileIds: number[], checked: boolean) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      fileIds.forEach((id) => (checked ? next.add(id) : next.delete(id)));
+      return next;
+    });
+  };
+
+  const allFileIndices = useMemo(() => files.map((f) => f.index), [files]);
+  const allSelected =
+    allFileIndices.length > 0 && allFileIndices.every((id) => selected.has(id));
+  const someSelected = allFileIndices.some((id) => selected.has(id));
+
+  // Common priority across a set of file indices, or MIXED when they differ.
+  const commonPriority = useCallback(
+    (fileIndices: number[]): number => {
+      if (fileIndices.length === 0) return MIXED;
+      const first = filesByIndex.get(fileIndices[0])?.priority;
+      return fileIndices.every((id) => filesByIndex.get(id)?.priority === first)
+        ? (first ?? MIXED)
+        : MIXED;
+    },
+    [filesByIndex]
+  );
+
+  // Weighted (by size) aggregate progress for a set of file indices, 0-1.
+  const folderProgress = useCallback(
+    (fileIndices: number[]): number => {
+      let done = 0;
+      let total = 0;
+      for (const id of fileIndices) {
+        const f = filesByIndex.get(id);
+        if (!f) continue;
+        done += f.progress * f.size;
+        total += f.size;
+      }
+      return total > 0 ? done / total : 0;
+    },
+    [filesByIndex]
+  );
+
+  const handleSort = (field: SortField) => {
+    if (currentSort === field) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setCurrentSort(field);
+      setSortDirection('asc');
+    }
+  };
+
+  const sortedTree = useMemo<TreeNode[]>(() => {
+    const mult = sortDirection === 'asc' ? 1 : -1;
+
+    const nameOf = (node: TreeNode) =>
+      node.type === 'folder' ? node.name : node.file.name;
+    const sizeOf = (node: TreeNode) =>
+      node.type === 'folder' ? node.size : node.file.size;
+    const progressOf = (node: TreeNode) =>
+      node.type === 'folder'
+        ? folderProgress(node.fileIndices)
+        : node.file.progress;
+    const priorityOf = (node: TreeNode) =>
+      node.type === 'folder'
+        ? commonPriority(node.fileIndices)
+        : node.file.priority;
+
+    const compare = (a: TreeNode, b: TreeNode): number => {
+      let primary = 0;
+      switch (currentSort) {
+        case 'name':
+          primary = nameOf(a).localeCompare(nameOf(b));
+          break;
+        case 'size':
+          primary = sizeOf(a) - sizeOf(b);
+          break;
+        case 'progress':
+          primary = progressOf(a) - progressOf(b);
+          break;
+        case 'priority':
+          primary = priorityOf(a) - priorityOf(b);
+          break;
+      }
+      if (primary !== 0) return primary * mult;
+      // Stable, deterministic tiebreak — always A→Z regardless of direction.
+      return nameOf(a).localeCompare(nameOf(b));
+    };
+
+    const sortRec = (nodes: TreeNode[]): TreeNode[] =>
+      [...nodes]
+        .sort(compare)
+        .map((node) =>
+          node.type === 'folder'
+            ? { ...node, children: sortRec(node.children) }
+            : node
+        );
+
+    return sortRec(tree);
+  }, [tree, currentSort, sortDirection, commonPriority, folderProgress]);
+
+  // Flatten the tree into visible rows, honouring collapsed folders.
+  const visibleRows = useMemo<FlatRow[]>(() => {
+    const rows: FlatRow[] = [];
+    const walk = (nodes: TreeNode[], depth: number) => {
+      for (const node of nodes) {
+        rows.push({ depth, node });
+        if (node.type === 'folder' && expanded.has(node.path)) {
+          walk(node.children, depth + 1);
+        }
+      }
+    };
+    walk(sortedTree, 0);
+    return rows;
+  }, [sortedTree, expanded]);
+
+  const renderPriorityOptions = (
+    includeMixed: boolean,
+    currentValue?: number
+  ) => {
+    const showFallback =
+      currentValue !== undefined &&
+      currentValue !== MIXED &&
+      !priorityOptions.includes(currentValue);
+    return (
+      <>
+        {includeMixed && (
+          <option value={MIXED} disabled hidden>
+            {getPriorityLabel(MIXED)}
+          </option>
+        )}
+        {showFallback && (
+          <option value={currentValue} disabled hidden>
+            {getPriorityLabel(currentValue)}
+          </option>
+        )}
+        {priorityOptions.map((value) => (
+          <option key={value} value={value}>
+            {getPriorityLabel(value)}
+          </option>
+        ))}
+      </>
+    );
   };
 
   if (files.length === 0) {
@@ -93,89 +363,285 @@ const TorrentFileList: React.FC<TorrentFileListProps> = ({
   }
 
   return (
-    <div className="max-h-96 overflow-auto">
-      <table className="table-xs table">
-        <thead className="bg-base-100 sticky top-0 z-10">
-          <tr>
-            <th className="max-w-xs min-w-50">
-              <FormattedMessage id="common.name" defaultMessage="Name" />
-            </th>
-            <th className="min-w-20">
-              <FormattedMessage id="common.size" defaultMessage="Size" />
-            </th>
-            <th className="min-w-30">
+    <div>
+      {selected.size > 0 && (
+        <div className="bg-base-300 mb-2 flex flex-wrap items-center justify-between gap-2 rounded-lg px-3 py-2">
+          <span className="text-sm font-semibold whitespace-nowrap">
+            {selected.size}{' '}
+            <FormattedMessage
+              id="downloads.selected"
+              defaultMessage="selected"
+            />
+          </span>
+          <div className="flex items-center gap-2">
+            <select
+              className="select select-xs select-primary min-w-36"
+              value={commonPriority([...selected])}
+              onChange={(e) =>
+                applyPriority([...selected], parseInt(e.target.value, 10))
+              }
+              aria-label={intl.formatMessage({
+                id: 'downloads.setPriorityForSelected',
+                defaultMessage: 'Set priority for selected files',
+              })}
+            >
+              {renderPriorityOptions(true, commonPriority([...selected]))}
+            </select>
+            <button
+              type="button"
+              className="btn btn-ghost btn-xs"
+              onClick={() => setSelected(new Set())}
+            >
               <FormattedMessage
-                id="common.progress"
-                defaultMessage="Progress"
+                id="downloads.clearSelection"
+                defaultMessage="Clear"
               />
-            </th>
-            <th className="min-w-35">
-              <FormattedMessage
-                id="common.priority"
-                defaultMessage="Priority"
-              />
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {files.map((file) => (
-            <tr key={file.index} className="hover">
-              <td className="max-w-xs min-w-50">
-                <span className="block truncate text-xs" title={file.name}>
-                  {file.name}
-                </span>
-              </td>
-              <td className="min-w-20 text-xs whitespace-nowrap">
-                {formatBytes(file.size)}
-              </td>
-              <td className="min-w-30">
-                <ProgressBar progress={file.progress * 100} />
-              </td>
-              <td className="min-w-35">
-                <div className="flex items-center gap-1">
-                  <select
-                    className="select select-xs select-primary min-w-30"
-                    value={file.priority}
-                    onChange={(e) =>
-                      handlePriorityChange(file.index, parseInt(e.target.value))
-                    }
-                    disabled={isUpdating || updatingFiles.has(file.index)}
-                  >
-                    {clientType === 'deluge' ? (
-                      // Deluge: 0=skip, 1=low, 2=normal, 5=high
-                      <>
-                        <option value={0}>{getPriorityLabel(0)}</option>
-                        <option value={1}>{getPriorityLabel(1)}</option>
-                        <option value={2}>{getPriorityLabel(2)}</option>
-                        <option value={5}>{getPriorityLabel(5)}</option>
-                      </>
-                    ) : clientType === 'transmission' ? (
-                      // Transmission: 0=skip, 1=low, 2=normal, 6=high
-                      <>
-                        <option value={0}>{getPriorityLabel(0)}</option>
-                        <option value={1}>{getPriorityLabel(1)}</option>
-                        <option value={2}>{getPriorityLabel(2)}</option>
-                        <option value={6}>{getPriorityLabel(6)}</option>
-                      </>
-                    ) : (
-                      // qBittorrent: 0=skip, 1=normal, 6=high, 7=maximum
-                      <>
-                        <option value={0}>{getPriorityLabel(0)}</option>
-                        <option value={1}>{getPriorityLabel(1)}</option>
-                        <option value={6}>{getPriorityLabel(6)}</option>
-                        <option value={7}>{getPriorityLabel(7)}</option>
-                      </>
-                    )}
-                  </select>
-                  {updatingFiles.has(file.index) && (
-                    <span className="loading loading-spinner loading-xs"></span>
-                  )}
-                </div>
-              </td>
+            </button>
+          </div>
+        </div>
+      )}
+      <div className="max-h-96 overflow-auto">
+        <table className="table-xs table">
+          <thead className="bg-base-100 sticky top-0 z-10">
+            <tr>
+              <th className="w-8">
+                <input
+                  type="checkbox"
+                  className="checkbox checkbox-sm checkbox-primary"
+                  checked={allSelected}
+                  ref={(el) => {
+                    if (el) el.indeterminate = !allSelected && someSelected;
+                  }}
+                  onChange={(e) =>
+                    setSelected(
+                      e.target.checked ? new Set(allFileIndices) : new Set()
+                    )
+                  }
+                  aria-label={intl.formatMessage({
+                    id: 'downloads.selectAllFiles',
+                    defaultMessage: 'Select all files',
+                  })}
+                />
+              </th>
+              <SortableColumnHeader<SortField>
+                field="name"
+                activeField={currentSort}
+                direction={sortDirection}
+                onSort={handleSort}
+                className="max-w-xs min-w-50"
+              >
+                <FormattedMessage id="common.name" defaultMessage="Name" />
+              </SortableColumnHeader>
+              <SortableColumnHeader<SortField>
+                field="size"
+                activeField={currentSort}
+                direction={sortDirection}
+                onSort={handleSort}
+                className="min-w-20"
+              >
+                <FormattedMessage id="common.size" defaultMessage="Size" />
+              </SortableColumnHeader>
+              <SortableColumnHeader<SortField>
+                field="progress"
+                activeField={currentSort}
+                direction={sortDirection}
+                onSort={handleSort}
+                className="min-w-30"
+              >
+                <FormattedMessage
+                  id="common.progress"
+                  defaultMessage="Progress"
+                />
+              </SortableColumnHeader>
+              <SortableColumnHeader<SortField>
+                field="priority"
+                activeField={currentSort}
+                direction={sortDirection}
+                onSort={handleSort}
+                className="min-w-35"
+              >
+                <FormattedMessage
+                  id="common.priority"
+                  defaultMessage="Priority"
+                />
+              </SortableColumnHeader>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {visibleRows.map(({ depth, node }) => {
+              const indent = { paddingLeft: `${depth * 1.25 + 0.25}rem` };
+
+              if (node.type === 'folder') {
+                const isExpanded = expanded.has(node.path);
+                const folderSelected =
+                  node.fileIndices.length > 0 &&
+                  node.fileIndices.every((id) => selected.has(id));
+                const folderSome = node.fileIndices.some((id) =>
+                  selected.has(id)
+                );
+                const folderPriority = commonPriority(node.fileIndices);
+                const folderUpdating = node.fileIndices.some((id) =>
+                  updatingFiles.has(id)
+                );
+
+                return (
+                  <tr
+                    key={`folder:${node.path}`}
+                    className="hover hover:bg-base-300 font-medium"
+                  >
+                    <td className="w-8">
+                      <input
+                        type="checkbox"
+                        className="checkbox checkbox-sm checkbox-primary"
+                        checked={folderSelected}
+                        ref={(el) => {
+                          if (el)
+                            el.indeterminate = !folderSelected && folderSome;
+                        }}
+                        onChange={(e) =>
+                          toggleSelection(node.fileIndices, e.target.checked)
+                        }
+                        aria-label={intl.formatMessage(
+                          {
+                            id: 'downloads.selectFolder',
+                            defaultMessage: 'Select folder {name}',
+                          },
+                          { name: node.name }
+                        )}
+                      />
+                    </td>
+                    <td className="max-w-xs min-w-50">
+                      <div className="flex items-center" style={indent}>
+                        <button
+                          type="button"
+                          onClick={() => toggleFolder(node.path)}
+                          className="hover:text-primary mr-1 flex w-full items-center gap-1 hover:cursor-pointer"
+                          aria-expanded={isExpanded}
+                          aria-label={intl.formatMessage(
+                            {
+                              id: 'downloads.toggleFolder',
+                              defaultMessage: 'Toggle folder {name}',
+                            },
+                            { name: node.name }
+                          )}
+                        >
+                          <span>
+                            <ChevronDownIcon
+                              className={`size-4 transition-transform ${
+                                isExpanded ? 'rotate-0' : '-rotate-90'
+                              }`}
+                            />
+                          </span>
+                          <span
+                            className="block cursor-pointer truncate text-xs"
+                            title={node.name}
+                          >
+                            {node.name}
+                          </span>
+                        </button>
+                      </div>
+                    </td>
+                    <td className="min-w-20 text-xs whitespace-nowrap">
+                      {formatBytes(node.size)}
+                    </td>
+                    <td className="min-w-30">
+                      <ProgressBar
+                        progress={folderProgress(node.fileIndices) * 100}
+                      />
+                    </td>
+                    <td className="min-w-35">
+                      <div className="flex items-center gap-1">
+                        <select
+                          className="select select-xs select-primary min-w-30"
+                          value={folderPriority}
+                          onChange={(e) =>
+                            applyPriority(
+                              node.fileIndices,
+                              parseInt(e.target.value, 10)
+                            )
+                          }
+                          disabled={folderUpdating}
+                        >
+                          {renderPriorityOptions(
+                            folderPriority === MIXED,
+                            folderPriority
+                          )}
+                        </select>
+                        {folderUpdating && (
+                          <span className="loading loading-spinner loading-xs"></span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              }
+
+              const file = node.file;
+              const fileUpdating = updatingFiles.has(file.index);
+
+              return (
+                <tr
+                  key={`file:${file.index}`}
+                  className="hover hover:bg-base-300"
+                >
+                  <td className="w-8">
+                    <input
+                      type="checkbox"
+                      className="checkbox checkbox-sm checkbox-primary"
+                      checked={selected.has(file.index)}
+                      onChange={(e) =>
+                        toggleSelection([file.index], e.target.checked)
+                      }
+                      aria-label={intl.formatMessage(
+                        {
+                          id: 'downloads.selectFile',
+                          defaultMessage: 'Select file {name}',
+                        },
+                        { name: file.name }
+                      )}
+                    />
+                  </td>
+                  <td className="max-w-xs min-w-50">
+                    <span
+                      className="block truncate text-xs"
+                      style={indent}
+                      title={file.name}
+                    >
+                      {file.name}
+                    </span>
+                  </td>
+                  <td className="min-w-20 text-xs whitespace-nowrap">
+                    {formatBytes(file.size)}
+                  </td>
+                  <td className="min-w-30">
+                    <ProgressBar progress={file.progress * 100} />
+                  </td>
+                  <td className="min-w-35">
+                    <div className="flex items-center gap-1">
+                      <select
+                        className="select select-xs select-primary min-w-30"
+                        value={file.priority}
+                        onChange={(e) =>
+                          applyPriority(
+                            [file.index],
+                            parseInt(e.target.value, 10)
+                          )
+                        }
+                        disabled={fileUpdating}
+                      >
+                        {renderPriorityOptions(false, file.priority)}
+                      </select>
+                      {fileUpdating && (
+                        <span className="loading loading-spinner loading-xs"></span>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 };

--- a/src/components/Admin/Downloads/index.tsx
+++ b/src/components/Admin/Downloads/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Button from '@app/components/Common/Button';
 import LoadingEllipsis from '@app/components/Common/LoadingEllipsis';
+import SortableColumnHeader from '@app/components/Common/SortableColumnHeader';
 import Tooltip from '@app/components/Common/ToolTip';
 import Toast from '@app/components/Toast';
 import { useDownloadActions, useDownloads } from '@app/hooks/useDownloads';
@@ -981,177 +982,102 @@ const AdminDownloads = () => {
                         onChange={handleSelectAll}
                       />
                     </th>
-                    <th
-                      className="hover:bg-base-300 cursor-pointer transition-colors select-none"
-                      onClick={() => handleSort('name')}
+                    <SortableColumnHeader<Sort>
+                      field="name"
+                      activeField={currentSort}
+                      direction={sortDirection}
+                      onSort={handleSort}
                     >
-                      <div className="flex items-center gap-1">
-                        <span>
-                          <FormattedMessage
-                            id="common.name"
-                            defaultMessage="Name"
-                          />
-                        </span>
-                        {currentSort === 'name' &&
-                          (sortDirection === 'asc' ? (
-                            <ChevronUpIcon className="h-4 w-4" />
-                          ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
-                          ))}
-                      </div>
-                    </th>
-                    <th
-                      className="hover:bg-base-300 cursor-pointer transition-colors select-none"
-                      onClick={() => handleSort('progress')}
+                      <FormattedMessage
+                        id="common.name"
+                        defaultMessage="Name"
+                      />
+                    </SortableColumnHeader>
+                    <SortableColumnHeader<Sort>
+                      field="progress"
+                      activeField={currentSort}
+                      direction={sortDirection}
+                      onSort={handleSort}
                     >
-                      <div className="flex items-center gap-1">
-                        <span>
-                          <FormattedMessage
-                            id="common.progress"
-                            defaultMessage="Progress"
-                          />
-                        </span>
-                        {currentSort === 'progress' &&
-                          (sortDirection === 'asc' ? (
-                            <ChevronUpIcon className="h-4 w-4" />
-                          ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
-                          ))}
-                      </div>
-                    </th>
-                    <th
-                      className="hover:bg-base-300 cursor-pointer transition-colors select-none"
-                      onClick={() => handleSort('size')}
+                      <FormattedMessage
+                        id="common.progress"
+                        defaultMessage="Progress"
+                      />
+                    </SortableColumnHeader>
+                    <SortableColumnHeader<Sort>
+                      field="size"
+                      activeField={currentSort}
+                      direction={sortDirection}
+                      onSort={handleSort}
                     >
-                      <div className="flex items-center gap-1">
-                        <span>
-                          <FormattedMessage
-                            id="common.size"
-                            defaultMessage="Size"
-                          />
-                        </span>
-                        {currentSort === 'size' &&
-                          (sortDirection === 'asc' ? (
-                            <ChevronUpIcon className="h-4 w-4" />
-                          ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
-                          ))}
-                      </div>
-                    </th>
-                    <th
-                      className="hover:bg-base-300 cursor-pointer transition-colors select-none"
-                      onClick={() => handleSort('speed')}
+                      <FormattedMessage
+                        id="common.size"
+                        defaultMessage="Size"
+                      />
+                    </SortableColumnHeader>
+                    <SortableColumnHeader<Sort>
+                      field="speed"
+                      activeField={currentSort}
+                      direction={sortDirection}
+                      onSort={handleSort}
                     >
-                      <div className="flex items-center gap-1">
-                        <span>
-                          <FormattedMessage
-                            id="common.speed"
-                            defaultMessage="Speed"
-                          />
-                        </span>
-                        {currentSort === 'speed' &&
-                          (sortDirection === 'asc' ? (
-                            <ChevronUpIcon className="h-4 w-4" />
-                          ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
-                          ))}
-                      </div>
-                    </th>
-                    <th
-                      className="hover:bg-base-300 cursor-pointer transition-colors select-none"
-                      onClick={() => handleSort('eta')}
+                      <FormattedMessage
+                        id="common.speed"
+                        defaultMessage="Speed"
+                      />
+                    </SortableColumnHeader>
+                    <SortableColumnHeader<Sort>
+                      field="eta"
+                      activeField={currentSort}
+                      direction={sortDirection}
+                      onSort={handleSort}
                     >
-                      <div className="flex items-center gap-1">
-                        <span>
-                          <FormattedMessage
-                            id="common.eta"
-                            defaultMessage="ETA"
-                          />
-                        </span>
-                        {currentSort === 'eta' &&
-                          (sortDirection === 'asc' ? (
-                            <ChevronUpIcon className="h-4 w-4" />
-                          ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
-                          ))}
-                      </div>
-                    </th>
-                    <th
-                      className="hover:bg-base-300 cursor-pointer transition-colors select-none"
-                      onClick={() => handleSort('ratio')}
+                      <FormattedMessage id="common.eta" defaultMessage="ETA" />
+                    </SortableColumnHeader>
+                    <SortableColumnHeader<Sort>
+                      field="ratio"
+                      activeField={currentSort}
+                      direction={sortDirection}
+                      onSort={handleSort}
                     >
-                      <div className="flex items-center gap-1">
-                        <span>
-                          <FormattedMessage
-                            id="common.ratio"
-                            defaultMessage="Ratio"
-                          />
-                        </span>
-                        {currentSort === 'ratio' &&
-                          (sortDirection === 'asc' ? (
-                            <ChevronUpIcon className="h-4 w-4" />
-                          ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
-                          ))}
-                      </div>
-                    </th>
-                    <th
-                      className="hover:bg-base-300 cursor-pointer transition-colors select-none"
-                      onClick={() => handleSort('status')}
+                      <FormattedMessage
+                        id="common.ratio"
+                        defaultMessage="Ratio"
+                      />
+                    </SortableColumnHeader>
+                    <SortableColumnHeader<Sort>
+                      field="status"
+                      activeField={currentSort}
+                      direction={sortDirection}
+                      onSort={handleSort}
                     >
-                      <div className="flex items-center gap-1">
-                        <span>
-                          <FormattedMessage
-                            id="common.status"
-                            defaultMessage="Status"
-                          />
-                        </span>
-                        {currentSort === 'status' &&
-                          (sortDirection === 'asc' ? (
-                            <ChevronUpIcon className="h-4 w-4" />
-                          ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
-                          ))}
-                      </div>
-                    </th>
-                    <th
-                      className="hover:bg-base-300 cursor-pointer transition-colors select-none"
-                      onClick={() => handleSort('client')}
+                      <FormattedMessage
+                        id="common.status"
+                        defaultMessage="Status"
+                      />
+                    </SortableColumnHeader>
+                    <SortableColumnHeader<Sort>
+                      field="client"
+                      activeField={currentSort}
+                      direction={sortDirection}
+                      onSort={handleSort}
                     >
-                      <div className="flex items-center gap-1">
-                        <span>
-                          <FormattedMessage
-                            id="downloads.client"
-                            defaultMessage="Client"
-                          />
-                        </span>
-                        {currentSort === 'client' &&
-                          (sortDirection === 'asc' ? (
-                            <ChevronUpIcon className="h-4 w-4" />
-                          ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
-                          ))}
-                      </div>
-                    </th>
-                    <th
-                      className="hover:bg-base-300 cursor-pointer transition-colors select-none"
-                      onClick={() => handleSort('priority')}
+                      <FormattedMessage
+                        id="downloads.client"
+                        defaultMessage="Client"
+                      />
+                    </SortableColumnHeader>
+                    <SortableColumnHeader<Sort>
+                      field="priority"
+                      activeField={currentSort}
+                      direction={sortDirection}
+                      onSort={handleSort}
                     >
-                      <div className="flex items-center gap-1">
-                        <span>
-                          <FormattedMessage
-                            id="common.priority"
-                            defaultMessage="Priority"
-                          />
-                        </span>
-                        {currentSort === 'priority' &&
-                          (sortDirection === 'asc' ? (
-                            <ChevronUpIcon className="h-4 w-4" />
-                          ) : (
-                            <ChevronDownIcon className="h-4 w-4" />
-                          ))}
-                      </div>
-                    </th>
+                      <FormattedMessage
+                        id="common.priority"
+                        defaultMessage="Priority"
+                      />
+                    </SortableColumnHeader>
                     <th>
                       <FormattedMessage
                         id="common.actions"

--- a/src/components/Common/SortableColumnHeader/index.tsx
+++ b/src/components/Common/SortableColumnHeader/index.tsx
@@ -1,0 +1,60 @@
+import { ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/24/solid';
+import React from 'react';
+
+interface SortableColumnHeaderProps<T extends string> {
+  /** The sort field this header controls. */
+  field: T;
+  /** The currently active sort field. */
+  activeField: T;
+  /** The current sort direction. */
+  direction: 'asc' | 'desc';
+  /** Invoked with `field` when the header is activated (click or keyboard). */
+  onSort: (field: T) => void;
+  /** Header label. */
+  children: React.ReactNode;
+  /** Optional extra classes applied to the `<th>`. */
+  className?: string;
+}
+
+/**
+ * A sortable table column header. The interactive control is a real `<button>`
+ * so it is keyboard focusable and operable (Enter/Space), and the `<th>`
+ * exposes `aria-sort` for assistive technology. Used by both the downloads
+ * list and the torrent file contents list to keep sorting consistent.
+ */
+function SortableColumnHeader<T extends string>({
+  field,
+  activeField,
+  direction,
+  onSort,
+  children,
+  className = '',
+}: SortableColumnHeaderProps<T>) {
+  const isActive = activeField === field;
+
+  return (
+    <th
+      scope="col"
+      className={`hover:bg-base-300 transition-colors select-none ${className}`}
+      aria-sort={
+        isActive ? (direction === 'asc' ? 'ascending' : 'descending') : 'none'
+      }
+    >
+      <button
+        type="button"
+        onClick={() => onSort(field)}
+        className="hover:text-primary flex w-full items-center gap-1 hover:cursor-pointer"
+      >
+        <span>{children}</span>
+        {isActive &&
+          (direction === 'asc' ? (
+            <ChevronUpIcon className="size-4" />
+          ) : (
+            <ChevronDownIcon className="size-4" />
+          ))}
+      </button>
+    </th>
+  );
+}
+
+export default SortableColumnHeader;

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -956,6 +956,9 @@
   "downloads.categoryUpdated": {
     "defaultMessage": "Category updated successfully"
   },
+  "downloads.clearSelection": {
+    "defaultMessage": "Clear"
+  },
   "downloads.client": {
     "defaultMessage": "Client"
   },
@@ -1118,8 +1121,20 @@
   "downloads.savePathUpdated": {
     "defaultMessage": "Save path updated successfully"
   },
+  "downloads.selectAllFiles": {
+    "defaultMessage": "Select all files"
+  },
+  "downloads.selectFile": {
+    "defaultMessage": "Select file {name}"
+  },
+  "downloads.selectFolder": {
+    "defaultMessage": "Select folder {name}"
+  },
   "downloads.selected": {
     "defaultMessage": "selected"
+  },
+  "downloads.setPriorityForSelected": {
+    "defaultMessage": "Set priority for selected files"
   },
   "downloads.staleData": {
     "defaultMessage": "The data for this torrent may be outdated because the download client is offline or not responding."
@@ -1171,6 +1186,9 @@
   },
   "downloads.tags": {
     "defaultMessage": "Tags"
+  },
+  "downloads.toggleFolder": {
+    "defaultMessage": "Toggle folder {name}"
   },
   "downloads.torrentDetails": {
     "defaultMessage": "Torrent Details"


### PR DESCRIPTION
## Description
Reworks the **Content** list inside the torrent details view so files can be managed in bulk and by folder, addressing #488. Behaviour now mirrors how qBittorrent handles torrent contents natively.

This is a **frontend-only** change scoped to `src/components/Admin/Downloads/TorrentFileList.tsx`. The backend already
accepts `fileIds: number[]` for `setTorrentFilePriority` across all three clients, so no server or API changes were required.

## Changes

### Folder tree & collapsing
- Files are grouped into a folder tree built from their `/`-separated paths (works for qBittorrent, Deluge, and Transmission, which all return full  relative paths). Arbitrary nesting depth is supported.
- Folders are collapsible. Smart default: a single root folder (and any single-child chain beneath it) auto-expands; anything that branches starts collapsed.
- Each folder shows aggregate size, size-weighted progress, and an inline priority dropdown that displays **Mixed** when its files differ. Changing it applies to every file in the folder in one request.

### Bulk selection & actions
- Tri-state checkboxes at the file, folder (indeterminate when partial), and header **select-all** levels.
- A sticky **"N selected"** bar lets you apply a priority to the whole selection at once, plus a **Clear** action.
- Selection and expansion reset when switching torrents but persist across a routine priority refresh.

### Column sorting
- **Name**, **Size**, **Progress**, and **Priority** headers are now click-to-sort with asc/desc toggling and a chevron indicator — the same pattern as the parent download list.
- Defaults to **Name, A→Z**. Sorting is recursive per level; folders and files intermix by the active column (folders sort by their aggregate value) while the tree structure is preserved.

### Related Issues
- Closes #488

## Has This Been Tested?

- [x] qBittorrent multi-file torrent (folders collapse, bulk priority,
      per-column sort)
- [x] Deluge and Transmission torrents
- [x] single-file / root-level-file torrents (no folder)

## Screenshots (if applicable)
<img width="744" height="499" alt="image" src="https://github.com/user-attachments/assets/ef25f60c-1c79-421d-a22b-592f9dd1fca7" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
