### PR TITLE
feat(sort): add sort direction toggle to all sortable lists

### DIFF
--- a/server/routes/invite.ts
+++ b/server/routes/invite.ts
@@ -51,6 +51,9 @@ inviteRoutes.get<Record<string, string>, InviteResultsResponse>(
         sortFilter = 'invite.createdAt';
     }
 
+    const sortDirection: 'ASC' | 'DESC' =
+      req.query.sortDirection === 'asc' ? 'ASC' : 'DESC';
+
     let statusFilter: InviteStatus[];
 
     switch (req.query.filter) {
@@ -130,7 +133,7 @@ inviteRoutes.get<Record<string, string>, InviteResultsResponse>(
     }
 
     const [invites, inviteCount] = await query
-      .orderBy(sortFilter, 'DESC')
+      .orderBy(sortFilter, sortDirection)
       .take(pageSize)
       .skip(skip)
       .getManyAndCount();

--- a/server/routes/notification.ts
+++ b/server/routes/notification.ts
@@ -36,6 +36,9 @@ notificationRoutes.get<Record<string, string>, NotificationResultsResponse>(
         sortFilter = 'notification.createdAt';
     }
 
+    const sortDirection: 'ASC' | 'DESC' =
+      req.query.sortDirection === 'asc' ? 'ASC' : 'DESC';
+
     let typeFilter: NotificationType[];
 
     switch (req.query.type) {
@@ -90,7 +93,7 @@ notificationRoutes.get<Record<string, string>, NotificationResultsResponse>(
     }
 
     const [notifications, notificationCount] = await query
-      .orderBy(sortFilter, 'DESC')
+      .orderBy(sortFilter, sortDirection)
       .take(pageSize)
       .skip(skip)
       .getManyAndCount();

--- a/server/routes/settings/newsletter.ts
+++ b/server/routes/settings/newsletter.ts
@@ -254,7 +254,8 @@ newsletterRoutes.get<Record<string, string>, NewsletterResultsResponse>(
           ? req.query.sort
           : 'modified';
       const sortColumn = SORT_COLUMNS[sortKey];
-      const sortDirection: 'ASC' | 'DESC' = sortKey === 'name' ? 'ASC' : 'DESC';
+      const sortDirection: 'ASC' | 'DESC' =
+        req.query.sortDirection === 'asc' ? 'ASC' : 'DESC';
 
       const query = getRepository(Newsletter)
         .createQueryBuilder('newsletter')

--- a/server/routes/user/index.ts
+++ b/server/routes/user/index.ts
@@ -58,9 +58,12 @@ router.get('/', async (req, res, next) => {
       .leftJoinAndSelect('user.redeemedInvite', 'redeemedInvite')
       .leftJoinAndSelect('redeemedInvite.createdBy', 'invitedBy');
 
+    const sortDirection: 'ASC' | 'DESC' =
+      req.query.sortDirection === 'asc' ? 'ASC' : 'DESC';
+
     switch (req.query.sort) {
       case 'updated':
-        query = query.orderBy('user.updatedAt', 'DESC');
+        query = query.orderBy('user.updatedAt', sortDirection);
         break;
       case 'displayname':
         query = query
@@ -68,7 +71,7 @@ router.get('/', async (req, res, next) => {
             "CASE WHEN (user.username IS NULL OR user.username = '') THEN CASE WHEN (user.plexUsername IS NULL OR user.plexUsername = '') THEN LOWER(user.email) ELSE LOWER(user.plexUsername) END ELSE LOWER(user.username) END",
             'displayNameSort'
           )
-          .orderBy('displayNameSort', 'ASC');
+          .orderBy('displayNameSort', sortDirection);
         break;
       case 'invites':
         query = query
@@ -78,10 +81,10 @@ router.get('/', async (req, res, next) => {
               .from(Invite, 'invite')
               .where('invite.createdBy.id = user.id');
           }, 'inviteCount')
-          .orderBy('inviteCount', 'DESC');
+          .orderBy('inviteCount', sortDirection);
         break;
       default:
-        query = query.orderBy('user.id', 'ASC');
+        query = query.orderBy('user.id', sortDirection);
         break;
     }
 
@@ -988,6 +991,19 @@ router.get<{ id: string }, UserNotificationsResponse>(
           break;
       }
 
+      let sortFilter: string;
+
+      switch (req.query.sort) {
+        case 'modified':
+          sortFilter = 'notification.updatedAt';
+          break;
+        default:
+          sortFilter = 'notification.createdAt';
+      }
+
+      const sortDirection: 'ASC' | 'DESC' =
+        req.query.sortDirection === 'asc' ? 'ASC' : 'DESC';
+
       const [notifications, notificationCount] = await getRepository(
         Notification
       )
@@ -999,7 +1015,7 @@ router.get<{ id: string }, UserNotificationsResponse>(
         .andWhere('notification.isRead IN (:...isRead)', {
           isRead: isReadFilter,
         })
-        .orderBy('notification.createdAt', 'DESC')
+        .orderBy(sortFilter, sortDirection)
         .take(pageSize)
         .skip(skip)
         .getManyAndCount();

--- a/src/components/Admin/Settings/Newsletters/index.tsx
+++ b/src/components/Admin/Settings/Newsletters/index.tsx
@@ -12,6 +12,7 @@ import { momentWithLocale as moment } from '@app/utils/momentLocale';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import {
   BarsArrowDownIcon,
+  BarsArrowUpIcon,
   BeakerIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -39,6 +40,7 @@ enum Filter {
 }
 
 type Sort = 'created' | 'modified' | 'name';
+type SortDirection = 'asc' | 'desc';
 
 const FILTER_SETTINGS_KEY = 'newsletters-filter-settings';
 
@@ -67,6 +69,10 @@ const Newsletters = () => {
   const [currentSort, setCurrentSort] = useState<Sort>(
     () => readFilterSettings()?.currentSort || 'modified'
   );
+  const [currentSortDirection, setCurrentSortDirection] =
+    useState<SortDirection>(
+      () => readFilterSettings()?.currentSortDirection || 'desc'
+    );
   const [currentPageSize, setCurrentPageSize] = useState<number>(
     () => readFilterSettings()?.currentPageSize || 10
   );
@@ -86,14 +92,17 @@ const Newsletters = () => {
   const { data, error, mutate } = useSWR<NewsletterResultsResponse>(
     `/api/v1/settings/newsletter?take=${currentPageSize}&skip=${
       pageIndex * currentPageSize
-    }&filter=${currentFilter}&sort=${currentSort}`
+    }&filter=${currentFilter}&sort=${currentSort}&sortDirection=${currentSortDirection}`
   );
 
   // Allow filter/sort to be driven by query params, keeping state in sync.
   const queryFilter = searchParams.get('filter') as Filter;
   const querySort = searchParams.get('sort') as Sort;
+  const querySortDirection = searchParams.get('sortDirection') as SortDirection;
   const [prevQueryFilter, setPrevQueryFilter] = useState(queryFilter);
   const [prevQuerySort, setPrevQuerySort] = useState(querySort);
+  const [prevQuerySortDirection, setPrevQuerySortDirection] =
+    useState(querySortDirection);
   if (prevQueryFilter !== queryFilter) {
     setPrevQueryFilter(queryFilter);
     if (Object.values(Filter).includes(queryFilter)) {
@@ -106,14 +115,25 @@ const Newsletters = () => {
       setCurrentSort(querySort);
     }
   }
+  if (prevQuerySortDirection !== querySortDirection) {
+    setPrevQuerySortDirection(querySortDirection);
+    if (['asc', 'desc'].includes(querySortDirection)) {
+      setCurrentSortDirection(querySortDirection);
+    }
+  }
 
   // Persist the filter/sort/page-size selections.
   useEffect(() => {
     window.localStorage.setItem(
       FILTER_SETTINGS_KEY,
-      JSON.stringify({ currentFilter, currentSort, currentPageSize })
+      JSON.stringify({
+        currentFilter,
+        currentSort,
+        currentSortDirection,
+        currentPageSize,
+      })
     );
-  }, [currentFilter, currentSort, currentPageSize]);
+  }, [currentFilter, currentSort, currentSortDirection, currentPageSize]);
 
   const [editState, setEditState] = useState<{
     open: boolean;
@@ -293,9 +313,31 @@ const Newsletters = () => {
             </select>
           </div>
           <div className="mb-2 flex grow sm:mr-2 sm:mb-0 md:grow-0">
-            <span className="border-primary bg-base-100 inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 sm:text-sm">
-              <BarsArrowDownIcon className="h-6 w-6" />
-            </span>
+            <button
+              type="button"
+              data-testid="newsletter-sort-direction-toggle"
+              aria-label={intl.formatMessage({
+                id: 'common.toggleSortDirection',
+                defaultMessage: 'Toggle sort direction',
+              })}
+              title={intl.formatMessage({
+                id: 'common.toggleSortDirection',
+                defaultMessage: 'Toggle sort direction',
+              })}
+              onClick={() => {
+                setCurrentSortDirection((prev) =>
+                  prev === 'asc' ? 'desc' : 'asc'
+                );
+                updateQueryParams('page', '1');
+              }}
+              className="border-primary bg-base-100 hover:bg-base-200 inline-flex cursor-pointer items-center rounded-l-md border border-r-0 px-3 transition-colors sm:text-sm"
+            >
+              {currentSortDirection === 'asc' ? (
+                <BarsArrowUpIcon className="h-6 w-6" />
+              ) : (
+                <BarsArrowDownIcon className="h-6 w-6" />
+              )}
+            </button>
             <select
               id="sort"
               name="sort"

--- a/src/components/Admin/Users/index.tsx
+++ b/src/components/Admin/Users/index.tsx
@@ -18,6 +18,7 @@ import { Permission, UserType, useUser } from '@app/hooks/useUser';
 import { momentWithLocale as moment } from '@app/utils/momentLocale';
 import {
   BarsArrowDownIcon,
+  BarsArrowUpIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   InboxArrowDownIcon,
@@ -42,9 +43,11 @@ import validator from 'validator';
 import * as Yup from 'yup';
 
 type Sort = 'created' | 'updated' | 'invites' | 'displayname';
+type SortDirection = 'asc' | 'desc';
 
 const getStoredUserFilterSettings = (): {
   currentSort?: Sort;
+  currentSortDirection?: SortDirection;
   currentPageSize?: number;
 } => {
   if (typeof window === 'undefined') return {};
@@ -66,6 +69,10 @@ const AdminUsers = () => {
   const [currentSort, setCurrentSort] = useState<Sort>(
     () => getStoredUserFilterSettings().currentSort ?? 'displayname'
   );
+  const [currentSortDirection, setCurrentSortDirection] =
+    useState<SortDirection>(
+      () => getStoredUserFilterSettings().currentSortDirection ?? 'desc'
+    );
   const [currentPageSize, setCurrentPageSize] = useState<number>(
     () => getStoredUserFilterSettings().currentPageSize ?? 10
   );
@@ -90,7 +97,7 @@ const AdminUsers = () => {
   } = useSWR<UserResultsResponse>(
     `/api/v1/user?take=${currentPageSize}&skip=${
       pageIndex * currentPageSize
-    }&sort=${currentSort}`
+    }&sort=${currentSort}&sortDirection=${currentSortDirection}`
   );
 
   const [isDeleting, setDeleting] = useState(false);
@@ -114,10 +121,11 @@ const AdminUsers = () => {
       'ul-filter-settings',
       JSON.stringify({
         currentSort,
+        currentSortDirection,
         currentPageSize,
       })
     );
-  }, [currentSort, currentPageSize]);
+  }, [currentSort, currentSortDirection, currentPageSize]);
 
   const isUserPermsEditable = (userId: number) =>
     userId !== 1 && userId !== currentUser?.id;
@@ -526,9 +534,31 @@ const AdminUsers = () => {
             )}
           </div>
           <div className="mb-2 flex grow lg:mb-0 lg:grow-0">
-            <span className="border-primary bg-base-100 inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 sm:text-sm">
-              <BarsArrowDownIcon className="size-7" />
-            </span>
+            <button
+              type="button"
+              data-testid="user-sort-direction-toggle"
+              aria-label={intl.formatMessage({
+                id: 'common.toggleSortDirection',
+                defaultMessage: 'Toggle sort direction',
+              })}
+              title={intl.formatMessage({
+                id: 'common.toggleSortDirection',
+                defaultMessage: 'Toggle sort direction',
+              })}
+              onClick={() => {
+                setCurrentSortDirection((prev) =>
+                  prev === 'asc' ? 'desc' : 'asc'
+                );
+                router.push(pathname);
+              }}
+              className="border-primary bg-base-100 hover:bg-base-200 inline-flex cursor-pointer items-center rounded-l-md border border-r-0 px-3 transition-colors sm:text-sm"
+            >
+              {currentSortDirection === 'asc' ? (
+                <BarsArrowUpIcon className="size-7" />
+              ) : (
+                <BarsArrowDownIcon className="size-7" />
+              )}
+            </button>
             <select
               id="sort"
               name="sort"

--- a/src/components/InviteList/index.tsx
+++ b/src/components/InviteList/index.tsx
@@ -13,6 +13,7 @@ import { useUser } from '@app/hooks/useUser';
 import { momentWithLocale } from '@app/utils/momentLocale';
 import {
   BarsArrowDownIcon,
+  BarsArrowUpIcon,
   CheckBadgeIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -44,6 +45,7 @@ enum Filter {
 }
 
 type Sort = 'created' | 'modified';
+type SortDirection = 'asc' | 'desc';
 
 const InviteList = () => {
   useRouteGuard(
@@ -106,6 +108,19 @@ const InviteList = () => {
     }
     return 'created';
   });
+  const [currentSortDirection, setCurrentSortDirection] =
+    useState<SortDirection>(() => {
+      if (typeof window !== 'undefined') {
+        const filterString = window.localStorage.getItem(
+          'invites-filter-settings'
+        );
+        if (filterString) {
+          const filterSettings = JSON.parse(filterString);
+          return filterSettings.currentSortDirection || 'desc';
+        }
+      }
+      return 'desc';
+    });
   const [currentPageSize, setCurrentPageSize] = useState<number>(() => {
     if (typeof window !== 'undefined') {
       const filterString = window.localStorage.getItem(
@@ -140,7 +155,7 @@ const InviteList = () => {
   } = useSWR<InviteResultsResponse>(
     `/api/v1/invite?take=${currentPageSize}&skip=${
       pageIndex * currentPageSize
-    }&filter=${currentFilter}&sort=${currentSort}${
+    }&filter=${currentFilter}&sort=${currentSort}&sortDirection=${currentSortDirection}${
       pathname.startsWith('/profile')
         ? `&createdBy=${currentUser?.id}`
         : userQuery?.userid
@@ -192,8 +207,11 @@ const InviteList = () => {
   // Override with query params if provided, keeping in sync as the URL changes
   const queryFilter = searchParams.get('filter') as Filter;
   const querySort = searchParams.get('sort') as Sort;
+  const querySortDirection = searchParams.get('sortDirection') as SortDirection;
   const [prevQueryFilter, setPrevQueryFilter] = useState(queryFilter);
   const [prevQuerySort, setPrevQuerySort] = useState(querySort);
+  const [prevQuerySortDirection, setPrevQuerySortDirection] =
+    useState(querySortDirection);
   if (prevQueryFilter !== queryFilter) {
     setPrevQueryFilter(queryFilter);
     if (Object.values(Filter).includes(queryFilter)) {
@@ -206,6 +224,12 @@ const InviteList = () => {
       setCurrentSort(querySort);
     }
   }
+  if (prevQuerySortDirection !== querySortDirection) {
+    setPrevQuerySortDirection(querySortDirection);
+    if (['asc', 'desc'].includes(querySortDirection)) {
+      setCurrentSortDirection(querySortDirection);
+    }
+  }
 
   // Set filter values to local storage any time they are changed
   useEffect(() => {
@@ -214,10 +238,11 @@ const InviteList = () => {
       JSON.stringify({
         currentFilter,
         currentSort,
+        currentSortDirection,
         currentPageSize,
       })
     );
-  }, [currentFilter, currentSort, currentPageSize]);
+  }, [currentFilter, currentSort, currentSortDirection, currentPageSize]);
 
   if (isLoading && !error) {
     return <LoadingEllipsis />;
@@ -356,9 +381,30 @@ const InviteList = () => {
               </select>
             </div>
             <div className="mb-2 flex grow sm:mr-2 sm:mb-0 lg:grow-0">
-              <span className="border-primary bg-base-100 inline-flex cursor-default items-center rounded-l-md border border-r-0 px-3 sm:text-sm">
-                <BarsArrowDownIcon className="h-6 w-6" />
-              </span>
+              <button
+                type="button"
+                data-testid="invite-sort-direction-toggle"
+                aria-label={intl.formatMessage({
+                  id: 'common.toggleSortDirection',
+                  defaultMessage: 'Toggle sort direction',
+                })}
+                title={intl.formatMessage({
+                  id: 'common.toggleSortDirection',
+                  defaultMessage: 'Toggle sort direction',
+                })}
+                onClick={() =>
+                  setCurrentSortDirection((prev) =>
+                    prev === 'asc' ? 'desc' : 'asc'
+                  )
+                }
+                className="border-primary bg-base-100 hover:bg-base-200 inline-flex cursor-pointer items-center rounded-l-md border border-r-0 px-3 transition-colors sm:text-sm"
+              >
+                {currentSortDirection === 'asc' ? (
+                  <BarsArrowUpIcon className="h-6 w-6" />
+                ) : (
+                  <BarsArrowDownIcon className="h-6 w-6" />
+                )}
+              </button>
               <select
                 id="sort"
                 name="sort"

--- a/src/components/NotificationList/index.tsx
+++ b/src/components/NotificationList/index.tsx
@@ -9,6 +9,8 @@ import Toast from '@app/components/Toast';
 import { useNotifications } from '@app/hooks/useNotifications';
 import { Permission, useUser } from '@app/hooks/useUser';
 import {
+  BarsArrowDownIcon,
+  BarsArrowUpIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   FunnelIcon,
@@ -34,8 +36,13 @@ enum Filter {
   UNREAD = 'unread',
 }
 
+type Sort = 'created' | 'modified';
+type SortDirection = 'asc' | 'desc';
+
 const getStoredNotificationFilterSettings = (): {
   currentFilter?: Filter;
+  currentSort?: Sort;
+  currentSortDirection?: SortDirection;
   currentPageSize?: number;
 } => {
   if (typeof window === 'undefined') return {};
@@ -69,6 +76,13 @@ const NotificationsList = () => {
     if (Object.values(Filter).includes(queryFilter)) return queryFilter;
     return getStoredNotificationFilterSettings().currentFilter ?? Filter.ALL;
   });
+  const [currentSort, setCurrentSort] = useState<Sort>(
+    () => getStoredNotificationFilterSettings().currentSort ?? 'created'
+  );
+  const [currentSortDirection, setCurrentSortDirection] =
+    useState<SortDirection>(
+      () => getStoredNotificationFilterSettings().currentSortDirection ?? 'desc'
+    );
   const [currentPageSize, setCurrentPageSize] = useState<number>(
     () => getStoredNotificationFilterSettings().currentPageSize ?? 10
   );
@@ -99,7 +113,7 @@ const NotificationsList = () => {
         ))
       ? `/api/v1/user/${user?.id}/notifications?take=${currentPageSize}&skip=${
           pageIndex * currentPageSize
-        }&filter=${currentFilter}`
+        }&filter=${currentFilter}&sort=${currentSort}&sortDirection=${currentSortDirection}`
       : null
   );
   const [editNotificationModal, setEditNotificationModal] = useState<{
@@ -125,10 +139,12 @@ const NotificationsList = () => {
       'nl-filter-settings',
       JSON.stringify({
         currentFilter,
+        currentSort,
+        currentSortDirection,
         currentPageSize,
       })
     );
-  }, [currentFilter, currentPageSize]);
+  }, [currentFilter, currentSort, currentSortDirection, currentPageSize]);
 
   const hasNextPage = (data?.pageInfo.pages ?? 0) > pageIndex + 1;
   const hasPrevPage = pageIndex > 0;
@@ -220,6 +236,48 @@ const NotificationsList = () => {
               </option>
               <option value="read">
                 <FormattedMessage id="common.read" defaultMessage="read" />
+              </option>
+            </select>
+          </div>
+          <div className="mb-2 flex grow sm:mr-2 sm:mb-0 lg:grow-0">
+            <button
+              type="button"
+              data-testid="notification-sort-direction-toggle"
+              aria-label={intl.formatMessage({
+                id: 'common.toggleSortDirection',
+                defaultMessage: 'Toggle sort direction',
+              })}
+              title={intl.formatMessage({
+                id: 'common.toggleSortDirection',
+                defaultMessage: 'Toggle sort direction',
+              })}
+              onClick={() =>
+                setCurrentSortDirection((prev) =>
+                  prev === 'asc' ? 'desc' : 'asc'
+                )
+              }
+              className="border-primary bg-base-100 hover:bg-base-200 inline-flex cursor-pointer items-center rounded-l-md border border-r-0 px-3 transition-colors sm:text-sm"
+            >
+              {currentSortDirection === 'asc' ? (
+                <BarsArrowUpIcon className="h-6 w-6" />
+              ) : (
+                <BarsArrowDownIcon className="h-6 w-6" />
+              )}
+            </button>
+            <select
+              id="sort"
+              name="sort"
+              value={currentSort}
+              onChange={(e) => {
+                setCurrentSort(e.target.value as Sort);
+              }}
+              className="select select-sm select-primary w-full flex-1 rounded-l-none"
+            >
+              <option value="created">
+                {intl.formatMessage({
+                  id: 'notification.sortMostRecent',
+                  defaultMessage: 'Most Recent',
+                })}
               </option>
             </select>
           </div>

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -773,6 +773,9 @@
   "common.title": {
     "defaultMessage": "Title"
   },
+  "common.toggleSortDirection": {
+    "defaultMessage": "Toggle sort direction"
+  },
   "common.transcodes": {
     "defaultMessage": "Transcodes"
   },
@@ -4252,6 +4255,9 @@
   },
   "notification.signUpDisabledMessage": {
     "defaultMessage": "The admin has currently disabled in-app notifications."
+  },
+  "notification.sortMostRecent": {
+    "defaultMessage": "Most Recent"
   },
   "notification.userCreated": {
     "defaultMessage": "User Created"

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -5790,6 +5790,13 @@ paths:
             type: string
             enum: [created, updated, invites, displayname]
             default: created
+        - in: query
+          name: sortDirection
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort direction (ascending or descending)
       responses:
         '200':
           description: A JSON array of all users
@@ -6161,6 +6168,19 @@ paths:
             type: string
             nullable: true
             enum: [all, read, unread]
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum: [created, modified]
+            default: created
+        - in: query
+          name: sortDirection
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort direction (ascending or descending)
       responses:
         '200':
           description: User's notifications returned
@@ -7729,6 +7749,13 @@ paths:
             enum: [created, modified]
             default: created
         - in: query
+          name: sortDirection
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort direction (ascending or descending)
+        - in: query
           name: createdBy
           schema:
             type: number
@@ -7965,6 +7992,13 @@ paths:
             enum: [created, modified]
             default: created
         - in: query
+          name: sortDirection
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort direction (ascending or descending)
+        - in: query
           name: createdBy
           schema:
             type: number
@@ -8077,6 +8111,13 @@ paths:
             nullable: true
             enum: [created, modified, name]
             default: modified
+        - in: query
+          name: sortDirection
+          schema:
+            type: string
+            enum: [asc, desc]
+            default: desc
+          description: Sort direction (ascending or descending)
       responses:
         '200':
           description: A list of newsletters


### PR DESCRIPTION
## Description
Building on the existing sort select boxes, the sort icon is now an interactive button that toggles between ascending (`BarsArrowUpIcon`) and descending (`BarsArrowDownIcon`), letting every list with a sort filter control its direction. Direction reuses the same `sortDirection` contract already used by the downloads list (`enum: [asc, desc]`, default `desc`), so the hardcoded per-field ASC/DESC forcing on the user and newsletter endpoints is replaced by the user-driven value. The notifications list, which previously had no sort control, gains both a sort select and the direction toggle.

- Fixes #514

## Has This Been Tested?

- [x] Invites change and save sort direction
- [x] Notifications sort behaviour is respected
- [x] User list sort direction updates and save correctly
- [x] Newsletter sort direction respected and saved

## Screenshots (if applicable)
<img width="179" height="58" alt="image" src="https://github.com/user-attachments/assets/3719cdd0-3379-4227-8fbf-9167ab5dd34b" />
<img width="180" height="54" alt="image" src="https://github.com/user-attachments/assets/8cd4a6da-13de-4d90-8fa9-d0f8d9db851c" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
