### PR TITLE
feat(settings): report health of all enabled services

### DIFF
--- a/server/api/downloads/base.ts
+++ b/server/api/downloads/base.ts
@@ -167,6 +167,32 @@ export async function testConnection(
 }
 
 /**
+ * Fetch the running version of a download client. Performs an authenticated
+ * request, so it also doubles as a connectivity check.
+ */
+export async function getClientVersion(
+  settings: DownloadClientSettings
+): Promise<string> {
+  clearClientCache(settings.id);
+  const client = await getClient(settings);
+
+  switch (settings.client) {
+    case 'qbittorrent':
+      return (client as QBittorrent).getAppVersion();
+    case 'deluge': {
+      const version = await (client as Deluge).getVersion();
+      return version.result;
+    }
+    case 'transmission': {
+      const session = await (client as Transmission).getSession();
+      return session.arguments.version;
+    }
+    default:
+      throw new Error(`Unsupported download client: ${settings.client}`);
+  }
+}
+
+/**
  * Fetch all torrent data from a single client with health check support
  */
 export async function fetchClientData(

--- a/server/api/plexapi.ts
+++ b/server/api/plexapi.ts
@@ -8,6 +8,7 @@ interface PlexStatusResponse {
   MediaContainer: {
     machineIdentifier: string;
     friendlyName: string;
+    version?: string;
   };
 }
 

--- a/server/api/seerr.ts
+++ b/server/api/seerr.ts
@@ -146,6 +146,17 @@ class SeerrAPI {
     }
   }
 
+  public async getStatus(): Promise<{ version: string }> {
+    try {
+      const response = await this.axios.get<{ version: string }>('/status');
+      return { version: response.data.version };
+    } catch (e) {
+      throw new Error(
+        `[Seerr] Failed to fetch status: ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+  }
+
   public async getDefaultQuotas(): Promise<SeerrQuotaResponse> {
     try {
       const response =

--- a/server/i18n/locale/en.json
+++ b/server/i18n/locale/en.json
@@ -27,5 +27,6 @@
   "notifications.user.created.message": "Invited by {displayName}.",
   "notifications.user.created.subject": "New User Created: {displayName}",
   "notifications.userSettings.extensionRequested": "Access extension requested",
-  "notifications.userSettings.extensionRequestedMessage": "{displayName} requested an access extension. {state, select, deactivated {Account Deactivated} ended {Trial Ended} other {Trial Ends}}: {accessEndDate}"
+  "notifications.userSettings.extensionRequestedMessage": "{displayName} requested an access extension. {state, select, deactivated {Account Deactivated} ended {Trial Ended} other {Trial Ends}}: {accessEndDate}",
+  "system.service.monitoring": "Monitoring {count, plural, one {# service} other {# services}}"
 }

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -142,3 +142,30 @@ export interface GitHubRelease {
   zipball_url: string;
   body: string;
 }
+
+export type ServiceHealthStatus =
+  'healthy' | 'retrying' | 'unhealthy' | 'unknown';
+
+export interface ServiceHealthInstance {
+  id: string;
+  name: string;
+  status: ServiceHealthStatus;
+  version?: string;
+  detail?: string;
+  error?: string;
+}
+
+export interface ServiceHealth {
+  id: string;
+  name: string;
+  status: ServiceHealthStatus;
+  version?: string;
+  detail?: string;
+  error?: string;
+  retryable: boolean;
+  instances?: ServiceHealthInstance[];
+}
+
+export interface ServiceHealthResponse {
+  services: ServiceHealth[];
+}

--- a/server/lib/plexHealthCheck.ts
+++ b/server/lib/plexHealthCheck.ts
@@ -13,6 +13,7 @@ export interface PlexHealthState {
   lastError?: string;
   cooldownUntil?: Date;
   consecutiveFailures: number;
+  version?: string;
 }
 
 export interface LibraryLink {
@@ -38,11 +39,12 @@ let plexHealthState: PlexHealthState = {
 };
 
 let cachedLibraries: LibraryItemsResponse | undefined;
+let cachedPlexVersion: string | undefined;
 let retryTimeout: NodeJS.Timeout | undefined;
 let revalidating = false;
 
 export function getPlexHealth(): PlexHealthState {
-  return { ...plexHealthState };
+  return { ...plexHealthState, version: cachedPlexVersion };
 }
 
 export function isPlexInCooldown(): boolean {
@@ -126,6 +128,28 @@ export function getPlexCachedLibraries(): LibraryItemsResponse | undefined {
   return cachedLibraries;
 }
 
+/**
+ * Best-effort fetch of the Plex server version for display purposes. Does not
+ * affect the health state and is skipped once the version is known or while
+ * Plex is in cooldown.
+ */
+export async function refreshPlexVersion(): Promise<void> {
+  if (cachedPlexVersion || isPlexInCooldown()) return;
+  try {
+    const admin = await getRepository(User).findOneOrFail({
+      select: { id: true, plexToken: true },
+      where: { id: 1 },
+    });
+    const plexApi = new PlexAPI({ plexToken: admin.plexToken });
+    const status = await plexApi.getStatus();
+    if (status.MediaContainer.version) {
+      cachedPlexVersion = status.MediaContainer.version;
+    }
+  } catch {
+    // Version stays unknown; status is reported separately.
+  }
+}
+
 function setPlexCachedLibraries(data: LibraryItemsResponse): void {
   cachedLibraries = data;
 }
@@ -154,7 +178,10 @@ export async function revalidatePlexLibraries(): Promise<void> {
     );
 
     await withPlexHealth(async () => {
-      await plexApi.getStatus();
+      const status = await plexApi.getStatus();
+      if (status.MediaContainer.version) {
+        cachedPlexVersion = status.MediaContainer.version;
+      }
 
       const libraries = await Promise.all(
         allEnabledLibraries.map(async (lib) => {

--- a/server/lib/serviceHealth.ts
+++ b/server/lib/serviceHealth.ts
@@ -1,0 +1,420 @@
+import { clearClientCache, getClientVersion } from '@server/api/downloads/base';
+import SeerrAPI from '@server/api/seerr';
+import LidarrAPI from '@server/api/servarr/lidarr';
+import ProwlarrAPI from '@server/api/servarr/prowlarr';
+import RadarrAPI from '@server/api/servarr/radarr';
+import SonarrAPI from '@server/api/servarr/sonarr';
+import TautulliAPI from '@server/api/tautulli';
+import { getIntl } from '@server/i18n';
+import type {
+  ServiceHealth,
+  ServiceHealthInstance,
+  ServiceHealthStatus,
+} from '@server/interfaces/api/settingsInterfaces';
+import { resetClientHealth } from '@server/lib/healthCheck';
+import { getPlexHealth, refreshPlexVersion } from '@server/lib/plexHealthCheck';
+import type {
+  DownloadClientSettings,
+  DVRSettings,
+  ServiceSettings,
+} from '@server/lib/settings';
+import { getSettings } from '@server/lib/settings';
+
+interface CheckResult {
+  status: ServiceHealthStatus;
+  version?: string;
+  detail?: string;
+  error?: string;
+}
+
+const errorMessage = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e);
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error('Health check timed out')),
+      ms
+    );
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
+const isServiceConfigured = (service: ServiceSettings): boolean =>
+  service.enabled === true && !!service.hostname;
+
+function buildUrl(
+  service: ServiceSettings,
+  path: string,
+  defaultPort: number
+): URL {
+  const protocol = service.useSsl ? 'https' : 'http';
+  const base = String(service.urlBase ?? '')
+    .split('/')
+    .filter(Boolean)
+    .join('/');
+  return new URL(
+    base ? `/${base}/${path}` : `/${path}`,
+    `${protocol}://${service.hostname}:${service.port ?? defaultPort}`
+  );
+}
+
+const aggregateStatus = (
+  instances: ServiceHealthInstance[]
+): ServiceHealthStatus => {
+  if (instances.length === 0) return 'unknown';
+  if (instances.some((i) => i.status === 'unhealthy')) return 'unhealthy';
+  if (instances.some((i) => i.status === 'retrying')) return 'retrying';
+  if (instances.every((i) => i.status === 'healthy')) return 'healthy';
+  return 'unknown';
+};
+
+async function checkArr(api: {
+  getSystemStatus: () => Promise<{ version: string }>;
+}): Promise<CheckResult> {
+  try {
+    const status = await api.getSystemStatus();
+    return { status: 'healthy', version: status.version };
+  } catch (e) {
+    return { status: 'unhealthy', error: errorMessage(e) };
+  }
+}
+
+interface CleanuparrStats {
+  health?: {
+    downloadClients?: unknown[];
+    arrInstances?: unknown[];
+  };
+}
+
+async function checkCleanuparr(service: ServiceSettings): Promise<CheckResult> {
+  const intl = getIntl(getSettings().main.locale ?? 'en');
+  try {
+    const url = buildUrl(service, 'api/stats', 11011);
+    url.searchParams.set('hours', '1');
+
+    const response = await fetch(url, {
+      headers: { 'X-Api-Key': service.apiKey ?? '' },
+      signal: AbortSignal.timeout(getSettings().network.requestTimeout),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Cleanuparr responded with HTTP ${response.status}`);
+    }
+
+    // Cleanuparr does not expose an application version, so surface the number
+    // of services it is monitoring as a useful health detail instead.
+    const stats = (await response.json()) as CleanuparrStats;
+    const monitored =
+      (stats.health?.downloadClients?.length ?? 0) +
+      (stats.health?.arrInstances?.length ?? 0);
+
+    return {
+      status: 'healthy',
+      detail: intl.formatMessage(
+        {
+          id: 'system.service.monitoring',
+          defaultMessage:
+            'Monitoring {count, plural, one {# service} other {# services}}',
+        },
+        { count: monitored }
+      ),
+    };
+  } catch (e) {
+    return { status: 'unhealthy', error: errorMessage(e) };
+  }
+}
+
+interface BazarrStatus {
+  data?: { bazarr_version?: string };
+}
+
+async function checkBazarr(service: ServiceSettings): Promise<CheckResult> {
+  try {
+    const response = await fetch(buildUrl(service, 'api/system/status', 6767), {
+      headers: {
+        'X-API-KEY': service.apiKey ?? '',
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(timeout()),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Bazarr responded with HTTP ${response.status}`);
+    }
+
+    const body = (await response.json()) as BazarrStatus;
+    const version = body.data?.bazarr_version;
+    if (!version) {
+      throw new Error('Bazarr did not return a valid status response');
+    }
+
+    return { status: 'healthy', version };
+  } catch (e) {
+    return { status: 'unhealthy', error: errorMessage(e) };
+  }
+}
+
+interface TdarrStatus {
+  status?: string;
+  version?: string;
+}
+
+async function checkTdarr(service: ServiceSettings): Promise<CheckResult> {
+  try {
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    if (service.apiKey) {
+      headers['x-api-key'] = service.apiKey;
+    }
+
+    const response = await fetch(
+      `${service.useSsl ? 'https' : 'http'}://${service.hostname}:${
+        service.port ?? 8265
+      }/api/v2/status`,
+      {
+        headers,
+        signal: AbortSignal.timeout(timeout()),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Tdarr responded with HTTP ${response.status}`);
+    }
+
+    const body = (await response.json()) as TdarrStatus;
+    return { status: 'healthy', version: body.version };
+  } catch (e) {
+    return { status: 'unhealthy', error: errorMessage(e) };
+  }
+}
+
+async function checkTautulli(): Promise<CheckResult> {
+  const tautulli = getSettings().tautulli;
+  try {
+    const info = await withTimeout(
+      new TautulliAPI({ ...tautulli, port: tautulli.port ?? 8181 }).getInfo(),
+      timeout()
+    );
+    return { status: 'healthy', version: info.tautulli_version };
+  } catch (e) {
+    return { status: 'unhealthy', error: errorMessage(e) };
+  }
+}
+
+async function checkSeerr(service: ServiceSettings): Promise<CheckResult> {
+  try {
+    const status = await withTimeout(
+      new SeerrAPI({ ...service, port: service.port ?? 5055 }).getStatus(),
+      timeout()
+    );
+    return { status: 'healthy', version: status.version };
+  } catch (e) {
+    return { status: 'unhealthy', error: errorMessage(e) };
+  }
+}
+
+async function checkDownloadClient(
+  client: DownloadClientSettings
+): Promise<CheckResult> {
+  try {
+    const version = await withTimeout(getClientVersion(client), timeout());
+    return { status: 'healthy', version };
+  } catch (e) {
+    return { status: 'unhealthy', error: errorMessage(e) };
+  }
+}
+
+const timeout = (): number => getSettings().network.requestTimeout;
+
+async function checkArrInstances(
+  prefix: string,
+  instances: DVRSettings[],
+  build: (instance: DVRSettings) => {
+    getSystemStatus: () => Promise<{ version: string }>;
+  }
+): Promise<ServiceHealthInstance[]> {
+  return Promise.all(
+    instances.map(async (instance) => {
+      const result = await checkArr(build(instance));
+      return {
+        id: `${prefix}-${instance.id}`,
+        name: instance.name,
+        ...result,
+      } satisfies ServiceHealthInstance;
+    })
+  );
+}
+
+export async function getServicesHealth(): Promise<ServiceHealth[]> {
+  const settings = getSettings();
+
+  const tasks: Promise<ServiceHealth | null>[] = [
+    (async (): Promise<ServiceHealth> => {
+      await refreshPlexVersion();
+      const plexHealth = getPlexHealth();
+      return {
+        id: 'plex',
+        name: 'Plex',
+        status: plexHealth.status,
+        version: plexHealth.version,
+        error: plexHealth.lastError,
+        retryable: true,
+      };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (settings.radarr.length === 0) return null;
+      const instances = await checkArrInstances(
+        'radarr',
+        settings.radarr,
+        (instance) =>
+          new RadarrAPI({
+            apiKey: instance.apiKey,
+            url: RadarrAPI.buildUrl(instance, '/api/v3'),
+            timeout: timeout(),
+          })
+      );
+      return {
+        id: 'radarr',
+        name: 'Radarr',
+        status: aggregateStatus(instances),
+        retryable: true,
+        instances,
+      };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (settings.sonarr.length === 0) return null;
+      const instances = await checkArrInstances(
+        'sonarr',
+        settings.sonarr,
+        (instance) =>
+          new SonarrAPI({
+            apiKey: instance.apiKey,
+            url: SonarrAPI.buildUrl(instance, '/api/v3'),
+            timeout: timeout(),
+          })
+      );
+      return {
+        id: 'sonarr',
+        name: 'Sonarr',
+        status: aggregateStatus(instances),
+        retryable: true,
+        instances,
+      };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (!isServiceConfigured(settings.prowlarr)) return null;
+      const result = await checkArr(
+        new ProwlarrAPI({
+          apiKey: settings.prowlarr.apiKey ?? '',
+          url: ProwlarrAPI.buildServiceUrl(settings.prowlarr, '/api/v1'),
+          timeout: timeout(),
+        })
+      );
+      return { id: 'prowlarr', name: 'Prowlarr', retryable: true, ...result };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (!isServiceConfigured(settings.lidarr)) return null;
+      const result = await checkArr(
+        new LidarrAPI({
+          apiKey: settings.lidarr.apiKey ?? '',
+          url: LidarrAPI.buildServiceUrl(settings.lidarr, '/api/v1'),
+          timeout: timeout(),
+        })
+      );
+      return { id: 'lidarr', name: 'Lidarr', retryable: true, ...result };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (!isServiceConfigured(settings.bazarr)) return null;
+      const result = await checkBazarr(settings.bazarr);
+      return { id: 'bazarr', name: 'Bazarr', retryable: true, ...result };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (!isServiceConfigured(settings.tdarr)) return null;
+      const result = await checkTdarr(settings.tdarr);
+      return { id: 'tdarr', name: 'Tdarr', retryable: true, ...result };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (!isServiceConfigured(settings.cleanuparr)) return null;
+      const result = await checkCleanuparr(settings.cleanuparr);
+      return {
+        id: 'cleanuparr',
+        name: 'Cleanuparr',
+        retryable: true,
+        ...result,
+      };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (!isServiceConfigured(settings.tautulli as ServiceSettings))
+        return null;
+      const result = await checkTautulli();
+      return { id: 'tautulli', name: 'Tautulli', retryable: true, ...result };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (!isServiceConfigured(settings.overseerr)) return null;
+      const result = await checkSeerr(settings.overseerr);
+      return { id: 'overseerr', name: 'Seerr', retryable: true, ...result };
+    })(),
+
+    (async (): Promise<ServiceHealth | null> => {
+      if (settings.downloads.length === 0) return null;
+      const instances = await Promise.all(
+        settings.downloads.map(async (client) => {
+          const result = await checkDownloadClient(client);
+          return {
+            id: `downloads-${client.id}`,
+            name: client.name,
+            ...result,
+          } satisfies ServiceHealthInstance;
+        })
+      );
+      return {
+        id: 'downloads',
+        name: 'Downloads',
+        status: aggregateStatus(instances),
+        retryable: true,
+        instances,
+      };
+    })(),
+  ];
+
+  const results = await Promise.all(tasks);
+  return results.filter(
+    (service): service is ServiceHealth => service !== null
+  );
+}
+
+export function resetServiceHealthState(id: string): void {
+  if (id === 'downloads') {
+    getSettings().downloads.forEach((client) => {
+      resetClientHealth(client.id);
+      clearClientCache(client.id);
+    });
+    return;
+  }
+
+  if (id.startsWith('downloads-')) {
+    const clientId = Number(id.slice('downloads-'.length));
+    if (Number.isInteger(clientId)) {
+      resetClientHealth(clientId);
+      clearClientCache(clientId);
+    }
+  }
+}

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -11,6 +11,7 @@ import type { PlexConnection } from '@server/interfaces/api/plexInterfaces';
 import type {
   LogMessage,
   LogsResultsResponse,
+  ServiceHealthResponse,
   SettingsAboutResponse,
 } from '@server/interfaces/api/settingsInterfaces';
 import { scheduledJobs } from '@server/job/schedule';
@@ -20,12 +21,17 @@ import ImageProxy from '@server/lib/imageproxy';
 import { Permission } from '@server/lib/permissions';
 import {
   markPlexHealthy,
+  resetPlexHealth,
   revalidatePlexLibraries,
 } from '@server/lib/plexHealthCheck';
 import QRCodeProxy from '@server/lib/qrcodeproxy';
 import { arrAuthLimiter, settingsAboutLimiter } from '@server/lib/rateLimiters';
 import restartManager from '@server/lib/restartManager';
 import { plexFullScanner } from '@server/lib/scanners/plex';
+import {
+  getServicesHealth,
+  resetServiceHealthState,
+} from '@server/lib/serviceHealth';
 import type {
   JobId,
   MainSettings,
@@ -326,6 +332,52 @@ settingsRoutes.get('/services', (_req, res) => {
 
   res.status(200).json(servicesWithId);
 });
+
+settingsRoutes.get<unknown, ServiceHealthResponse>(
+  '/health',
+  async (_req, res, next) => {
+    try {
+      const services = await getServicesHealth();
+      res.status(200).json({ services });
+    } catch (e) {
+      logger.error('Failed to get service health', {
+        label: 'Health Check',
+        message: e instanceof Error ? e.message : String(e),
+      });
+      next({ status: 500, message: 'Failed to get service health.' });
+    }
+  }
+);
+
+settingsRoutes.post<unknown, ServiceHealthResponse, { id?: string }>(
+  '/health/retry',
+  async (req, res, next) => {
+    const { id } = req.body;
+
+    if (typeof id !== 'string' || id.trim().length === 0) {
+      return next({ status: 400, message: 'A service id is required.' });
+    }
+
+    try {
+      if (id === 'plex') {
+        resetPlexHealth();
+        await revalidatePlexLibraries();
+      } else {
+        resetServiceHealthState(id);
+      }
+
+      const services = await getServicesHealth();
+      res.status(200).json({ services });
+    } catch (e) {
+      logger.error('Failed to retry service health check', {
+        label: 'Health Check',
+        serviceId: id,
+        message: e instanceof Error ? e.message : String(e),
+      });
+      next({ status: 500, message: 'Failed to retry service health check.' });
+    }
+  }
+);
 
 settingsRoutes.get('/uptime', (_req, res) => {
   const settings = getSettings();

--- a/src/components/Admin/Settings/Services/Tdarr/index.tsx
+++ b/src/components/Admin/Settings/Services/Tdarr/index.tsx
@@ -4,6 +4,7 @@ import RestartRequiredAlert, {
 } from '@app/components/Admin/Settings/RestartRequiredAlert';
 import Button from '@app/components/Common/Button';
 import LoadingEllipsis from '@app/components/Common/LoadingEllipsis';
+import SensitiveInput from '@app/components/Common/SensitiveInput';
 import Toast from '@app/components/Toast';
 import {
   ArrowDownTrayIcon,
@@ -48,12 +49,14 @@ const ServicesTdarr = () => {
           enabled: dataTdarr?.enabled ?? false,
           hostname: dataTdarr?.hostname ?? '',
           port: dataTdarr?.port ?? 8265,
+          apiKey: dataTdarr?.apiKey ?? '',
         }}
         onSubmit={async (values) => {
           try {
             await axios.post('/api/v1/settings/Tdarr', {
               hostname: values.hostname,
               port: values.port,
+              apiKey: values.apiKey,
               enabled: values.enabled,
             } as ServiceSettings);
 
@@ -174,6 +177,30 @@ const ServicesTdarr = () => {
                     touched.port &&
                     typeof errors.port === 'string' && (
                       <div className="text-error">{errors.port}</div>
+                    )}
+                </div>
+              </div>
+              <div className="grid grid-cols-1 space-y-2 sm:grid-cols-3 sm:space-y-0 sm:space-x-2">
+                <label htmlFor="apiKey" className="text-label">
+                  <FormattedMessage
+                    id="common.apiKey"
+                    defaultMessage="API Key"
+                  />
+                </label>
+                <div className="sm:col-span-2">
+                  <div className="col-span-2 flex">
+                    <SensitiveInput
+                      as="field"
+                      id="apiKey"
+                      name="apiKey"
+                      buttonSize="sm"
+                      className="input input-sm input-primary w-full"
+                    />
+                  </div>
+                  {errors.apiKey &&
+                    touched.apiKey &&
+                    typeof errors.apiKey === 'string' && (
+                      <div className="text-error">{errors.apiKey}</div>
                     )}
                 </div>
               </div>

--- a/src/components/Admin/Settings/System/ServicesHealth/index.tsx
+++ b/src/components/Admin/Settings/System/ServicesHealth/index.tsx
@@ -1,0 +1,315 @@
+'use client';
+import Badge from '@app/components/Common/Badge';
+import Button from '@app/components/Common/Button';
+import LoadingEllipsis from '@app/components/Common/LoadingEllipsis';
+import Toast from '@app/components/Toast';
+import {
+  ArrowPathIcon,
+  ChevronDownIcon,
+  ChevronRightIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/solid';
+import type {
+  ServiceHealth,
+  ServiceHealthInstance,
+  ServiceHealthResponse,
+  ServiceHealthStatus,
+} from '@server/interfaces/api/settingsInterfaces';
+import axios from 'axios';
+import { useCallback, useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import useSWR from 'swr';
+
+const StatusBadge = ({ status }: { status: ServiceHealthStatus }) => {
+  switch (status) {
+    case 'healthy':
+      return (
+        <Badge badgeType="success">
+          <FormattedMessage
+            id="system.status.healthy"
+            defaultMessage="Healthy"
+          />
+        </Badge>
+      );
+    case 'unhealthy':
+      return (
+        <Badge badgeType="error">
+          <FormattedMessage
+            id="system.status.unhealthy"
+            defaultMessage="Unhealthy"
+          />
+        </Badge>
+      );
+    case 'retrying':
+      return (
+        <Badge badgeType="warning">
+          <FormattedMessage
+            id="system.status.retrying"
+            defaultMessage="Retrying…"
+          />
+        </Badge>
+      );
+    default:
+      return (
+        <Badge badgeType="warning">
+          <FormattedMessage
+            id="system.status.unknown"
+            defaultMessage="Unknown"
+          />
+        </Badge>
+      );
+  }
+};
+
+const RetryButton = ({
+  onRetry,
+  isRetrying,
+}: {
+  onRetry: () => void;
+  isRetrying: boolean;
+}) => (
+  <Button
+    buttonType="warning"
+    buttonSize="sm"
+    onClick={onRetry}
+    disabled={isRetrying}
+    className="btn-outline"
+  >
+    <ArrowPathIcon
+      className={`mr-1 size-4 ${isRetrying ? 'animate-spin' : ''}`}
+    />
+    <FormattedMessage id="common.retry" defaultMessage="Retry" />
+  </Button>
+);
+
+const ServiceDetail = ({
+  status,
+  version,
+  detail,
+  error,
+}: {
+  status: ServiceHealthStatus;
+  version?: string;
+  detail?: string;
+  error?: string;
+}) => {
+  if ((status === 'unhealthy' || status === 'retrying') && error) {
+    return <p className="text-neutral text-sm break-all">{error}</p>;
+  }
+
+  if (version || detail) {
+    return <p className="text-neutral text-sm">{version || detail}</p>;
+  }
+
+  return null;
+};
+
+const InstanceRow = ({
+  instance,
+  onRetry,
+  isRetrying,
+}: {
+  instance: ServiceHealthInstance;
+  onRetry: () => void;
+  isRetrying: boolean;
+}) => (
+  <div className="border-base-content/10 flex flex-row items-center justify-between gap-3 border-t px-4 py-2 pl-14">
+    <div>
+      <h5 className="flex gap-2 font-semibold">
+        {instance.name}{' '}
+        <span>
+          <StatusBadge status={instance.status} />
+        </span>
+      </h5>
+      <ServiceDetail
+        status={instance.status}
+        version={instance.version}
+        detail={instance.detail}
+        error={instance.error}
+      />
+    </div>
+    <RetryButton onRetry={onRetry} isRetrying={isRetrying} />
+  </div>
+);
+
+const ServiceCard = ({
+  service,
+  onRetry,
+  retryingId,
+}: {
+  service: ServiceHealth;
+  onRetry: (id: string) => void;
+  retryingId: string | null;
+}) => {
+  const intl = useIntl();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const hasMultipleInstances =
+    !!service.instances && service.instances.length > 1;
+
+  // Single-instance multi-capable services render flat using their one child.
+  const singleInstance =
+    service.instances && service.instances.length === 1
+      ? service.instances[0]
+      : undefined;
+  const version = singleInstance?.version ?? service.version;
+  const error = singleInstance?.error ?? service.error;
+  const detail = singleInstance?.detail ?? service.detail;
+
+  if (hasMultipleInstances && service.instances) {
+    const healthyCount = service.instances.filter(
+      (i) => i.status === 'healthy'
+    ).length;
+
+    return (
+      <div className="border-base-content/10 bg-base-200/50 rounded-lg border">
+        <div className="flex flex-row items-center justify-between gap-4 px-4 py-2">
+          <div className="flex items-start gap-2">
+            <button
+              type="button"
+              className="text-neutral hover:text-base-content mt-1 rounded p-0.5 transition hover:cursor-pointer"
+              onClick={() => setIsExpanded((prev) => !prev)}
+              aria-expanded={isExpanded}
+              aria-label={
+                isExpanded
+                  ? intl.formatMessage({
+                      id: 'system.health.collapseInstances',
+                      defaultMessage: 'Hide instances',
+                    })
+                  : intl.formatMessage({
+                      id: 'system.health.expandInstances',
+                      defaultMessage: 'Show instances',
+                    })
+              }
+            >
+              {isExpanded ? (
+                <ChevronDownIcon className="size-4" />
+              ) : (
+                <ChevronRightIcon className="size-4" />
+              )}
+            </button>
+            <div>
+              <h4 className="flex gap-2 text-lg font-bold">
+                {service.name}
+                <span>
+                  <StatusBadge status={service.status} />
+                </span>
+              </h4>
+              <p className="text-neutral text-sm">
+                <FormattedMessage
+                  id="system.health.instanceSummary"
+                  defaultMessage="{healthy} of {total} healthy"
+                  values={{
+                    healthy: healthyCount,
+                    total: service.instances.length,
+                  }}
+                />
+              </p>
+            </div>
+          </div>
+          {service.retryable && !isExpanded && (
+            <RetryButton
+              onRetry={() => onRetry(service.id)}
+              isRetrying={retryingId === service.id}
+            />
+          )}
+        </div>
+        {isExpanded &&
+          service.instances.map((instance) => (
+            <InstanceRow
+              key={instance.id}
+              instance={instance}
+              onRetry={() => onRetry(instance.id)}
+              isRetrying={retryingId === instance.id}
+            />
+          ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-base-content/10 bg-base-200/50 hover:bg-base-200/30 rounded-lg border px-4 py-2">
+      <div className="flex flex-row items-center justify-between gap-4">
+        <div>
+          <h4 className="flex gap-2 text-lg font-bold">
+            {service.name}
+            <span>
+              <StatusBadge status={service.status} />
+            </span>
+          </h4>
+          <ServiceDetail
+            status={service.status}
+            version={version}
+            detail={detail}
+            error={error}
+          />
+        </div>
+        {service.retryable && (
+          <RetryButton
+            onRetry={() => onRetry(service.id)}
+            isRetrying={retryingId === service.id}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+const ServicesHealth = () => {
+  const intl = useIntl();
+  const { data, mutate, isLoading } = useSWR<ServiceHealthResponse>(
+    '/api/v1/settings/health',
+    { revalidateOnFocus: true }
+  );
+
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+
+  const handleRetry = useCallback(
+    async (id: string) => {
+      setRetryingId(id);
+      try {
+        const res = await axios.post<ServiceHealthResponse>(
+          '/api/v1/settings/health/retry',
+          { id }
+        );
+        await mutate(res.data, { revalidate: false });
+      } catch (e) {
+        Toast({
+          title: intl.formatMessage({
+            id: 'system.health.retryFailed',
+            defaultMessage: 'Failed to retry service health check.',
+          }),
+          type: 'error',
+          icon: <XCircleIcon className="size-7" />,
+          message: e.response?.data?.message || e.message,
+        });
+      } finally {
+        setRetryingId(null);
+      }
+    },
+    [intl, mutate]
+  );
+
+  if (isLoading) {
+    return <LoadingEllipsis />;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return (
+    <>
+      {data.services.map((service) => (
+        <ServiceCard
+          key={service.id}
+          service={service}
+          onRetry={handleRetry}
+          retryingId={retryingId}
+        />
+      ))}
+    </>
+  );
+};
+
+export default ServicesHealth;

--- a/src/components/Admin/Settings/System/index.tsx
+++ b/src/components/Admin/Settings/System/index.tsx
@@ -3,6 +3,7 @@ import Error from '@app/app/error';
 import { RESTART_REQUIRED_SWR_KEY } from '@app/components/Admin/Settings/RestartRequiredAlert';
 import DiskSpace from '@app/components/Admin/Settings/System/DiskSpace';
 import Releases from '@app/components/Admin/Settings/System/Releases';
+import ServicesHealth from '@app/components/Admin/Settings/System/ServicesHealth';
 import Alert from '@app/components/Common/Alert';
 import Badge from '@app/components/Common/Badge';
 import Button from '@app/components/Common/Button';
@@ -129,6 +130,7 @@ const SystemSettings = () => {
           isRestarting={isRestartingServer || isReconnecting}
           onRestart={handleRestartServer}
         />
+        <ServicesHealth />
       </div>
       <DiskSpace data={data} />
       <div className="mt-6">

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -5570,6 +5570,18 @@
   "sonarrSettings.title": {
     "defaultMessage": "Sonarr Settings"
   },
+  "system.health.collapseInstances": {
+    "defaultMessage": "Hide instances"
+  },
+  "system.health.expandInstances": {
+    "defaultMessage": "Show instances"
+  },
+  "system.health.instanceSummary": {
+    "defaultMessage": "{healthy} of {total} healthy"
+  },
+  "system.health.retryFailed": {
+    "defaultMessage": "Failed to retry service health check."
+  },
   "system.health.title": {
     "defaultMessage": "Health"
   },
@@ -5593,6 +5605,9 @@
   },
   "system.status.healthy": {
     "defaultMessage": "Healthy"
+  },
+  "system.status.retrying": {
+    "defaultMessage": "Retrying…"
   },
   "system.status.unhealthy": {
     "defaultMessage": "Unhealthy"

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -72,6 +72,76 @@ components:
         consecutiveFailures:
           type: number
           example: 0
+    ServiceHealthInstance:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Unique instance identifier
+          example: 'radarr-1'
+        name:
+          type: string
+          description: Display name of the instance
+          example: 'Radarr (4K)'
+        status:
+          type: string
+          enum: [healthy, retrying, unhealthy, unknown]
+          example: 'healthy'
+        version:
+          type: string
+          nullable: true
+          description: Reported service version, when available
+        detail:
+          type: string
+          nullable: true
+          description: Additional health detail shown when a version is not available
+        error:
+          type: string
+          nullable: true
+          description: Error message from the most recent failed check
+    ServiceHealth:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Service identifier
+          example: 'radarr'
+        name:
+          type: string
+          description: Display name of the service
+          example: 'Radarr'
+        status:
+          type: string
+          enum: [healthy, retrying, unhealthy, unknown]
+          example: 'healthy'
+        version:
+          type: string
+          nullable: true
+          description: Reported service version, when available
+        detail:
+          type: string
+          nullable: true
+          description: Additional health detail shown when a version is not available
+        error:
+          type: string
+          nullable: true
+          description: Error message from the most recent failed check
+        retryable:
+          type: boolean
+          description: Whether the service supports a manual retry
+          example: true
+        instances:
+          type: array
+          description: Present for multi-instance services (Radarr, Sonarr, download clients)
+          items:
+            $ref: '#/components/schemas/ServiceHealthInstance'
+    ServiceHealthResponse:
+      type: object
+      properties:
+        services:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceHealth'
     CalendarEvent:
       type: object
       properties:
@@ -3214,6 +3284,59 @@ paths:
                           type: string
                           description: Service identifier
                           example: 'bazarr'
+  /settings/health:
+    get:
+      summary: Get service health
+      description: Returns the health of all enabled and configured services. Plex reflects its existing in-memory health state; all other services are actively probed using their saved configuration.
+      tags:
+        - settings
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceHealthResponse'
+        '401':
+          description: Unauthorized - user not authenticated
+        '403':
+          description: Forbidden - insufficient permissions
+        '500':
+          description: Failed to compute service health
+  /settings/health/retry:
+    post:
+      summary: Retry a service health check
+      description: Resets any passive health state for the identified service and recomputes the full health report. Accepts a service or instance identifier (e.g. `plex`, `radarr`, `radarr-1`, `downloads`, `downloads-2`).
+      tags:
+        - settings
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                id:
+                  type: string
+                  description: Service or instance identifier to retry
+                  example: 'radarr-1'
+              required:
+                - id
+      responses:
+        '200':
+          description: Recomputed service health report
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ServiceHealthResponse'
+        '400':
+          description: A service id is required
+        '401':
+          description: Unauthorized - user not authenticated
+        '403':
+          description: Forbidden - insufficient permissions
+        '500':
+          description: Failed to retry service health check
   /settings/uptime:
     get:
       summary: Get Uptime settings


### PR DESCRIPTION
## Description
The system Health section previously reported only the Streamarr process. This extends it to report the health of every enabled and configured service, shown as a card per service beneath the existing Streamarr card.

- Closes #510

## Has This Been Tested?

- [x] Health tab lists every enabled service with correct status on first load
- [x] Plex and each download client display a version; Cleanuparr shows "Monitoring N services"
- [x] Stopping a service flips it to unhealthy with an error line; Retry recovers it
- [x] Multi-instance Radarr/Sonarr/downloads collapse into a parent with correct aggregation and per-instance retries
- [x] Disabled services do not appear

## Screenshots (if applicable)
<img width="823" height="874" alt="image" src="https://github.com/user-attachments/assets/c0e390a1-acf2-4062-81ac-eb2837510610" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
