### PR TITLE
feat(newsletters): retry when external services are unreachable, then abort

### DIFF
--- a/docs/using-streamarr/newsletters/README.md
+++ b/docs/using-streamarr/newsletters/README.md
@@ -19,7 +19,7 @@ Content blocks pull from your connected services, each of which is optional:
 | By Tag (Plex)    | Plex labels          | Labeled items in a Plex library          |
 | By Tag (Servarr) | Radarr / Sonarr tags | A configured Radarr and/or Sonarr server |
 
-A newsletter with no available source simply omits that block.
+A newsletter with no available source simply omits that block. A block that resolves to no items is dropped entirely — including its heading — so an empty block never appears. If **every** configured block resolves empty, the newsletter is not sent (there is nothing to deliver); see [When a content source is unreachable](#when-a-content-source-is-unreachable). A plain newsletter with no content blocks configured always sends.
 
 ---
 
@@ -107,6 +107,12 @@ To prevent accidental spam, a schedule may run **at most once per hour**; anythi
 
 > If the server is offline when a one-time newsletter was due, it is skipped and automatically disabled the next time the server starts.
 
+### When a content source is unreachable
+
+If a scheduled newsletter cannot gather one of its content blocks because a service (Plex, Tautulli, or an \*Arr app) is unreachable, Streamarr does **not** send a half-empty email. It retries after a short delay and, if the source is still unavailable after the configured number of attempts, **aborts** the send — nothing is delivered, the failure is logged, and the run is recorded in the newsletter's [history](#history). One-time newsletters are disabled after an abort.
+
+A block that is simply empty (no matching items) is not a failure — it is dropped and the rest of the newsletter still goes out. This is distinct from a failure: retries only apply to unreachable services, whereas an empty result is not retried. If every configured block is empty, the scheduled run is skipped (logged, not recorded in history, and not retried); a manual **Send Now** or **Test** in the same state reports that there is nothing to send. The number of retry attempts and the delay between them are configured under [Settings → Network](../settings/README.md#scheduled-retry-interval).
+
 ---
 
 ## Preview, test, and send
@@ -122,6 +128,8 @@ A newsletter cannot be sent again while a send is already in progress.
 ## History
 
 Each newsletter keeps a paginated history of its sends, showing the date, what triggered it (manual, scheduled, or test), the recipient count, and the number of failures. Open it from the **History** action on the newsletter list.
+
+An **aborted** scheduled send (see [When a content source is unreachable](#when-a-content-source-is-unreachable)) is recorded here too, with every intended recipient counted as a failure so the undelivered run stands out.
 
 ---
 

--- a/docs/using-streamarr/settings/README.md
+++ b/docs/using-streamarr/settings/README.md
@@ -199,6 +199,26 @@ The maximum time, in seconds, that Streamarr will wait for a response from an ex
 
 Increase this value if you connect to slow or remote services that occasionally time out; lower it if you would rather fail fast when a service is unresponsive.
 
+### Scheduled Retry Attempts
+
+The number of times a scheduled task that pulls data from external services (such as Plex, Tautulli, or the \*Arr apps) retries before giving up.
+
+- Must be a whole number.
+- Minimum: **1** (retries disabled — the task runs once). Maximum: **10**.
+
+When an external service is unreachable, Streamarr does not act on incomplete data. It waits the retry interval below and tries again, up to this many total attempts. If every attempt fails, the task is **aborted** and the failure is logged. Data that is simply empty (for example, no matching items) is **not** treated as a failure and does not trigger a retry.
+
+> Only scheduled tasks retry. On-demand actions — such as a manual newsletter **Send Now** — fail immediately so you can fix the problem and try again.
+
+Scheduled newsletters are the first feature to use these settings; see [Newsletters → When a content source is unreachable](../newsletters/README.md#when-a-content-source-is-unreachable) for how an aborted send behaves.
+
+### Scheduled Retry Interval
+
+The time, in seconds, Streamarr waits between the scheduled retry attempts described above.
+
+- Must be a whole number of seconds.
+- Minimum: **30 seconds**. Maximum: **3600 seconds** (1 hour).
+
 ---
 
 ## API Reference

--- a/server/lib/migrations/0001-NetworkSettings.ts
+++ b/server/lib/migrations/0001-NetworkSettings.ts
@@ -18,6 +18,8 @@ const migrateNetworkProxyCsrf = (
     requestTimeout: 10000,
     trustProxy: settings.main.trustProxy ?? false,
     csrfProtection: settings.main.csrfProtection ?? false,
+    scheduledRetryAttempts: 3,
+    scheduledRetryInterval: 300000,
   };
 
   delete settings.main.trustProxy;

--- a/server/lib/newsletters/dataProviders.ts
+++ b/server/lib/newsletters/dataProviders.ts
@@ -37,6 +37,18 @@ export interface NewsletterBlockData {
   byTag: NewsletterMediaItem[];
 }
 
+export interface NewsletterDataFailure {
+  block: 'recentlyAdded' | 'topStreams' | 'byTag';
+  source: string;
+  mediaType?: NewsletterMediaType;
+  error: string;
+}
+
+export interface NewsletterBlockDataResult {
+  data: NewsletterBlockData;
+  failures: NewsletterDataFailure[];
+}
+
 const MAX_BLOCK_ITEMS = 24;
 const DEFAULT_DAYS = 7;
 const DEFAULT_COUNT = 6;
@@ -287,15 +299,19 @@ const collectRecentlyAddedForType = async (
 
 const getRecentlyAdded = async (
   config: NonNullable<NewsletterBlockConfig['recentlyAdded']>
-): Promise<NewsletterRecentlyAddedSection[]> => {
+): Promise<{
+  sections: NewsletterRecentlyAddedSection[];
+  failures: NewsletterDataFailure[];
+}> => {
+  const sections: NewsletterRecentlyAddedSection[] = [];
+  const failures: NewsletterDataFailure[] = [];
+
   try {
     const plexClient = await getPlexClient();
 
     if (!plexClient) {
-      return [];
+      return { sections, failures };
     }
-
-    const sections: NewsletterRecentlyAddedSection[] = [];
 
     for (const type of RECENTLY_ADDED_TYPES) {
       const typeConfig = config[type];
@@ -315,24 +331,37 @@ const getRecentlyAdded = async (
           sections.push({ type, items });
         }
       } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        failures.push({
+          block: 'recentlyAdded',
+          source: 'plex',
+          mediaType: type,
+          error: errorMessage,
+        });
         logger.warn(
           'Failed to gather a recently added section for newsletter',
           {
             label: 'Newsletters',
             mediaType: type,
-            errorMessage: e instanceof Error ? e.message : String(e),
+            errorMessage,
           }
         );
       }
     }
 
-    return sections;
+    return { sections, failures };
   } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    failures.push({
+      block: 'recentlyAdded',
+      source: 'plex',
+      error: errorMessage,
+    });
     logger.warn('Failed to gather recently added items for newsletter', {
       label: 'Newsletters',
-      errorMessage: e instanceof Error ? e.message : String(e),
+      errorMessage,
     });
-    return [];
+    return { sections, failures };
   }
 };
 
@@ -422,7 +451,13 @@ const collectTopStreamsForType = async (
 
 const getTopStreams = async (
   config: NonNullable<NewsletterBlockConfig['topStreams']>
-): Promise<NewsletterRecentlyAddedSection[]> => {
+): Promise<{
+  sections: NewsletterRecentlyAddedSection[];
+  failures: NewsletterDataFailure[];
+}> => {
+  const sections: NewsletterRecentlyAddedSection[] = [];
+  const failures: NewsletterDataFailure[] = [];
+
   try {
     const settings = getSettings();
 
@@ -431,13 +466,11 @@ const getTopStreams = async (
         'Tautulli is not configured; skipping top streams newsletter block',
         { label: 'Newsletters' }
       );
-      return [];
+      return { sections, failures };
     }
 
     const tautulli = new TautulliAPI(settings.tautulli);
     const plexClient = await getPlexClient();
-
-    const sections: NewsletterRecentlyAddedSection[] = [];
 
     for (const type of TOP_STREAMS_TYPES) {
       const typeConfig = config[type];
@@ -458,28 +491,45 @@ const getTopStreams = async (
           sections.push({ type, items });
         }
       } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        failures.push({
+          block: 'topStreams',
+          source: 'tautulli',
+          mediaType: type,
+          error: errorMessage,
+        });
         logger.warn('Failed to gather a top streams section for newsletter', {
           label: 'Newsletters',
           mediaType: type,
-          errorMessage: e instanceof Error ? e.message : String(e),
+          errorMessage,
         });
       }
     }
 
-    return sections;
+    return { sections, failures };
   } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    failures.push({
+      block: 'topStreams',
+      source: 'tautulli',
+      error: errorMessage,
+    });
     logger.warn('Failed to gather top streams for newsletter', {
       label: 'Newsletters',
-      errorMessage: e instanceof Error ? e.message : String(e),
+      errorMessage,
     });
-    return [];
+    return { sections, failures };
   }
 };
 
 const getByTag = async (
   config: NonNullable<NewsletterBlockConfig['byTag']>
-): Promise<NewsletterMediaItem[]> => {
+): Promise<{
+  items: NewsletterMediaItem[];
+  failures: NewsletterDataFailure[];
+}> => {
   const items: NewsletterMediaItem[] = [];
+  const failures: NewsletterDataFailure[] = [];
   const seen = new Set<string>();
 
   const pushUnique = (item: NewsletterMediaItem) => {
@@ -537,11 +587,13 @@ const getByTag = async (
         }
       }
     } catch (e) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      failures.push({ block: 'byTag', source: 'plex', error: errorMessage });
       logger.warn(
         'Failed to gather Plex labeled items for by tag newsletter block',
         {
           label: 'Newsletters',
-          errorMessage: e instanceof Error ? e.message : String(e),
+          errorMessage,
         }
       );
     }
@@ -586,12 +638,18 @@ const getByTag = async (
 
         resolved.forEach(pushUnique);
       } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        failures.push({
+          block: 'byTag',
+          source: `radarr:${radarrSettings.name}`,
+          error: errorMessage,
+        });
         logger.warn(
           'Failed to gather Radarr tagged movies for by tag newsletter block',
           {
             label: 'Newsletters',
             server: radarrSettings.name,
-            errorMessage: e instanceof Error ? e.message : String(e),
+            errorMessage,
           }
         );
       }
@@ -650,42 +708,86 @@ const getByTag = async (
 
         resolved.forEach(pushUnique);
       } catch (e) {
+        const errorMessage = e instanceof Error ? e.message : String(e);
+        failures.push({
+          block: 'byTag',
+          source: `sonarr:${sonarrSettings.name}`,
+          error: errorMessage,
+        });
         logger.warn(
           'Failed to gather Sonarr tagged series for by tag newsletter block',
           {
             label: 'Newsletters',
             server: sonarrSettings.name,
-            errorMessage: e instanceof Error ? e.message : String(e),
+            errorMessage,
           }
         );
       }
     }
   }
 
-  return items.slice(0, count);
+  return { items: items.slice(0, count), failures };
+};
+
+export type NewsletterBlockKey = 'recentlyAdded' | 'topStreams' | 'byTag';
+
+export const getConfiguredBlocks = (
+  blocks: NewsletterBlockConfig | null | undefined
+): NewsletterBlockKey[] => {
+  const configured: NewsletterBlockKey[] = [];
+
+  if (
+    RECENTLY_ADDED_TYPES.some((type) => blocks?.recentlyAdded?.[type]?.enabled)
+  ) {
+    configured.push('recentlyAdded');
+  }
+
+  if (TOP_STREAMS_TYPES.some((type) => blocks?.topStreams?.[type]?.enabled)) {
+    configured.push('topStreams');
+  }
+
+  if (blocks?.byTag?.plex?.enabled || blocks?.byTag?.servarr?.enabled) {
+    configured.push('byTag');
+  }
+
+  return configured;
 };
 
 export const resolveBlockData = async (
   blocks: NewsletterBlockConfig | null | undefined
-): Promise<NewsletterBlockData> => {
-  const hasRecentlyAdded = RECENTLY_ADDED_TYPES.some(
-    (type) => blocks?.recentlyAdded?.[type]?.enabled
-  );
-  const hasTopStreams = TOP_STREAMS_TYPES.some(
-    (type) => blocks?.topStreams?.[type]?.enabled
-  );
+): Promise<NewsletterBlockDataResult> => {
+  const configured = new Set(getConfiguredBlocks(blocks));
+
+  const emptySections = {
+    sections: [] as NewsletterRecentlyAddedSection[],
+    failures: [] as NewsletterDataFailure[],
+  };
 
   const [recentlyAdded, topStreams, byTag] = await Promise.all([
-    hasRecentlyAdded && blocks?.recentlyAdded
+    configured.has('recentlyAdded') && blocks?.recentlyAdded
       ? getRecentlyAdded(blocks.recentlyAdded)
-      : Promise.resolve([] as NewsletterRecentlyAddedSection[]),
-    hasTopStreams && blocks?.topStreams
+      : Promise.resolve(emptySections),
+    configured.has('topStreams') && blocks?.topStreams
       ? getTopStreams(blocks.topStreams)
-      : Promise.resolve([] as NewsletterRecentlyAddedSection[]),
-    blocks?.byTag?.plex?.enabled || blocks?.byTag?.servarr?.enabled
+      : Promise.resolve(emptySections),
+    configured.has('byTag') && blocks?.byTag
       ? getByTag(blocks.byTag)
-      : Promise.resolve([] as NewsletterMediaItem[]),
+      : Promise.resolve({
+          items: [] as NewsletterMediaItem[],
+          failures: [] as NewsletterDataFailure[],
+        }),
   ]);
 
-  return { recentlyAdded, topStreams, byTag };
+  return {
+    data: {
+      recentlyAdded: recentlyAdded.sections,
+      topStreams: topStreams.sections,
+      byTag: byTag.items,
+    },
+    failures: [
+      ...recentlyAdded.failures,
+      ...topStreams.failures,
+      ...byTag.failures,
+    ],
+  };
 };

--- a/server/lib/newsletters/render.ts
+++ b/server/lib/newsletters/render.ts
@@ -264,7 +264,7 @@ export const renderNewsletter = async (
     : undefined;
 
   const blockData =
-    providedBlockData ?? (await resolveBlockData(newsletter.blocks));
+    providedBlockData ?? (await resolveBlockData(newsletter.blocks)).data;
 
   let body = newsletter.body ?? '';
 

--- a/server/lib/newsletters/scheduler.ts
+++ b/server/lib/newsletters/scheduler.ts
@@ -1,8 +1,17 @@
 import { getRepository } from '@server/datasource';
 import Newsletter from '@server/entity/Newsletter';
+import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import schedule from 'node-schedule';
-import { sendNewsletter } from './send';
+import {
+  NewsletterDataUnavailableError,
+  NewsletterEmptyError,
+  recordNewsletterAbort,
+  sendNewsletter,
+} from './send';
+
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_RETRY_INTERVAL_MS = 5 * 60 * 1000;
 
 /**
  * Manages dynamic node-schedule jobs keyed by newsletter id, unlike the
@@ -12,6 +21,13 @@ import { sendNewsletter } from './send';
  */
 class NewsletterScheduler {
   private jobs = new Map<number, schedule.Job>();
+
+  // Tracks in-flight retry attempts for scheduled sends whose content sources
+  // were unreachable, keyed by newsletter id.
+  private retries = new Map<
+    number,
+    { attempts: number; timer: NodeJS.Timeout | null }
+  >();
 
   public async loadAll(): Promise<void> {
     try {
@@ -70,22 +86,54 @@ class NewsletterScheduler {
         name: newsletter.name,
       });
 
+      let fresh: Newsletter | null = null;
+
       try {
         // Re-fetch so edits made after scheduling are respected.
-        const fresh = await getRepository(Newsletter).findOne({
+        fresh = await getRepository(Newsletter).findOne({
           where: { id: newsletter.id },
         });
 
+        const pending = this.retries.get(newsletter.id);
+        if (pending?.timer) {
+          clearTimeout(pending.timer);
+          pending.timer = null;
+        }
+
         if (!fresh || !fresh.enabled) {
+          this.retries.delete(newsletter.id);
           return;
         }
 
         await sendNewsletter(fresh, 'schedule');
+        this.retries.delete(fresh.id);
 
         if (fresh.scheduleType === 'once') {
           this.cancel(fresh.id);
         }
       } catch (e) {
+        if (e instanceof NewsletterDataUnavailableError) {
+          await this.handleDataUnavailable(fresh ?? newsletter, e, run);
+          return;
+        }
+
+        if (e instanceof NewsletterEmptyError) {
+          this.retries.delete(newsletter.id);
+
+          logger.warn(
+            'Scheduled newsletter skipped; all configured content blocks were empty',
+            {
+              label: 'Newsletters',
+              newsletterId: newsletter.id,
+              name: newsletter.name,
+              blocks: e.blocks,
+            }
+          );
+
+          await this.disableOnceNewsletter(fresh ?? newsletter);
+          return;
+        }
+
         logger.error('Scheduled newsletter send failed', {
           label: 'Newsletters',
           newsletterId: newsletter.id,
@@ -130,6 +178,100 @@ class NewsletterScheduler {
       existing.cancel();
       this.jobs.delete(id);
     }
+
+    const retry = this.retries.get(id);
+
+    if (retry?.timer) {
+      clearTimeout(retry.timer);
+    }
+
+    this.retries.delete(id);
+  }
+
+  private async handleDataUnavailable(
+    newsletter: Newsletter,
+    error: NewsletterDataUnavailableError,
+    run: () => Promise<void>
+  ): Promise<void> {
+    const { network } = getSettings();
+    const maxAttempts = Math.max(
+      1,
+      network.scheduledRetryAttempts ?? DEFAULT_RETRY_ATTEMPTS
+    );
+    const intervalMs = Math.max(
+      0,
+      network.scheduledRetryInterval ?? DEFAULT_RETRY_INTERVAL_MS
+    );
+
+    const state = this.retries.get(newsletter.id) ?? {
+      attempts: 0,
+      timer: null,
+    };
+    state.attempts += 1;
+
+    if (state.attempts < maxAttempts) {
+      logger.warn(
+        `External services unavailable on attempt ${state.attempts} of ${maxAttempts}, retrying in ${intervalMs}ms`,
+        {
+          label: 'Newsletters',
+          newsletterId: newsletter.id,
+          name: newsletter.name,
+          attempt: state.attempts,
+          maxAttempts,
+          retryInMs: intervalMs,
+          failures: error.failures.map((failure) => failure.source),
+        }
+      );
+
+      state.timer = setTimeout(() => void run(), intervalMs);
+      this.retries.set(newsletter.id, state);
+      return;
+    }
+
+    this.retries.delete(newsletter.id);
+
+    try {
+      await recordNewsletterAbort(newsletter, error.failures);
+    } catch (e) {
+      logger.error('Failed to record aborted newsletter', {
+        label: 'Newsletters',
+        newsletterId: newsletter.id,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    await this.disableOnceNewsletter(newsletter);
+  }
+
+  /**
+   * Disables and unschedules a one-time newsletter after it has been aborted or
+   * skipped. Recurring newsletters are left untouched so they run again on
+   * their next cron tick. No-op for recurring schedules.
+   */
+  private async disableOnceNewsletter(newsletter: Newsletter): Promise<void> {
+    if (newsletter.scheduleType !== 'once') {
+      return;
+    }
+
+    try {
+      const newsletterRepository = getRepository(Newsletter);
+      const current = await newsletterRepository.findOne({
+        where: { id: newsletter.id },
+      });
+
+      if (current) {
+        current.enabled = false;
+        await newsletterRepository.save(current);
+      }
+    } catch (e) {
+      logger.error('Failed to disable one-time newsletter after abort', {
+        label: 'Newsletters',
+        newsletterId: newsletter.id,
+        errorMessage: e instanceof Error ? e.message : String(e),
+      });
+    }
+
+    this.cancel(newsletter.id);
   }
 
   public nextRun(id: number): Date | null {

--- a/server/lib/newsletters/send.ts
+++ b/server/lib/newsletters/send.ts
@@ -10,7 +10,8 @@ import logger from '@server/logger';
 import path from 'path';
 import { In } from 'typeorm';
 import validator from 'validator';
-import { resolveBlockData } from './dataProviders';
+import type { NewsletterDataFailure } from './dataProviders';
+import { getConfiguredBlocks, resolveBlockData } from './dataProviders';
 import type { RenderedNewsletter } from './render';
 import {
   getNewsletterEmailStrings,
@@ -22,6 +23,96 @@ const runningNewsletters = new Set<number>();
 
 export const isNewsletterSending = (id: number): boolean =>
   runningNewsletters.has(id);
+
+export class NewsletterDataUnavailableError extends Error {
+  public readonly failures: NewsletterDataFailure[];
+
+  constructor(failures: NewsletterDataFailure[]) {
+    super(
+      'One or more external services are unavailable. The newsletter was not sent.'
+    );
+    this.name = 'NewsletterDataUnavailableError';
+    this.failures = failures;
+  }
+}
+
+export class NewsletterEmptyError extends Error {
+  public readonly blocks: string[];
+
+  constructor(blocks: string[]) {
+    super('There is no content to send — all configured blocks are empty.');
+    this.name = 'NewsletterEmptyError';
+    this.blocks = blocks;
+  }
+}
+
+/**
+ * Resolves a newsletter's recipient list: active users, honouring custom
+ * selection and per-user un-subscription for non-important newsletters, filtered
+ * to those with a valid email address.
+ */
+const resolveNewsletterRecipients = async (
+  newsletter: Newsletter
+): Promise<User[]> => {
+  const userRepository = getRepository(User);
+
+  let recipients =
+    newsletter.recipientMode === 'custom'
+      ? await userRepository.find({
+          where: { id: In(newsletter.recipientIds ?? []), active: true },
+          relations: ['settings'],
+        })
+      : await userRepository.find({
+          where: { active: true },
+          relations: ['settings'],
+        });
+
+  if (!newsletter.isImportant) {
+    recipients = recipients.filter(
+      (user) =>
+        !(user.settings?.unsubscribedNewsletters ?? []).includes(newsletter.id)
+    );
+  }
+
+  return recipients.filter((user) =>
+    validator.isEmail(user.email, { require_tld: false })
+  );
+};
+
+export const recordNewsletterAbort = async (
+  newsletter: Newsletter,
+  failures: NewsletterDataFailure[]
+): Promise<{ recipientCount: number }> => {
+  const recipients = await resolveNewsletterRecipients(newsletter);
+  const recipientCount = recipients.length;
+
+  await getRepository(NewsletterHistory).save(
+    new NewsletterHistory({
+      newsletter,
+      triggeredBy: 'schedule',
+      recipientCount,
+      failureCount: recipientCount,
+    })
+  );
+
+  logger.error(
+    'Newsletter was aborted because external services were unavailable',
+    {
+      label: 'Newsletters',
+      newsletterId: newsletter.id,
+      name: newsletter.name,
+      recipientCount,
+      failures: failures.map((failure) => ({
+        block: failure.block,
+        source: failure.source,
+        mediaType: failure.mediaType,
+        error: failure.error,
+      })),
+    }
+  );
+
+  return { recipientCount };
+};
 
 /**
  * Sends a newsletter to its resolved recipients using PreparedEmail
@@ -56,39 +147,30 @@ export const sendNewsletter = async (
   runningNewsletters.add(newsletter.id);
 
   try {
-    let recipients: User[];
+    const recipients: User[] =
+      triggeredBy === 'test' && options.testUser
+        ? [options.testUser].filter((user) =>
+            validator.isEmail(user.email, { require_tld: false })
+          )
+        : await resolveNewsletterRecipients(newsletter);
 
-    if (triggeredBy === 'test' && options.testUser) {
-      recipients = [options.testUser];
-    } else {
-      const userRepository = getRepository(User);
-
-      recipients =
-        newsletter.recipientMode === 'custom'
-          ? await userRepository.find({
-              where: { id: In(newsletter.recipientIds ?? []), active: true },
-              relations: ['settings'],
-            })
-          : await userRepository.find({
-              where: { active: true },
-              relations: ['settings'],
-            });
-
-      if (!newsletter.isImportant) {
-        recipients = recipients.filter(
-          (user) =>
-            !(user.settings?.unsubscribedNewsletters ?? []).includes(
-              newsletter.id
-            )
-        );
-      }
-    }
-
-    recipients = recipients.filter((user) =>
-      validator.isEmail(user.email, { require_tld: false })
+    const { data: blockData, failures } = await resolveBlockData(
+      newsletter.blocks
     );
 
-    const blockData = await resolveBlockData(newsletter.blocks);
+    if (failures.length > 0) {
+      throw new NewsletterDataUnavailableError(failures);
+    }
+
+    const configuredBlocks = getConfiguredBlocks(newsletter.blocks);
+
+    if (
+      configuredBlocks.length > 0 &&
+      configuredBlocks.every((block) => blockData[block].length === 0)
+    ) {
+      throw new NewsletterEmptyError(configuredBlocks);
+    }
+
     const { applicationUrl, applicationTitle, customLogo } = settings.main;
     const logoUrl = customLogo || '/logo_full.png';
 

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -63,6 +63,8 @@ export interface NetworkSettings {
   requestTimeout: number;
   trustProxy: boolean;
   csrfProtection: boolean;
+  scheduledRetryAttempts: number;
+  scheduledRetryInterval: number;
 }
 
 export interface DVRSettings {
@@ -471,6 +473,8 @@ class Settings {
         requestTimeout: 10000,
         trustProxy: false,
         csrfProtection: false,
+        scheduledRetryAttempts: 3,
+        scheduledRetryInterval: 300000,
       },
       tautulli: {
         enabled: false,

--- a/server/routes/settings/newsletter.ts
+++ b/server/routes/settings/newsletter.ts
@@ -21,6 +21,8 @@ import {
 import newsletterScheduler from '@server/lib/newsletters/scheduler';
 import {
   isNewsletterSending,
+  NewsletterDataUnavailableError,
+  NewsletterEmptyError,
   sendNewsletter,
 } from '@server/lib/newsletters/send';
 import {
@@ -77,7 +79,7 @@ const resolvePreviewBlockData = async (
     return cached.data;
   }
 
-  const data = await resolveBlockData(newsletter.blocks);
+  const { data } = await resolveBlockData(newsletter.blocks);
   previewBlockDataCache.set(key, { data, expires: now + PREVIEW_CACHE_TTL });
 
   // Opportunistically drop expired entries so the map cannot grow unbounded.
@@ -459,6 +461,15 @@ newsletterRoutes.post<{ id: string }, NewsletterSendResult>(
         newsletterId: req.params.id,
         errorMessage: e instanceof Error ? e.message : String(e),
       });
+
+      if (e instanceof NewsletterDataUnavailableError) {
+        return next({ status: 503, message: e.message });
+      }
+
+      if (e instanceof NewsletterEmptyError) {
+        return next({ status: 422, message: e.message });
+      }
+
       next({
         status: 500,
         message: e instanceof Error ? e.message : 'Unable to send newsletter.',
@@ -493,6 +504,11 @@ newsletterRoutes.post<{ id: string }, NewsletterSendResult>(
         newsletterId: req.params.id,
         errorMessage: e instanceof Error ? e.message : String(e),
       });
+
+      if (e instanceof NewsletterEmptyError) {
+        return next({ status: 422, message: e.message });
+      }
+
       next({
         status: 500,
         message:

--- a/src/components/Admin/Settings/Network/index.tsx
+++ b/src/components/Admin/Settings/Network/index.tsx
@@ -63,6 +63,72 @@ const NetworkSettings = () => {
       ),
     trustProxy: Yup.boolean(),
     csrfProtection: Yup.boolean(),
+    scheduledRetryAttempts: Yup.number()
+      .typeError(
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryAttempts',
+          defaultMessage: 'You must provide a valid number of retry attempts',
+        })
+      )
+      .required(
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryAttempts',
+          defaultMessage: 'You must provide a valid number of retry attempts',
+        })
+      )
+      .integer(
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryAttemptsInteger',
+          defaultMessage: 'Retry attempts must be a whole number',
+        })
+      )
+      .min(
+        1,
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryAttemptsMin',
+          defaultMessage: 'There must be at least 1 attempt',
+        })
+      )
+      .max(
+        10,
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryAttemptsMax',
+          defaultMessage: 'Retry attempts must not exceed 10',
+        })
+      ),
+    scheduledRetryInterval: Yup.number()
+      .typeError(
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryInterval',
+          defaultMessage: 'You must provide a valid retry interval',
+        })
+      )
+      .required(
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryInterval',
+          defaultMessage: 'You must provide a valid retry interval',
+        })
+      )
+      .integer(
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryIntervalInteger',
+          defaultMessage: 'Retry interval must be a whole number of seconds',
+        })
+      )
+      .min(
+        30,
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryIntervalMin',
+          defaultMessage: 'Retry interval must be at least 30 seconds',
+        })
+      )
+      .max(
+        3600,
+        intl.formatMessage({
+          id: 'networkSettings.validation.scheduledRetryIntervalMax',
+          defaultMessage: 'Retry interval must not exceed 3600 seconds',
+        })
+      ),
   });
 
   if (!data && !error) {
@@ -93,6 +159,10 @@ const NetworkSettings = () => {
           requestTimeout: data ? data.requestTimeout / 1000 : 10,
           trustProxy: data?.trustProxy ?? false,
           csrfProtection: data?.csrfProtection ?? false,
+          scheduledRetryAttempts: data?.scheduledRetryAttempts ?? 3,
+          scheduledRetryInterval: data
+            ? data.scheduledRetryInterval / 1000
+            : 300,
         }}
         enableReinitialize
         validationSchema={NetworkSettingsSchema}
@@ -102,6 +172,9 @@ const NetworkSettings = () => {
               requestTimeout: Number(values.requestTimeout) * 1000,
               trustProxy: values.trustProxy,
               csrfProtection: values.csrfProtection,
+              scheduledRetryAttempts: Number(values.scheduledRetryAttempts),
+              scheduledRetryInterval:
+                Number(values.scheduledRetryInterval) * 1000,
             });
             revalidate();
             mutate(RESTART_REQUIRED_SWR_KEY);
@@ -227,6 +300,72 @@ const NetworkSettings = () => {
                   touched.requestTimeout &&
                   typeof errors.requestTimeout === 'string' && (
                     <div className="text-error">{errors.requestTimeout}</div>
+                  )}
+              </div>
+            </div>
+            <div className="grid grid-cols-1 space-y-2 sm:grid-cols-3 sm:space-y-0 sm:space-x-2">
+              <label htmlFor="scheduledRetryAttempts" className="col-span-1">
+                <FormattedMessage
+                  id="networkSettings.scheduledRetryAttempts"
+                  defaultMessage="Scheduled Retry Attempts"
+                />
+                <span className="text-neutral block text-sm font-light">
+                  <FormattedMessage
+                    id="networkSettings.scheduledRetryAttempts.description"
+                    defaultMessage="Maximum retry attempts to gather data from external services. (Set to 1 to disable)"
+                  />
+                </span>
+              </label>
+              <div className="col-span-2">
+                <Field
+                  id="scheduledRetryAttempts"
+                  name="scheduledRetryAttempts"
+                  type="number"
+                  inputMode="numeric"
+                  min="1"
+                  max="10"
+                  step="1"
+                  className="input input-primary input-sm w-1/6 rounded-md"
+                />
+                {errors.scheduledRetryAttempts &&
+                  touched.scheduledRetryAttempts &&
+                  typeof errors.scheduledRetryAttempts === 'string' && (
+                    <div className="text-error">
+                      {errors.scheduledRetryAttempts}
+                    </div>
+                  )}
+              </div>
+            </div>
+            <div className="grid grid-cols-1 space-y-2 sm:grid-cols-3 sm:space-y-0 sm:space-x-2">
+              <label htmlFor="scheduledRetryInterval" className="col-span-1">
+                <FormattedMessage
+                  id="networkSettings.scheduledRetryInterval"
+                  defaultMessage="Scheduled Retry Interval"
+                />
+                <span className="text-neutral block text-sm font-light">
+                  <FormattedMessage
+                    id="networkSettings.scheduledRetryInterval.description"
+                    defaultMessage="Time (in seconds) to wait between scheduled retry attempts."
+                  />
+                </span>
+              </label>
+              <div className="col-span-2">
+                <Field
+                  id="scheduledRetryInterval"
+                  name="scheduledRetryInterval"
+                  type="number"
+                  inputMode="numeric"
+                  min="30"
+                  max="3600"
+                  step="1"
+                  className="input input-primary input-sm w-1/6 rounded-md"
+                />
+                {errors.scheduledRetryInterval &&
+                  touched.scheduledRetryInterval &&
+                  typeof errors.scheduledRetryInterval === 'string' && (
+                    <div className="text-error">
+                      {errors.scheduledRetryInterval}
+                    </div>
                   )}
               </div>
             </div>

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -3863,6 +3863,18 @@
   "networkSettings.saveSuccess": {
     "defaultMessage": "Network settings saved successfully"
   },
+  "networkSettings.scheduledRetryAttempts": {
+    "defaultMessage": "Scheduled Retry Attempts"
+  },
+  "networkSettings.scheduledRetryAttempts.description": {
+    "defaultMessage": "Maximum retry attempts to gather data from external services. (Set to 1 to disable)"
+  },
+  "networkSettings.scheduledRetryInterval": {
+    "defaultMessage": "Scheduled Retry Interval"
+  },
+  "networkSettings.scheduledRetryInterval.description": {
+    "defaultMessage": "Time (in seconds) to wait between scheduled retry attempts."
+  },
   "networkSettings.title": {
     "defaultMessage": "Network Settings"
   },
@@ -3877,6 +3889,30 @@
   },
   "networkSettings.validation.requestTimeoutMin": {
     "defaultMessage": "Request timeout must be at least 1 second"
+  },
+  "networkSettings.validation.scheduledRetryAttempts": {
+    "defaultMessage": "You must provide a valid number of retry attempts"
+  },
+  "networkSettings.validation.scheduledRetryAttemptsInteger": {
+    "defaultMessage": "Retry attempts must be a whole number"
+  },
+  "networkSettings.validation.scheduledRetryAttemptsMax": {
+    "defaultMessage": "Retry attempts must not exceed 10"
+  },
+  "networkSettings.validation.scheduledRetryAttemptsMin": {
+    "defaultMessage": "There must be at least 1 attempt"
+  },
+  "networkSettings.validation.scheduledRetryInterval": {
+    "defaultMessage": "You must provide a valid retry interval"
+  },
+  "networkSettings.validation.scheduledRetryIntervalInteger": {
+    "defaultMessage": "Retry interval must be a whole number of seconds"
+  },
+  "networkSettings.validation.scheduledRetryIntervalMax": {
+    "defaultMessage": "Retry interval must not exceed 3600 seconds"
+  },
+  "networkSettings.validation.scheduledRetryIntervalMin": {
+    "defaultMessage": "Retry interval must be at least 30 seconds"
   },
   "newsletterSettings.saveError": {
     "defaultMessage": "Newsletter preferences failed to save."

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -898,6 +898,23 @@ components:
         csrfProtection:
           type: boolean
           example: false
+        scheduledRetryAttempts:
+          type: integer
+          minimum: 1
+          maximum: 10
+          description: >-
+            Total number of attempts (including the first) a scheduled task
+            makes to gather its data from external services before aborting.
+            A value of 1 disables retries.
+          example: 3
+        scheduledRetryInterval:
+          type: integer
+          minimum: 30000
+          maximum: 3600000
+          description: >-
+            Delay in milliseconds between scheduled task retry attempts
+            when an external service is unreachable.
+          example: 300000
     SeerrQuotaResponse:
       type: object
       properties:
@@ -8205,8 +8222,12 @@ paths:
                 $ref: '#/components/schemas/NewsletterSendResult'
         '409':
           description: The newsletter is already being sent
+        '422':
+          description: All configured content blocks are empty; nothing to send
         '500':
           description: Server error
+        '503':
+          description: One or more external services are unavailable
   /settings/newsletter/{id}/test:
     parameters:
       - name: id
@@ -8227,6 +8248,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NewsletterSendResult'
+        '422':
+          description: All configured content blocks are empty; nothing to send
         '500':
           description: Server error
   /settings/newsletter/{id}/preview:


### PR DESCRIPTION
## Description
Newsletters could send confusing, empty emails. When a content source (Plex, Tautulli, or an *Arr app) was unreachable while a scheduled send ran, the data providers swallowed the error and returned an empty result — indistinguishable from a block that legitimately had no items — so the newsletter went out anyway with missing or empty blocks (e.g. a "Box Office Top 10" arriving with nothing in it).

This PR makes the data layer distinguish a fetch failure from a legitimately empty result and adds two guards before a send:

- **Unreachable service**: a scheduled send retries after a configurable delay and, if it still cannot gather its data after a configurable number of attempts, aborts — no email is sent, the failure is logged, and the run is recorded in the newsletter's history. Manual and test sends fail fast so the admin is told immediately.

- **All blocks empty**: if every content block a newsletter has configured resolves empty (no failure, just no items), the send is skipped rather than delivering a newsletter that is just body text. Empty blocks are dropped individually (heading included), so a newsletter with a mix of populated and empty blocks still sends with only the populated ones. A plain newsletter with no content blocks configured always sends.

The retry/abort settings are intentionally generic (`scheduledRetry*` under Network settings) so they can be reused by other scheduled tasks in future; newsletters are the first consumer.

Changes

- `dataProviders.ts`: `resolveBlockData` now returns `{ data, failures }`; each provider records a failure only when a configured fetch throws (unconfigured sources and zero-item results are not failures). Added a `getConfiguredBlocks` helper.
- `send.ts`: added `NewsletterDataUnavailableError` and `NewsletterEmptyError`; a send throws the former when any source failed and the latter when all configured blocks are empty, before dispatching. Added `recordNewsletterAbort` (writes a history row with `failureCount === recipientCount`, no schema change).
- `scheduler.ts`: on `NewsletterDataUnavailableError`, retries up to `scheduledRetryAttempts` at `scheduledRetryInterval`, then aborts; on `NewsletterEmptyError`, skips immediately with no retry and no history row. One-time newsletters are disabled after either outcome (shared `disableOnceNewsletter` helper).
- `settings.ts` + `migrations/0001-NetworkSettings.ts`: new `NetworkSettings` fields `scheduledRetryAttempts` (default `3`) and `scheduledRetryInterval` (default `300000` ms), inherited by existing installs via the load-time merge.
- `routes/settings/newsletter.ts`: manual send returns 503 (unreachable) or 422 (all empty); test returns 422 (all empty). Both surface the message to the admin.
- `Admin/Settings/Network/index.tsx`: two new validated inputs — attempts (1–10) and interval (shown in seconds, stored in ms, mirroring the request-timeout field).
- `streamarr-api.yml`: `scheduledRetry*` added to the `NetworkSettings` schema; `422`/`503` responses documented on the send/test endpoints.
- Docs: `settings/README.md` (the two Network settings) and `newsletters/README.md` (retry/abort and empty behaviour).

Notes

- Empty is not a failure: only a thrown fetch error triggers a retry; a source that returns no items is a valid empty result.
- Aborts are strict — a failure in any one configured source aborts the whole send rather than delivering a partial newsletter.
- The all-empty case is not retried (retrying will not populate genuinely empty data) and is not recorded in history; it is logged for scheduled runs and reported via toast for manual/test.
- The fail-fast guards apply to manual and test sends, not just scheduled.
- Retry state is in-memory (consistent with the existing service health checks), so a restart mid-retry-window drops any pending retry.
- Settings are named generically (`scheduledRetry*`) for future reuse beyond newsletters.

- Fixes #504

## Has This Been Tested?

- [x] Scheduled newsletter with a By-Tag (Plex) block; stopped Plex before the send fired → retried per the configured attempts/interval, then aborted; no email delivered; abort logged and shown in History with all recipients counted as failures.  Restoring Plex within the window → the next retry delivered normally.
- [x] Scheduled newsletter whose blocks all resolved empty (services up) → skipped, logged, nothing delivered, no history row. A newsletter with one empty and one populated block → sent with only the populated block (no empty heading).
- [x] Text-only newsletter (no blocks configured) → sent normally.
Manual Send Now and Test with a source down → failed immediately (503) with a clear message; with all blocks empty → 422 "nothing to send".
- [x] Network settings: attempts (1–10) and interval (30–3600 s) validate and persist; an existing settings file without the new fields picks up the defaults after upgrade.

## Screenshots (if applicable)
<img width="551" height="458" alt="image" src="https://github.com/user-attachments/assets/bf513409-0029-40a8-9a2a-1623b93cee25" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [x] Database migration (if required)
