### PR TITLE
feat(auth): harden sign-in session handling and tighten socket CORS

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -174,10 +174,6 @@ app
     server.use('/api', sessionMiddleware);
     const httpServer = createServer(server);
     const io = new SocketIOServer(httpServer, {
-      cors: {
-        origin: '*',
-        methods: ['GET', 'POST'],
-      },
       destroyUpgrade: false,
     });
     io.engine.use(sessionMiddleware);

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -269,15 +269,18 @@ authRoutes.post('/plex', plexAuthLimiter, async (req, res, next) => {
       }
     }
 
-    // Set logged in session
-    if (req.session) {
-      req.session.userId = user.id;
-    }
+    // Regenerate the session ID on sign-in to prevent session fixation, then
+    // let express-session persist the new session on response end.
+    const authedUser = user;
+    await new Promise<void>((resolve, reject) =>
+      req.session.regenerate((e) => (e ? reject(e) : resolve()))
+    );
+    req.session.userId = authedUser.id;
 
     // Silently provision a per-user Plex JWT device (experimental, non-fatal)
-    void maybeProvisionPlexJwt(user.id, authToken);
+    void maybeProvisionPlexJwt(authedUser.id, authToken);
 
-    res.status(200).json(user?.filter() ?? {});
+    res.status(200).json(authedUser.filter());
   } catch (e) {
     logger.error('Something went wrong authenticating with Plex account', {
       label: 'API',
@@ -388,12 +391,15 @@ authRoutes.post('/local', async (req, res, next) => {
       }
     }
 
-    // Set logged in session
-    if (user && req.session) {
-      req.session.userId = user.id;
-    }
+    // Regenerate the session ID on sign-in to prevent session fixation; let
+    // express-session persist it on response end.
+    const authedUser = user;
+    await new Promise<void>((resolve, reject) =>
+      req.session.regenerate((e) => (e ? reject(e) : resolve()))
+    );
+    req.session.userId = authedUser.id;
 
-    res.status(200).json(user?.filter() ?? {});
+    res.status(200).json(authedUser.filter());
   } catch (e) {
     logger.error(
       'Something went wrong authenticating with Streamarr password',
@@ -420,7 +426,7 @@ authRoutes.post('/logout', (req, res, next) => {
     res.clearCookie('streamarr.sid', {
       httpOnly: true,
       sameSite: settings.network.csrfProtection ? 'strict' : 'lax',
-      secure: process.env.NODE_ENV === 'production',
+      secure: req.secure,
     });
     res.status(200).json({ status: 'ok' });
   });


### PR DESCRIPTION
## Description
Auth-mechanics hardening.

- Session fixation: `/auth/plex` and `/auth/local` previously set `req.session.userId` on the pre-existing session. They now `regenerate()` the session (fresh ID) before associating the user and emit the login response inside `session.save()`, so the authenticated session can't be ridden with an identifier a client held before sign-in.
- Cookie-flag consistency: logout cleared `streamarr.sid` with `secure: NODE_ENV === 'production'`, mismatching the session cookie's secure: `'auto'`. It now uses `secure: req.secure`, mirroring how the cookie was actually set (both resolve identically via `trust proxy`), so it clears reliably behind a proxy.
- socket.io CORS: removed `origin: '*'`. The browser client connects same-origin, so socket.io's same-origin default is correct and removes a cross-site-WebSocket-hijacking surface against the session-authenticated socket.

## Has This Been Tested?

- [x] Plex and local sign-in issue a new session ID (cookie value changes pre- vs post-login); authenticated requests succeed immediately after (session persisted before response).
- [x] Logout clears the cookie over both plain HTTP and HTTPS-behind-proxy.
- [x] Socket notifications (`newNotification`) still connect and deliver same-origin; cross-origin handshake is rejected.

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
