### PR TITLE
fix: disable priority setting inflight & validate API key in cleanuparr

### DIFF
--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -389,9 +389,15 @@ settingsRoutes.post('/cleanuparr/test', async (req, res, next) => {
       !/^[A-Za-z0-9.-]+$/.test(hostname) ||
       !Number.isInteger(portNumber) ||
       portNumber < 1 ||
-      portNumber > 65535
+      portNumber > 65535 ||
+      typeof apiKey !== 'string' ||
+      apiKey.trim().length === 0 ||
+      (useSsl !== undefined && typeof useSsl !== 'boolean')
     ) {
-      return next({ status: 400, message: 'Invalid hostname or port' });
+      return next({
+        status: 400,
+        message: 'Invalid hostname, port, or API key',
+      });
     }
 
     const protocol = useSsl ? 'https' : 'http';

--- a/src/components/Admin/Downloads/TorrentFileList.tsx
+++ b/src/components/Admin/Downloads/TorrentFileList.tsx
@@ -380,6 +380,7 @@ const TorrentFileList: React.FC<TorrentFileListProps> = ({
               onChange={(e) =>
                 applyPriority([...selected], parseInt(e.target.value, 10))
               }
+              disabled={[...selected].some((id) => updatingFiles.has(id))}
               aria-label={intl.formatMessage({
                 id: 'downloads.setPriorityForSelected',
                 defaultMessage: 'Set priority for selected files',


### PR DESCRIPTION
## Description
This pull request introduces improvements to validation and UI responsiveness in the application. The main changes focus on strengthening input validation for an API endpoint and enhancing the user interface by disabling controls during updates.

**Validation improvements:**

* Strengthened the validation logic in the `/cleanuparr/test` endpoint to check that `apiKey` is a non-empty string and `useSsl` is a boolean if provided, in addition to existing hostname and port checks. The error message was also updated to reflect the new validation rules.

**UI/UX enhancements:**

* Updated the `TorrentFileList` component to disable the priority selection dropdown when any selected files are currently being updated, preventing user actions during ongoing updates.

## Has This Been Tested?

- [x] Confirmed inflight updating disables priority settings per file
- [x] API key's correctly validated during testing

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
