### PR TITLE
refactor(loading): scope page-level loading states to their sections

### DIFF
--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -25,10 +25,11 @@ export interface SettingsAboutResponse {
     type: string;
     version: string;
   };
-  diskSpace: {
-    items: DiskSpaceItem[];
-    failedPaths: DiskSpaceFailure[];
-  };
+}
+
+export interface SettingsAboutDiskSpaceResponse {
+  items: DiskSpaceItem[];
+  failedPaths: DiskSpaceFailure[];
 }
 
 export interface DiskSpaceItem {

--- a/server/lib/rateLimiters.ts
+++ b/server/lib/rateLimiters.ts
@@ -52,6 +52,13 @@ export const settingsAboutLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+export const settingsAboutDiskSpaceLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 30, // limit expensive disk space introspection per IP
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 export const newsletterPreviewLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 30,

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -12,6 +12,7 @@ import type {
   LogMessage,
   LogsResultsResponse,
   ServiceHealthResponse,
+  SettingsAboutDiskSpaceResponse,
   SettingsAboutResponse,
 } from '@server/interfaces/api/settingsInterfaces';
 import { scheduledJobs } from '@server/job/schedule';
@@ -25,7 +26,11 @@ import {
   revalidatePlexLibraries,
 } from '@server/lib/plexHealthCheck';
 import QRCodeProxy from '@server/lib/qrcodeproxy';
-import { arrAuthLimiter, settingsAboutLimiter } from '@server/lib/rateLimiters';
+import {
+  arrAuthLimiter,
+  settingsAboutDiskSpaceLimiter,
+  settingsAboutLimiter,
+} from '@server/lib/rateLimiters';
 import restartManager from '@server/lib/restartManager';
 import { plexFullScanner } from '@server/lib/scanners/plex';
 import {
@@ -44,7 +49,7 @@ import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
 import { appDataPath } from '@server/utils/appDataVolume';
 import { getAppVersion } from '@server/utils/appVersion';
-import { getConfigDiskSpace } from '@server/utils/diskSpace';
+import { getCachedConfigDiskSpace } from '@server/utils/diskSpace';
 import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
 import fs, { promises as fsPromises } from 'fs';
@@ -1198,10 +1203,9 @@ settingsRoutes.get('/about', settingsAboutLimiter, async (req, res) => {
   const userRepository = getRepository(User);
   const configPath = appDataPath();
 
-  const [totalInvites, totalUsers, diskSpace] = await Promise.all([
+  const [totalInvites, totalUsers] = await Promise.all([
     inviteRepository.count(),
     userRepository.count(),
-    getConfigDiskSpace(configPath),
   ]);
 
   const dbTypeRaw = dataSource.options.type;
@@ -1242,9 +1246,17 @@ settingsRoutes.get('/about', settingsAboutLimiter, async (req, res) => {
     nodeVersion: process.version.replace(/^v/, ''),
     appDataPath: configPath,
     database: { type: dbDisplayType, version: dbVersion },
-    diskSpace,
   } as SettingsAboutResponse);
 });
+
+settingsRoutes.get(
+  '/about/diskspace',
+  settingsAboutDiskSpaceLimiter,
+  async (_req, res) => {
+    const diskSpace = await getCachedConfigDiskSpace(appDataPath());
+    res.status(200).json(diskSpace as SettingsAboutDiskSpaceResponse);
+  }
+);
 
 settingsRoutes.get('/releases', async (_req, res, next) => {
   try {

--- a/server/utils/diskSpace.ts
+++ b/server/utils/diskSpace.ts
@@ -11,6 +11,8 @@ import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
 
+const DU_TIMEOUT_MS = 30 * 1000;
+
 /**
  * Walks up the directory tree from `targetPath` until it finds a path that
  * exists on the filesystem. Returns the nearest existing ancestor (or the
@@ -102,10 +104,45 @@ export const getDiskSpaceStats = async (diskPath: string) => {
 };
 
 /**
- * Recursively calculates the total size in bytes of all files under
- * `targetPath`. Skips symbolic links and unreadable entries.
+ * Returns the total bytes used under `targetPath`. Prefers the native `du`
+ * command, which is significantly faster than a recursive JS walk and runs
+ * off the event loop. Note: `du` reports on-disk (block-allocated) usage
+ * rather than apparent file size, so totals can differ slightly. Falls back to
+ * a recursive walk when `du` is unavailable (e.g. non-POSIX host) or fails.
  */
 export const getPathUsedBytes = async (targetPath: string): Promise<number> => {
+  try {
+    // -s: summarize to a single total; -k: report in 1024-byte block units.
+    // `--` guards against a path that begins with `-` being read as a flag.
+    const { stdout } = await execFileAsync('du', ['-sk', '--', targetPath], {
+      timeout: DU_TIMEOUT_MS,
+    });
+    const blocksKb = Number(stdout.trim().split(/\s+/)[0]);
+
+    if (Number.isFinite(blocksKb)) {
+      return blocksKb * 1024;
+    }
+
+    throw new Error(`Unable to parse du output for path: ${targetPath}`);
+  } catch (e) {
+    logger.warn('Falling back to recursive path size calculation', {
+      label: 'Settings',
+      targetPath,
+      errorMessage: e instanceof Error ? e.message : 'Unknown error',
+    });
+
+    return getPathUsedBytesRecursive(targetPath);
+  }
+};
+
+/**
+ * Recursively calculates the total size in bytes of all files under
+ * `targetPath`. Skips symbolic links and unreadable entries. Used as a
+ * fallback when the native `du` command is unavailable.
+ */
+const getPathUsedBytesRecursive = async (
+  targetPath: string
+): Promise<number> => {
   try {
     const rootStats = await fsPromises.lstat(targetPath);
 
@@ -236,4 +273,46 @@ export const getConfigDiskSpace = async (
     },
     { items: [], failedPaths: [] }
   );
+};
+
+const DISK_SPACE_CACHE_TTL_MS = 30 * 1000;
+
+type DiskSpaceResult = {
+  items: DiskSpaceItem[];
+  failedPaths: DiskSpaceFailure[];
+};
+
+let diskSpaceCache: {
+  key: string;
+  expiresAt: number;
+  promise: Promise<DiskSpaceResult>;
+} | null = null;
+
+export const getCachedConfigDiskSpace = async (
+  configPath: string
+): Promise<DiskSpaceResult> => {
+  const now = Date.now();
+
+  if (
+    diskSpaceCache &&
+    diskSpaceCache.key === configPath &&
+    diskSpaceCache.expiresAt > now
+  ) {
+    return diskSpaceCache.promise;
+  }
+
+  const promise = getConfigDiskSpace(configPath);
+  diskSpaceCache = {
+    key: configPath,
+    expiresAt: now + DISK_SPACE_CACHE_TTL_MS,
+    promise,
+  };
+
+  promise.catch(() => {
+    if (diskSpaceCache?.promise === promise) {
+      diskSpaceCache = null;
+    }
+  });
+
+  return promise;
 };

--- a/src/components/Admin/Settings/General/index.tsx
+++ b/src/components/Admin/Settings/General/index.tsx
@@ -115,11 +115,8 @@ const GeneralSettings = () => {
     }
   };
 
-  if (!data && !error) {
-    return <LoadingEllipsis />;
-  }
-  return (
-    <div className="mb-6">
+  const header = (
+    <>
       <h3 className="text-2xl font-extrabold">
         <FormattedMessage
           id="generalSettings.title"
@@ -132,6 +129,20 @@ const GeneralSettings = () => {
           defaultMessage="Configure global and default Streamarr settings"
         />
       </p>
+    </>
+  );
+
+  if (!data && !error) {
+    return (
+      <div className="mb-6">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
+  }
+  return (
+    <div className="mb-6">
+      {header}
       <Formik
         initialValues={{
           applicationTitle: data?.applicationTitle,

--- a/src/components/Admin/Settings/Network/index.tsx
+++ b/src/components/Admin/Settings/Network/index.tsx
@@ -131,26 +131,35 @@ const NetworkSettings = () => {
       ),
   });
 
+  const header = (
+    <div className="mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="networkSettings.title"
+          defaultMessage="Network Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="networkSettings.description"
+          defaultMessage="Configure global network settings for your Streamarr instance."
+        />
+      </p>
+    </div>
+  );
+
   if (!data && !error) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mb-10 max-w-6xl">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   return (
     <div className="mb-10 max-w-6xl">
-      <div className="mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="networkSettings.title"
-            defaultMessage="Network Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="networkSettings.description"
-            defaultMessage="Configure global network settings for your Streamarr instance."
-          />
-        </p>
-      </div>
+      {header}
       <RestartRequiredAlert
         filterServices={['Proxy Support', 'CSRF Protection']}
       />

--- a/src/components/Admin/Settings/Plex/index.tsx
+++ b/src/components/Admin/Settings/Plex/index.tsx
@@ -267,48 +267,57 @@ const PlexSettings = ({ onComplete }: SettingsPlexProps) => {
     }
   };
 
+  const header = (
+    <div className="my-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="plexSettings.title"
+          defaultMessage="Plex Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="plexSettings.description"
+          defaultMessage="Configure the settings for your Plex server. Streamarr scans your Plex libraries to generate menus and share to invited users."
+        />
+      </p>
+      {!!onComplete && (
+        <Alert type="primary">
+          <p className="flex-1 text-sm leading-5">
+            <FormattedMessage
+              id="plexSettings.setupInstructions"
+              defaultMessage="To set up Plex, you can either enter the details manually or select a server retrieved from {plexLink}. Press the button to the right of the dropdown to fetch the list of available servers."
+              values={{
+                plexLink: (
+                  <a
+                    href="https://plex.tv"
+                    className="inline-flex text-white transition duration-300 hover:underline"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    plex.tv
+                  </a>
+                ),
+              }}
+            />
+          </p>
+        </Alert>
+      )}
+    </div>
+  );
+
   if (!data && !error) {
-    return <LoadingEllipsis />;
+    return (
+      <>
+        {header}
+        <LoadingEllipsis />
+      </>
+    );
   }
 
   return (
     <>
-      <div className="my-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="plexSettings.title"
-            defaultMessage="Plex Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="plexSettings.description"
-            defaultMessage="Configure the settings for your Plex server. Streamarr scans your Plex libraries to generate menus and share to invited users."
-          />
-        </p>
-        {!!onComplete && (
-          <Alert type="primary">
-            <p className="flex-1 text-sm leading-5">
-              <FormattedMessage
-                id="plexSettings.setupInstructions"
-                defaultMessage="To set up Plex, you can either enter the details manually or select a server retrieved from {plexLink}. Press the button to the right of the dropdown to fetch the list of available servers."
-                values={{
-                  plexLink: (
-                    <a
-                      href="https://plex.tv"
-                      className="inline-flex text-white transition duration-300 hover:underline"
-                      target="_blank"
-                      rel="noreferrer"
-                    >
-                      plex.tv
-                    </a>
-                  ),
-                }}
-              />
-            </p>
-          </Alert>
-        )}
-      </div>
+      {header}
       <Formik
         initialValues={{
           hostname: data?.ip,

--- a/src/components/Admin/Settings/Services/Bazarr/index.tsx
+++ b/src/components/Admin/Settings/Services/Bazarr/index.tsx
@@ -50,26 +50,35 @@ const ServicesBazarr = () => {
       ),
   });
 
+  const header = (
+    <div className="mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="servicesSettings.bazarr.title"
+          defaultMessage="Bazarr Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="servicesSettings.bazarr.description"
+          defaultMessage="Optionally configure the settings for your Bazarr server."
+        />
+      </p>
+    </div>
+  );
+
   if (!dataBazarr) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mb-10 max-w-6xl">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   return (
     <div className="mb-10 max-w-6xl">
-      <div className="mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="servicesSettings.bazarr.title"
-            defaultMessage="Bazarr Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="servicesSettings.bazarr.description"
-            defaultMessage="Optionally configure the settings for your Bazarr server."
-          />
-        </p>
-      </div>
+      {header}
       <RestartRequiredAlert filterServices={['Bazarr']} />
       <Formik
         initialValues={{

--- a/src/components/Admin/Settings/Services/Cleanuparr/index.tsx
+++ b/src/components/Admin/Settings/Services/Cleanuparr/index.tsx
@@ -100,26 +100,35 @@ const ServicesCleanuparr = () => {
     [intl]
   );
 
+  const header = (
+    <div className="mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="servicesSettings.cleanuparr.title"
+          defaultMessage="Cleanuparr Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="servicesSettings.cleanuparr.description"
+          defaultMessage="Optionally configure the settings for your Cleanuparr server. Cleanuparr must be configured with a matching base path."
+        />
+      </p>
+    </div>
+  );
+
   if (!dataCleanuparr) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mb-10 max-w-6xl">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   return (
     <div className="mb-10 max-w-6xl">
-      <div className="mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="servicesSettings.cleanuparr.title"
-            defaultMessage="Cleanuparr Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="servicesSettings.cleanuparr.description"
-            defaultMessage="Optionally configure the settings for your Cleanuparr server. Cleanuparr must be configured with a matching base path."
-          />
-        </p>
-      </div>
+      {header}
       <RestartRequiredAlert filterServices={['Cleanuparr']} />
       <Alert
         title={intl.formatMessage({

--- a/src/components/Admin/Settings/Services/Lidarr/index.tsx
+++ b/src/components/Admin/Settings/Services/Lidarr/index.tsx
@@ -217,26 +217,35 @@ const ServicesLidarr = () => {
     }
   };
 
+  const header = (
+    <div className="mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="servicesSettings.lidarr.title"
+          defaultMessage="Lidarr Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="servicesSettings.lidarr.description"
+          defaultMessage="Optionally configure the settings for your Lidarr server."
+        />
+      </p>
+    </div>
+  );
+
   if (!dataLidarr) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mb-10 max-w-6xl">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   return (
     <div className="mb-10 max-w-6xl">
-      <div className="mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="servicesSettings.lidarr.title"
-            defaultMessage="Lidarr Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="servicesSettings.lidarr.description"
-            defaultMessage="Optionally configure the settings for your Lidarr server."
-          />
-        </p>
-      </div>
+      {header}
       <RestartRequiredAlert filterServices={['Lidarr']} />
       <Formik
         initialValues={{

--- a/src/components/Admin/Settings/Services/Overseerr/index.tsx
+++ b/src/components/Admin/Settings/Services/Overseerr/index.tsx
@@ -77,26 +77,35 @@ const ServicesOverseerr = () => {
     ),
   });
 
+  const header = (
+    <div className="mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="servicesSettings.overseerr.title"
+          defaultMessage="Seerr Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="servicesSettings.overseerr.description"
+          defaultMessage="Optionally configure the settings for your Seerr server."
+        />
+      </p>
+    </div>
+  );
+
   if (!dataOverseerr) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mb-10 max-w-6xl">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   return (
     <div className="mb-10 max-w-6xl">
-      <div className="mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="servicesSettings.overseerr.title"
-            defaultMessage="Seerr Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="servicesSettings.overseerr.description"
-            defaultMessage="Optionally configure the settings for your Seerr server."
-          />
-        </p>
-      </div>
+      {header}
       <RestartRequiredAlert filterServices={['Seerr']} />
       <Alert
         title={intl.formatMessage({

--- a/src/components/Admin/Settings/Services/Prowlarr/index.tsx
+++ b/src/components/Admin/Settings/Services/Prowlarr/index.tsx
@@ -212,26 +212,35 @@ const ServicesProwlarr = () => {
     }
   };
 
+  const header = (
+    <div className="mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="servicesSettings.prowlarr.title"
+          defaultMessage="Prowlarr Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="servicesSettings.prowlarr.description"
+          defaultMessage="Optionally configure the settings for your Prowlarr server."
+        />
+      </p>
+    </div>
+  );
+
   if (!dataProwlarr) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mb-10 max-w-6xl">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   return (
     <div className="mb-10 max-w-6xl">
-      <div className="mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="servicesSettings.prowlarr.title"
-            defaultMessage="Prowlarr Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="servicesSettings.prowlarr.description"
-            defaultMessage="Optionally configure the settings for your Prowlarr server."
-          />
-        </p>
-      </div>
+      {header}
       <RestartRequiredAlert filterServices={['Prowlarr']} />
       <Formik
         initialValues={{

--- a/src/components/Admin/Settings/Services/Tautulli/index.tsx
+++ b/src/components/Admin/Settings/Services/Tautulli/index.tsx
@@ -123,26 +123,35 @@ const ServicesTautulli = () => {
     ]
   );
 
+  const header = (
+    <div className="mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="servicesSettings.tautulli.title"
+          defaultMessage="Tautulli Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="servicesSettings.tautulli.description"
+          defaultMessage="Optionally configure the settings for your Tautulli server. Streamarr proxies tautulli at /activity for users."
+        />
+      </p>
+    </div>
+  );
+
   if (!dataTautulli) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mb-10 max-w-6xl">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   return (
     <div className="mb-10 max-w-6xl">
-      <div className="mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="servicesSettings.tautulli.title"
-            defaultMessage="Tautulli Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="servicesSettings.tautulli.description"
-            defaultMessage="Optionally configure the settings for your Tautulli server. Streamarr proxies tautulli at /activity for users."
-          />
-        </p>
-      </div>
+      {header}
       <RestartRequiredAlert filterServices={['Tautulli']} />
       <Formik
         initialValues={{

--- a/src/components/Admin/Settings/Services/Tdarr/index.tsx
+++ b/src/components/Admin/Settings/Services/Tdarr/index.tsx
@@ -23,26 +23,35 @@ const ServicesTdarr = () => {
     '/api/v1/settings/tdarr'
   );
 
+  const header = (
+    <div className="mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="servicesSettings.tdarr.title"
+          defaultMessage="Tdarr Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="servicesSettings.tdarr.description"
+          defaultMessage="Configure the settings for your Tdarr server."
+        />
+      </p>
+    </div>
+  );
+
   if (!dataTdarr) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mb-10 max-w-6xl">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   return (
     <div className="mb-10 max-w-6xl">
-      <div className="mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="servicesSettings.tdarr.title"
-            defaultMessage="Tdarr Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="servicesSettings.tdarr.description"
-            defaultMessage="Configure the settings for your Tdarr server."
-          />
-        </p>
-      </div>
+      {header}
       <RestartRequiredAlert filterServices={['Tdarr']} />
       <Formik
         initialValues={{

--- a/src/components/Admin/Settings/Services/Uptime/index.tsx
+++ b/src/components/Admin/Settings/Services/Uptime/index.tsx
@@ -40,26 +40,35 @@ const ServicesUptime = () => {
       ),
   });
 
+  const header = (
+    <div className="mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="servicesSettings.uptime.title"
+          defaultMessage="Uptime Settings"
+        />
+      </h3>
+      <p className="mb-5">
+        <FormattedMessage
+          id="servicesSettings.uptime.description"
+          defaultMessage="Optionally configure the settings for your Uptime server. Streamarr presents your uptime link via the help centre."
+        />
+      </p>
+    </div>
+  );
+
   if (!dataUptime) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mb-10 max-w-6xl">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   return (
     <div className="mb-10 max-w-6xl">
-      <div className="mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="servicesSettings.uptime.title"
-            defaultMessage="Uptime Settings"
-          />
-        </h3>
-        <p className="mb-5">
-          <FormattedMessage
-            id="servicesSettings.uptime.description"
-            defaultMessage="Optionally configure the settings for your Uptime server. Streamarr presents your uptime link via the help centre."
-          />
-        </p>
-      </div>
+      {header}
       <Formik
         initialValues={{
           enabled: dataUptime?.enabled ?? false,

--- a/src/components/Admin/Settings/System/DiskSpace/index.tsx
+++ b/src/components/Admin/Settings/System/DiskSpace/index.tsx
@@ -1,4 +1,5 @@
 import Alert from '@app/components/Common/Alert';
+import LoadingEllipsis from '@app/components/Common/LoadingEllipsis';
 import ProgressBar from '@app/components/Common/ProgressBar';
 import { formatBytes } from '@app/utils/numberHelper';
 import {
@@ -6,12 +7,13 @@ import {
   ChevronDownIcon,
   ChevronRightIcon,
 } from '@heroicons/react/24/solid';
-import type { SettingsAboutResponse } from '@server/interfaces/api/settingsInterfaces';
+import type { SettingsAboutDiskSpaceResponse } from '@server/interfaces/api/settingsInterfaces';
 import { useCallback, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
+import useSWR from 'swr';
 
 interface DiskSpaceProps {
-  data: SettingsAboutResponse;
+  appDataPath: string;
 }
 
 const ROOT_NODE_KEY = '__root__';
@@ -107,13 +109,21 @@ const DiskMetrics = ({
   </div>
 );
 
-const DiskSpace = ({ data }: DiskSpaceProps) => {
+const DiskSpace = ({ appDataPath }: DiskSpaceProps) => {
   const intl = useIntl();
 
-  const { items: diskSpaceItems, failedPaths } = data.diskSpace;
-  const appDataNorm = normalizePath(data.appDataPath);
+  const { data, error } = useSWR<SettingsAboutDiskSpaceResponse>(
+    '/api/v1/settings/about/diskspace',
+    { revalidateOnFocus: false }
+  );
+
+  const diskSpaceItems = useMemo(() => data?.items ?? [], [data]);
+  const failedPaths = data?.failedPaths ?? [];
+  const appDataNorm = normalizePath(appDataPath);
   const hasDiskSpaceWarning =
-    failedPaths.length > 0 || diskSpaceItems.length === 0;
+    !!error ||
+    failedPaths.length > 0 ||
+    (!!data && diskSpaceItems.length === 0);
 
   const [expandedRows, setExpandedRows] = useState<Set<string>>(
     () => new Set([ROOT_NODE_KEY])
@@ -210,7 +220,7 @@ const DiskSpace = ({ data }: DiskSpaceProps) => {
 
   return (
     <div className="mt-6">
-      <div className="flex items-center justify-between">
+      <div className="mb-4 flex items-center justify-between">
         <h3 className="flex items-center gap-2 text-2xl font-extrabold">
           <FormattedMessage
             id="systemSettings.diskSpace.title"
@@ -218,6 +228,7 @@ const DiskSpace = ({ data }: DiskSpaceProps) => {
           />
         </h3>
       </div>
+      {!data && !error && <LoadingEllipsis />}
       {hasDiskSpaceWarning && (
         <Alert
           type="warning"
@@ -234,120 +245,122 @@ const DiskSpace = ({ data }: DiskSpaceProps) => {
           </span>
         </Alert>
       )}
-      <div className="border-base-content/10 mt-4 overflow-hidden rounded-lg border">
-        <div className="border-base-content/10 text-base-content bg-base-200/50 hidden gap-3 border-b px-3 py-2 text-sm font-semibold md:grid md:grid-cols-12">
-          <span className="col-span-4">
-            <FormattedMessage
-              id="systemSettings.diskSpace.location"
-              defaultMessage="Location"
-            />
-          </span>
-          <span className="col-span-2 text-right">
-            <FormattedMessage
-              id="systemSettings.diskSpace.freeSpace"
-              defaultMessage="Free Space"
-            />
-          </span>
-          <span className="col-span-2 text-right">
-            <FormattedMessage
-              id="systemSettings.diskSpace.usedSpace"
-              defaultMessage="Used Space"
-            />
-          </span>
-          <span className="col-span-2 text-right">
-            <FormattedMessage
-              id="systemSettings.diskSpace.totalSpace"
-              defaultMessage="Total Space"
-            />
-          </span>
-          <span className="col-span-2" />
-        </div>
-        <div>
-          {rootDiskItem && (
-            <div className="bg-base-200/50 hover:bg-base-200/30 grid grid-cols-1 gap-3 px-3 py-3 md:grid-cols-12 md:items-center">
-              <div className="min-w-0 md:col-span-4">
-                <span className="text-base-content flex items-center gap-2 text-sm">
-                  <ExpandButton
-                    hasChildren={childCountByParent.has(ROOT_NODE_KEY)}
-                    isExpanded={expandedRows.has(ROOT_NODE_KEY)}
-                    onToggle={() => toggleRow(ROOT_NODE_KEY)}
-                  />
-                  <span className="min-w-0 truncate font-mono">
-                    {rootDiskItem.mountPoint}
-                  </span>
-                </span>
-              </div>
-              <DiskMetrics
-                freeBytes={rootDiskItem.freeBytes}
-                usedBytes={rootDiskItem.usedBytes}
-                totalBytes={rootDiskItem.totalBytes}
+      {(data || error) && (
+        <div className="border-base-content/10 mt-4 overflow-hidden rounded-lg border">
+          <div className="border-base-content/10 text-base-content bg-base-200/50 hidden gap-3 border-b px-3 py-2 text-sm font-semibold md:grid md:grid-cols-12">
+            <span className="col-span-4">
+              <FormattedMessage
+                id="systemSettings.diskSpace.location"
+                defaultMessage="Location"
               />
-              <div className="md:col-span-2">
-                <ProgressBar
-                  progress={rootUsedPercent}
-                  color={getDiskSpaceColor(rootUsedPercent)}
-                  showPercentage={false}
-                  size="sm"
-                />
-              </div>
-            </div>
-          )}
-          {diskRows.map((row) => {
-            const hasChildren = childCountByParent.has(row.rowKey);
-            const isExpanded = expandedRows.has(row.rowKey);
-            const isVisible = isRowVisible(row.parentKey);
-            return (
-              <div
-                key={`${row.disk.deviceId}-${row.disk.path}`}
-                className={`bg-base-200/50 hover:bg-base-200/30 overflow-hidden transition-all duration-300 ease-in-out motion-reduce:transition-none ${
-                  isVisible
-                    ? 'border-base-content/10 max-h-40 translate-y-0 border-t opacity-100'
-                    : 'pointer-events-none max-h-0 -translate-y-1 opacity-0'
-                }`}
-              >
-                <div className="grid grid-cols-1 gap-3 px-3 py-3 md:grid-cols-12 md:items-center">
-                  <div className="min-w-0 md:col-span-4">
-                    <span
-                      className={`text-base-content flex items-center gap-2 text-sm ${
-                        !row.isChild
-                          ? ''
-                          : row.parentKey === ROOT_NODE_KEY
-                            ? 'pl-4'
-                            : 'pl-16'
-                      }`}
-                    >
-                      <ExpandButton
-                        hasChildren={hasChildren}
-                        isExpanded={isExpanded}
-                        onToggle={() => toggleRow(row.rowKey)}
-                      />
-                      {row.isChild && (
-                        <ArrowTurnDownRightIcon className="text-neutral size-5 shrink-0" />
-                      )}
-                      <span className="min-w-0 truncate font-mono">
-                        {row.displayPath}
-                      </span>
-                    </span>
-                  </div>
-                  <DiskMetrics
-                    freeBytes={row.disk.freeBytes}
-                    usedBytes={row.usedBytes}
-                    totalBytes={row.totalBytes}
-                  />
-                  <div className="md:col-span-2">
-                    <ProgressBar
-                      progress={row.usedPercent}
-                      color={getDiskSpaceColor(row.usedPercent)}
-                      showPercentage={false}
-                      size="sm"
+            </span>
+            <span className="col-span-2 text-right">
+              <FormattedMessage
+                id="systemSettings.diskSpace.freeSpace"
+                defaultMessage="Free Space"
+              />
+            </span>
+            <span className="col-span-2 text-right">
+              <FormattedMessage
+                id="systemSettings.diskSpace.usedSpace"
+                defaultMessage="Used Space"
+              />
+            </span>
+            <span className="col-span-2 text-right">
+              <FormattedMessage
+                id="systemSettings.diskSpace.totalSpace"
+                defaultMessage="Total Space"
+              />
+            </span>
+            <span className="col-span-2" />
+          </div>
+          <div>
+            {rootDiskItem && (
+              <div className="bg-base-200/50 hover:bg-base-200/30 grid grid-cols-1 gap-3 px-3 py-3 md:grid-cols-12 md:items-center">
+                <div className="min-w-0 md:col-span-4">
+                  <span className="text-base-content flex items-center gap-2 text-sm">
+                    <ExpandButton
+                      hasChildren={childCountByParent.has(ROOT_NODE_KEY)}
+                      isExpanded={expandedRows.has(ROOT_NODE_KEY)}
+                      onToggle={() => toggleRow(ROOT_NODE_KEY)}
                     />
-                  </div>
+                    <span className="min-w-0 truncate font-mono">
+                      {rootDiskItem.mountPoint}
+                    </span>
+                  </span>
+                </div>
+                <DiskMetrics
+                  freeBytes={rootDiskItem.freeBytes}
+                  usedBytes={rootDiskItem.usedBytes}
+                  totalBytes={rootDiskItem.totalBytes}
+                />
+                <div className="md:col-span-2">
+                  <ProgressBar
+                    progress={rootUsedPercent}
+                    color={getDiskSpaceColor(rootUsedPercent)}
+                    showPercentage={false}
+                    size="sm"
+                  />
                 </div>
               </div>
-            );
-          })}
+            )}
+            {diskRows.map((row) => {
+              const hasChildren = childCountByParent.has(row.rowKey);
+              const isExpanded = expandedRows.has(row.rowKey);
+              const isVisible = isRowVisible(row.parentKey);
+              return (
+                <div
+                  key={`${row.disk.deviceId}-${row.disk.path}`}
+                  className={`bg-base-200/50 hover:bg-base-200/30 overflow-hidden transition-all duration-300 ease-in-out motion-reduce:transition-none ${
+                    isVisible
+                      ? 'border-base-content/10 max-h-40 translate-y-0 border-t opacity-100'
+                      : 'pointer-events-none max-h-0 -translate-y-1 opacity-0'
+                  }`}
+                >
+                  <div className="grid grid-cols-1 gap-3 px-3 py-3 md:grid-cols-12 md:items-center">
+                    <div className="min-w-0 md:col-span-4">
+                      <span
+                        className={`text-base-content flex items-center gap-2 text-sm ${
+                          !row.isChild
+                            ? ''
+                            : row.parentKey === ROOT_NODE_KEY
+                              ? 'pl-4'
+                              : 'pl-16'
+                        }`}
+                      >
+                        <ExpandButton
+                          hasChildren={hasChildren}
+                          isExpanded={isExpanded}
+                          onToggle={() => toggleRow(row.rowKey)}
+                        />
+                        {row.isChild && (
+                          <ArrowTurnDownRightIcon className="text-neutral size-5 shrink-0" />
+                        )}
+                        <span className="min-w-0 truncate font-mono">
+                          {row.displayPath}
+                        </span>
+                      </span>
+                    </div>
+                    <DiskMetrics
+                      freeBytes={row.disk.freeBytes}
+                      usedBytes={row.usedBytes}
+                      totalBytes={row.totalBytes}
+                    />
+                    <div className="md:col-span-2">
+                      <ProgressBar
+                        progress={row.usedPercent}
+                        color={getDiskSpaceColor(row.usedPercent)}
+                        showPercentage={false}
+                        size="sm"
+                      />
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/src/components/Admin/Settings/System/Releases/index.tsx
+++ b/src/components/Admin/Settings/System/Releases/index.tsx
@@ -90,26 +90,38 @@ interface ReleasesProps {
 const Releases = ({ currentVersion }: ReleasesProps) => {
   const { data, error } = useSWR<GitHubRelease[]>('/api/v1/settings/releases');
 
+  const header = (
+    <h3 className="text-2xl font-bold">
+      <FormattedMessage id="aboutReleases.title" defaultMessage="Releases" />
+    </h3>
+  );
+
   if (!data && !error) {
-    return <LoadingEllipsis />;
+    return (
+      <div>
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   if (!data) {
     return (
-      <div className="text-gray-300">
-        <FormattedMessage
-          id="aboutReleases.dataUnavailable"
-          defaultMessage="Release data is currently unavailable"
-        />
+      <div>
+        {header}
+        <div className="text-gray-300">
+          <FormattedMessage
+            id="aboutReleases.dataUnavailable"
+            defaultMessage="Release data is currently unavailable"
+          />
+        </div>
       </div>
     );
   }
 
   return (
     <div>
-      <h3 className="text-2xl font-bold">
-        <FormattedMessage id="aboutReleases.title" defaultMessage="Releases" />
-      </h3>
+      {header}
       <div className="mt-6 mb-10 space-y-3">
         {data.map((release, index) => {
           return (

--- a/src/components/Admin/Settings/System/index.tsx
+++ b/src/components/Admin/Settings/System/index.tsx
@@ -132,7 +132,7 @@ const SystemSettings = () => {
         />
         <ServicesHealth />
       </div>
-      <DiskSpace data={data} />
+      <DiskSpace appDataPath={data.appDataPath} />
       <div className="mt-6">
         <List
           title={intl.formatMessage({

--- a/src/components/Admin/Settings/Users/index.tsx
+++ b/src/components/Admin/Settings/Users/index.tsx
@@ -27,12 +27,8 @@ const UserSettings = () => {
     mutate: revalidate,
   } = useSWR<MainSettings>('/api/v1/settings/main');
 
-  if (!data && !error) {
-    return <LoadingEllipsis />;
-  }
-
-  return (
-    <div className="mb-6">
+  const header = (
+    <>
       <h3 className="text-2xl font-extrabold">
         <FormattedMessage
           id="userSettings.title"
@@ -45,6 +41,21 @@ const UserSettings = () => {
           defaultMessage="Configure global and default user settings."
         />
       </p>
+    </>
+  );
+
+  if (!data && !error) {
+    return (
+      <div className="mb-6">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6">
+      {header}
       <Formik
         initialValues={{
           localLogin: data?.localLogin,

--- a/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsGeneral/index.tsx
@@ -221,8 +221,22 @@ const UserSettingsGeneral = () => {
     }
   };
 
+  const header = (
+    <h3 className="text-2xl font-extrabold">
+      <FormattedMessage
+        id="generalSettings.title"
+        defaultMessage="General Settings"
+      />
+    </h3>
+  );
+
   if (!data && !error) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mt-3 mb-6">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   if (!data) {
@@ -237,12 +251,7 @@ const UserSettingsGeneral = () => {
 
   return (
     <div className="mt-3 mb-6">
-      <h3 className="text-2xl font-extrabold">
-        <FormattedMessage
-          id="generalSettings.title"
-          defaultMessage="General Settings"
-        />
-      </h3>
+      {header}
       <Formik
         initialValues={{
           displayName: data?.username ?? '',

--- a/src/components/UserProfile/UserSettings/UserSettingsNotifications/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsNotifications/index.tsx
@@ -148,8 +148,24 @@ const UserSettingsNotifications = ({
       : `/admin/users/${user?.id}${settingsRoute.route}`,
   }));
 
+  const header = (
+    <div className="mt-3 mb-6">
+      <h3 className="text-2xl font-extrabold">
+        <FormattedMessage
+          id="notification.settings"
+          defaultMessage="Notification Settings"
+        />
+      </h3>
+    </div>
+  );
+
   if (userLoading || (!data && !error)) {
-    return <LoadingEllipsis />;
+    return (
+      <div>
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   if (userError || !user) {
@@ -166,14 +182,7 @@ const UserSettingsNotifications = ({
 
   return (
     <div>
-      <div className="mt-3 mb-6">
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="notification.settings"
-            defaultMessage="Notification Settings"
-          />
-        </h3>
-      </div>
+      {header}
       <AdminTabs tabType="button" AdminRoutes={computedRoutes} />
       <div className="section">{children}</div>
     </div>

--- a/src/components/UserProfile/UserSettings/UserSettingsPassword/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsPassword/index.tsx
@@ -75,8 +75,19 @@ const UserPasswordChange = () => {
       ),
   });
 
+  const header = (
+    <h3 className="text-2xl font-extrabold">
+      <FormattedMessage id="common.password" defaultMessage="Password" />
+    </h3>
+  );
+
   if (!data && !error) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mt-3 mb-6">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   if (!data) {
@@ -90,11 +101,7 @@ const UserPasswordChange = () => {
   ) {
     return (
       <>
-        <div className="mt-3 mb-6">
-          <h3 className="text-2xl font-extrabold">
-            <FormattedMessage id="common.password" defaultMessage="Password" />
-          </h3>
-        </div>
+        <div className="mt-3 mb-6">{header}</div>
         <Alert
           title={intl.formatMessage({
             id: 'userSettings.password.noPermission',

--- a/src/components/UserProfile/UserSettings/UserSettingsPermissions/index.tsx
+++ b/src/components/UserProfile/UserSettings/UserSettingsPermissions/index.tsx
@@ -28,8 +28,22 @@ const UserPermissions = () => {
     user ? `/api/v1/user/${user?.id}/settings/permissions` : null
   );
 
+  const header = (
+    <h3 className="text-2xl font-extrabold">
+      <FormattedMessage
+        id="settings.permissions"
+        defaultMessage="Permissions"
+      />
+    </h3>
+  );
+
   if (!data && !error) {
-    return <LoadingEllipsis />;
+    return (
+      <div className="mt-3 mb-6">
+        {header}
+        <LoadingEllipsis />
+      </div>
+    );
   }
 
   if (!data) {
@@ -45,14 +59,7 @@ const UserPermissions = () => {
   if (currentUser?.id !== 1 && currentUser?.id === user?.id) {
     return (
       <>
-        <div className="mt-3 mb-6">
-          <h3 className="text-2xl font-extrabold">
-            <FormattedMessage
-              id="settings.permissions"
-              defaultMessage="Permissions"
-            />
-          </h3>
-        </div>
+        <div className="mt-3 mb-6">{header}</div>
         <Alert
           title={
             <FormattedMessage

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -5352,53 +5352,66 @@ paths:
                   appDataPath:
                     type: string
                     example: /app/config
-                  diskSpace:
-                    type: object
-                    properties:
-                      items:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            deviceId:
-                              type: string
-                              example: '2064'
-                            name:
-                              type: string
-                              example: App Data
-                            path:
-                              type: string
-                              example: /app/config
-                            mountPoint:
-                              type: string
-                              example: /
-                            pathUsedBytes:
-                              type: number
-                              example: 104857600
-                            totalBytes:
-                              type: number
-                              example: 249108103168
-                            freeBytes:
-                              type: number
-                              example: 124554051584
-                            usedBytes:
-                              type: number
-                              example: 124554051584
-                            usedPercent:
-                              type: number
-                              format: float
-                              example: 50
-                      failedPaths:
-                        type: array
-                        items:
-                          type: object
-                          properties:
-                            name:
-                              type: string
-                              example: Image Cache
-                            path:
-                              type: string
-                              example: /app/config/cache/images
+  /settings/about/diskspace:
+    get:
+      summary: Get disk space usage
+      description: >-
+        Returns disk usage for the application data directory and its immediate
+        subdirectories. Results are cached server-side for a short period.
+      tags:
+        - settings
+      responses:
+        '200':
+          description: Disk space usage
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        deviceId:
+                          type: string
+                          example: '2064'
+                        name:
+                          type: string
+                          example: App Data
+                        path:
+                          type: string
+                          example: /app/config
+                        mountPoint:
+                          type: string
+                          example: /
+                        pathUsedBytes:
+                          type: number
+                          example: 104857600
+                        totalBytes:
+                          type: number
+                          example: 249108103168
+                        freeBytes:
+                          type: number
+                          example: 124554051584
+                        usedBytes:
+                          type: number
+                          example: 124554051584
+                        usedPercent:
+                          type: number
+                          format: float
+                          example: 50
+                  failedPaths:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          example: Image Cache
+                        path:
+                          type: string
+                          example: /app/config/cache/images
   /settings/releases:
     get:
       summary: Get GitHub releases


### PR DESCRIPTION
## Description
Improves perceived load time across settings and profile pages by moving loading states as close as possible to the components that actually depend on the data, per #501. Previously many pages did `if (!data) return <LoadingEllipsis />` at the top, blocking the page heading and static chrome until the fetch resolved. Now the heading/description paint immediately and only the data-dependent section shows the loading indicator.

This also includes a targeted System-page fix: `GET /settings/about` computed disk usage inline (per-path `df` plus a recursive size walk), so the whole page waited on it. Disk space is now a separate endpoint that loads in its own section.

## Changes

**Loading states (#501)**
- Hoisted the static heading/description in each affected page so it renders immediately, keeping the form/list gated on data via a section-scoped `<LoadingEllipsis />`. Form bodies are unchanged.
  - Admin → Settings: General, Network, Users, Plex, System/Releases
  - Admin → Settings → Services: Bazarr, Cleanuparr, Lidarr, Overseerr, Prowlarr, Tautulli, Tdarr, Uptime
  - User Settings: General, Password, Permissions, Notifications
- Intentionally left as-is (single essential source / no independent chrome): frame pages (Activity, Movies, TV, Music, Subtitles, Indexers, Transcoding, Cleaning, Watch), `user`-gated profile pages (`UserProfile`, `ProfileLayout`), bare notification child-forms, and the `admin`/`schedule` layout auth gates.
- Closes #501 

**System disk space**

- `GET /api/v1/settings/about` no longer collects/returns `diskSpace`; it resolves as soon as the cheap counts and DB version are ready.
- New `GET /api/v1/settings/about/diskspace` returning `{ items, failedPaths }`, behind the existing `Permission.ADMIN` gate and a dedicated `settingsAboutDiskSpaceLimiter`.
- `getCachedConfigDiskSpace` caches collection for 30s (keyed by config path).
- `getPathUsedBytes` now uses native `du -sk` (off the event loop) with the recursive JS walk kept as a fallback.
- `DiskSpace` takes `appDataPath` and self-fetches the new endpoint (`revalidateOnFocus: false`), rendering its heading immediately with a scoped loader.
- Types: removed `diskSpace` from `SettingsAboutResponse`; added `SettingsAboutDiskSpaceResponse`.
- Spec: updated `streamarr-api.yml` — removed `diskSpace` from `/settings/about`, added the `/settings/about/diskspace` path.

## Notes

- **API contract change:** consumers of `/settings/about` must use `/settings/about/diskspace` for disk usage. The only in-app consumer (`DiskSpace`) is updated here.
- `du` reports block-allocated (on-disk) usage rather than summed apparent file size, so "Used Space" totals may shift slightly toward the true on-disk number; the recursive fallback preserves prior behaviour where `du` is absent.
- No new i18n strings (reuses the existing `LoadingEllipsis`).
- The loading changes deliberately follow the established inline pattern rather than route-level `loading.tsx` / SWR Suspense, which don't fit client-fetched SWR data.

## Has This Been Tested?

- [x] Affected settings/profile pages: heading paints immediately, only the section shows the loading state
- [x] Settings forms still submit and populate correctly
- [x] System page renders immediately; Disk Space loads in its own section
- [x] Disk Space populates correctly (root + subfolders; warning on partial/failed paths)
- [x] Verified both the `du` path and the forced-fallback path produce sensible totals

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
