### PR TITLE
perf(auth): resolve index and protected-route redirects server-side

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,9 +9,10 @@ import NotificationProvider from '@app/context/NotificationContext';
 import { NotificationSidebarProvider } from '@app/context/NotificationSidebarContext';
 import { SettingsProvider } from '@app/context/SettingsContext';
 import { UserContext } from '@app/context/UserContext';
-import type { User } from '@app/hooks/useUser';
-import { getPublicSettings } from '@app/utils/serverFetchHelpers';
-import { cookies } from 'next/headers';
+import {
+  getPublicSettings,
+  getServerUser,
+} from '@app/utils/serverFetchHelpers';
 import NextTopLoader from 'nextjs-toploader';
 import type { ReactNode } from 'react';
 import { Toaster } from 'react-hot-toast';
@@ -23,34 +24,14 @@ export default async function RootLayout({
   children: ReactNode;
 }) {
   const currentSettings = await getPublicSettings();
-
-  let user: User | undefined = undefined;
-  try {
-    const cookieStore = await cookies();
-    const cookieHeader = cookieStore
-      .getAll()
-      .map((c) => `${c.name}=${c.value}`)
-      .join('; ');
-    const res = await fetch(
-      `http://${process.env.HOST || 'localhost'}:${
-        process.env.PORT || 3000
-      }/api/v1/auth/me`,
-      {
-        headers: { cookie: cookieHeader || undefined },
-      }
-    );
-    if (res.ok) {
-      user = await res.json();
-    }
-  } catch {
-    // ignore
-  }
+  const user = await getServerUser();
 
   const initialized = currentSettings.initialized;
 
   return (
     <html lang="en-CA" className="scroll-smooth" data-theme="streamarr">
       <head>
+        <link rel="preconnect" href="https://image.tmdb.org" />
         <PWAHeader applicationTitle={currentSettings.applicationTitle} />
       </head>
       <body

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,19 @@
 import Index from '@app/components/Index';
-import { generatePageMetadata } from '@app/utils/serverFetchHelpers';
-import type { NextPage } from 'next';
+import {
+  generatePageMetadata,
+  getServerUser,
+} from '@app/utils/serverFetchHelpers';
+import { redirect } from 'next/navigation';
 
 export const generateMetadata = () =>
   generatePageMetadata('Stream the greatest Movies, Shows, Classics and more');
 
-const IndexPage: NextPage = () => {
+const IndexPage = async () => {
+  const user = await getServerUser();
+  if (user) {
+    redirect(user.active ? '/watch' : '/profile');
+  }
+
   return <Index />;
 };
 

--- a/src/components/Common/ImageFader/index.tsx
+++ b/src/components/Common/ImageFader/index.tsx
@@ -64,6 +64,8 @@ const ImageFader: ForwardRefRenderFunction<HTMLDivElement, ImageFaderProps> = (
             alt=""
             src={imageUrl}
             fill
+            loading={i === 0 ? 'eager' : 'lazy'}
+            fetchPriority={i === 0 ? 'high' : 'auto'}
             {...overrides}
           />
           <div

--- a/src/components/Help/Devices/Header/index.tsx
+++ b/src/components/Help/Devices/Header/index.tsx
@@ -20,12 +20,12 @@ const Header = () => {
           gradient="bg-gradient-to-t from-brand-dark/90 to-brand-light/70"
           backgroundImages={
             backdrops?.map(
-              (backdrop) => `https://image.tmdb.org/t/p/original${backdrop}`
+              (backdrop) => `https://image.tmdb.org/t/p/w1280${backdrop}`
             ) ?? ['/img/people-cinema-watching.jpg']
           }
         />
       </div>
-      <div className="relative container mx-auto max-w-screen-lg py-14">
+      <div className="relative container mx-auto max-w-5xl py-14">
         <p className="mx-7 text-center text-3xl font-extrabold text-white md:mx-14 md:text-5xl">
           <FormattedMessage
             id="help.devices.headerTitle"

--- a/src/components/Help/Devices/index.tsx
+++ b/src/components/Help/Devices/index.tsx
@@ -264,7 +264,7 @@ const DeviceTabs = () => {
           gradient="backdrop-blur-xl bg-black/70"
           backgroundImages={
             backdrops?.map(
-              (backdrop) => `https://image.tmdb.org/t/p/original${backdrop}`
+              (backdrop) => `https://image.tmdb.org/t/p/w1280${backdrop}`
             ) ?? ['/img/people-cinema-watching.jpg']
           }
         />
@@ -272,7 +272,7 @@ const DeviceTabs = () => {
           return (
             <div
               key={i}
-              className={`relative mx-auto flex max-w-screen-xl flex-wrap px-5 text-white ${activeTab === `tab-${i}` ? 'block' : 'hidden'}`}
+              className={`relative mx-auto flex max-w-7xl flex-wrap px-5 text-white ${activeTab === `tab-${i}` ? 'block' : 'hidden'}`}
             >
               <div className="container mx-auto mt-6 max-w-screen-sm px-4 md:grow md:max-lg:w-1/2">
                 <p className="border-primary border-s-2 py-2 ps-6 text-2xl leading-6 text-white uppercase">

--- a/src/components/Help/Header/index.tsx
+++ b/src/components/Help/Header/index.tsx
@@ -23,7 +23,7 @@ const HelpHeader = () => {
           gradient="bg-gradient-to-t from-brand-dark/90 to-brand-light/70"
           backgroundImages={
             backdrops?.map(
-              (backdrop) => `https://image.tmdb.org/t/p/original${backdrop}`
+              (backdrop) => `https://image.tmdb.org/t/p/w1280${backdrop}`
             ) ?? ['/img/people-cinema-watching.jpg']
           }
         />
@@ -32,7 +32,7 @@ const HelpHeader = () => {
             <LanguagePicker />
           </div>
         )}
-        <div className="z-0 container mx-auto h-44 max-w-screen-xl content-center">
+        <div className="z-0 container mx-auto h-44 max-w-7xl content-center">
           <h2 className="my-4 text-center text-3xl font-extrabold text-white">
             <FormattedMessage
               id="help.helpCentre"

--- a/src/components/Index/Hero/index.tsx
+++ b/src/components/Index/Hero/index.tsx
@@ -39,7 +39,7 @@ export default function Hero() {
         rotationSpeed={6000}
         backgroundImages={
           backdrops?.map(
-            (backdrop) => `https://image.tmdb.org/t/p/original${backdrop}`
+            (backdrop) => `https://image.tmdb.org/t/p/w1280${backdrop}`
           ) ?? ['/img/people-cinema-watching.jpg']
         }
       />
@@ -54,7 +54,7 @@ export default function Hero() {
             width={448}
             height={100}
             unoptimized={true}
-            className="mx-auto mt-5 mb-10 h-auto w-[448px] px-5 md:mx-0 md:px-0"
+            className="mx-auto mt-5 mb-10 h-auto w-md px-5 md:mx-0 md:px-0"
           />
           <h1 className="mb-2 text-xl font-extrabold md:text-3xl">
             <FormattedMessage

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -276,7 +276,7 @@ const FaderBackground = () => {
           rotationSpeed={6000}
           backgroundImages={
             backdrops?.map(
-              (backdrop) => `https://image.tmdb.org/t/p/original${backdrop}`
+              (backdrop) => `https://image.tmdb.org/t/p/w1280${backdrop}`
             ) ?? ['/img/people-cinema-watching.jpg']
           }
         />

--- a/src/components/Setup/index.tsx
+++ b/src/components/Setup/index.tsx
@@ -101,7 +101,7 @@ const Setup = () => {
         rotationSpeed={6000}
         backgroundImages={
           backdrops?.map(
-            (backdrop) => `https://image.tmdb.org/t/p/original${backdrop}`
+            (backdrop) => `https://image.tmdb.org/t/p/w1280${backdrop}`
           ) ?? ['/img/people-cinema-watching.jpg']
         }
       />

--- a/src/components/UserProfile/ProfileLayout.tsx
+++ b/src/components/UserProfile/ProfileLayout.tsx
@@ -32,12 +32,12 @@ const ProfileLayout = ({ children }: { children: React.ReactNode }) => {
       ...new Set(
         watchData?.results
           .filter((r) => r.backdropPath)
-          .map((r) => `https://image.tmdb.org/t/p/original${r.backdropPath}`)
+          .map((r) => `https://image.tmdb.org/t/p/w1280${r.backdropPath}`)
       ),
     ];
     if (watchBackdrops.length) return watchBackdrops;
     return (
-      backdrops?.map((b) => `https://image.tmdb.org/t/p/original${b}`) ?? [
+      backdrops?.map((b) => `https://image.tmdb.org/t/p/w1280${b}`) ?? [
         '/img/people-cinema-watching.jpg',
       ]
     );

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,6 +5,8 @@ export const SETUP_REGEX = /\/(setup|signin\/plex\/loading)/;
 export const publicRoutes =
   /(\/|signin(\/plex\/loading)?|signup|resetpassword\/?(.*)?|setup|signin(\/plex\/loading)?|help\/?(.*)?)$/;
 
+const SESSION_COOKIE = 'streamarr.sid';
+
 export function proxy(req: NextRequest) {
   const pathname = req.nextUrl.pathname;
 
@@ -19,6 +21,15 @@ export function proxy(req: NextRequest) {
     pathname.startsWith('/external')
   ) {
     return NextResponse.next();
+  }
+
+  // Public routes are reachable without a session.
+  if (publicRoutes.test(pathname)) {
+    return NextResponse.next();
+  }
+
+  if (!req.cookies.get(SESSION_COOKIE)) {
+    return NextResponse.redirect(new URL('/signin', req.url));
   }
 
   return NextResponse.next();

--- a/src/utils/serverFetchHelpers.ts
+++ b/src/utils/serverFetchHelpers.ts
@@ -1,31 +1,67 @@
+import type { User } from '@app/hooks/useUser';
 import type { PublicSettingsResponse } from '@server/interfaces/api/settingsInterfaces';
 import type { Metadata } from 'next';
+import { cookies } from 'next/headers';
+import { cache } from 'react';
 
 const DEFAULT_TITLE = 'Streamarr';
 const MAX_RETRIES = 2;
 const RETRY_DELAY = 500;
 
-export async function getPublicSettings(): Promise<PublicSettingsResponse> {
-  const url = `http://${process.env.HOST || 'localhost'}:${
-    process.env.PORT || 3000
-  }/api/v1/settings/public`;
+export const getPublicSettings = cache(
+  async (): Promise<PublicSettingsResponse> => {
+    const url = `http://${process.env.HOST || 'localhost'}:${
+      process.env.PORT || 3000
+    }/api/v1/settings/public`;
 
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    try {
-      const res = await fetch(url, { cache: 'no-store' });
-      if (res.ok) return await res.json();
-    } catch {
-      // fetch failed — retry unless exhausted
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      try {
+        const res = await fetch(url, { cache: 'no-store' });
+        if (res.ok) return await res.json();
+      } catch {
+        // fetch failed — retry unless exhausted
+      }
+      if (attempt < MAX_RETRIES) {
+        await new Promise((r) => setTimeout(r, RETRY_DELAY));
+      }
     }
-    if (attempt < MAX_RETRIES) {
-      await new Promise((r) => setTimeout(r, RETRY_DELAY));
-    }
+
+    return {
+      applicationTitle: DEFAULT_TITLE,
+    } as PublicSettingsResponse;
   }
+);
 
-  return {
-    applicationTitle: DEFAULT_TITLE,
-  } as PublicSettingsResponse;
-}
+/**
+ * Resolves the current user server-side from the request session cookie via
+ * the internal /auth/me endpoint. Wrapped in React `cache` so the layout,
+ * page-level redirect gate, and metadata all share a single request-scoped
+ * fetch. Returns undefined for unauthenticated or failed lookups.
+ */
+export const getServerUser = cache(async (): Promise<User | undefined> => {
+  try {
+    const cookieStore = await cookies();
+    const cookieHeader = cookieStore
+      .getAll()
+      .map((c) => `${c.name}=${c.value}`)
+      .join('; ');
+    const res = await fetch(
+      `http://${process.env.HOST || 'localhost'}:${
+        process.env.PORT || 3000
+      }/api/v1/auth/me`,
+      {
+        headers: cookieHeader ? { cookie: cookieHeader } : undefined,
+        cache: 'no-store',
+      }
+    );
+    if (res.ok) {
+      return (await res.json()) as User;
+    }
+  } catch {
+    // ignore — treated as unauthenticated
+  }
+  return undefined;
+});
 
 export async function generatePageMetadata(prefix: string): Promise<Metadata> {
   const settings = await getPublicSettings();


### PR DESCRIPTION
## Description
Authenticated users hitting `/` were served the full marketing landing page (Hero, backdrop slider, library counts) client-side, then redirected to `/watch` on hydration — the visible fallback-image → API-images → loading → watch flash on slow connections. The session is already resolved server-side in the root layout, but the decision was deferred to the client. This hoists the auth-based routing to the server boundary and trims the landing render cost.

- Authed users are redirected (`/watch`, or `/profile` when `!active`) from `page.tsx` during RSC execution, before `<Index />` renders or streams.
- Logged-out deep-links to protected routes redirect to `/signin` in `proxy.ts` on session-cookie absence, before any protected shell renders. Cookie presence is not validation — authoritative session/`active` checks remain in `getServerUser()` and the client `Layout` as defense in depth.
- `getServerUser()` and `getPublicSettings()` are wrapped in React `cache()`, collapsing the previous 2–3 per-request self-fetches into one each.
- Landing/auth backdrops load `w1280` instead of `original` (all eight fader sites), the first fader image uses `loading="eager"`/`fetchPriority="high"` and a `preconnect` to `image.tmdb.org` is added.

## Has This Been Tested?

- [x] Authed / → server 307 to /watch; expired → /profile; no marketing paint or backdrop fetch.
- [x] Logged-out /watch, /profile, /admin → /signin; /, /signin, /signup, /help/*, /setup reachable logged-out.
- [x] Stale/invalid streamarr.sid on a protected route → proxy passes, getServerUser/Layout bounce to /signin (no loop).
- [x] Verified proxy.ts is picked up as the Next 16 proxy (no proxyDir set) and the /signin redirect fires in the dev request log.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
