### PR TITLE
fix(layout): move client-side redirects out of render and logout errors

### DIFF
--- a/src/app/logout/page.tsx
+++ b/src/app/logout/page.tsx
@@ -11,28 +11,23 @@ const LogOutPage = () => {
   const router = useRouter();
   const intl = useIntl();
 
-  const clearPlexToken = () => {
-    try {
-      localStorage.removeItem('myPlexAccessToken');
-    } catch {
-      // fail silently
-    }
-  };
-
-  const logout = async () => {
-    clearPlexToken();
-    const response = await axios.post('/api/v1/auth/logout');
-
-    if (response.data?.status === 'ok') {
-      revalidate().then(() => {
-        router.push('/');
-      });
-    }
-  };
-
   useEffect(() => {
+    const logout = async () => {
+      try {
+        localStorage.removeItem('myPlexAccessToken');
+      } catch {
+        // fail silently
+      }
+
+      const response = await axios.post('/api/v1/auth/logout');
+
+      if (response.data?.status === 'ok') {
+        revalidate(undefined, false);
+      }
+    };
+
     logout();
-  });
+  }, [revalidate, router]);
 
   return (
     <LoadingEllipsis

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -17,7 +17,7 @@ import type {
   UserSettingsNotificationsResponse,
 } from '@server/interfaces/api/userSettingsInterfaces';
 import axios from 'axios';
-import { redirect, usePathname, useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef } from 'react';
 import { useIntl } from 'react-intl';
 import useSWR, { SWRConfig } from 'swr';
@@ -30,6 +30,7 @@ const Layout = ({
   initialized: boolean;
 }) => {
   const pathname = usePathname();
+  const router = useRouter();
   const { user, loading } = useUser();
   const { currentSettings } = useSettings();
   const tokenRef = useRef(false);
@@ -123,33 +124,33 @@ const Layout = ({
     }
   }, [user, loading]);
 
-  if (!initialized) {
-    if (!pathname.match(/setup|signin\/plex\/loading/)) {
-      redirect('/setup');
+  const redirectTarget = useMemo(() => {
+    if (!initialized) {
+      return pathname.match(/setup|signin\/plex\/loading/) ? null : '/setup';
     }
-  } else {
+
     // Redirect from setup to admin after completion
     if (pathname.match(/^\/setup$/) && user) {
-      redirect('/admin');
+      return '/admin';
     }
 
     // Protected routes require authentication
     if (!publicRoutes.test(pathname) && !user && !loading) {
-      redirect('/signin');
+      return '/signin';
     }
 
     // Authenticated users on signin/home go to watch
     if (pathname.match(/(signin|\/$)/) && user && !loading) {
-      redirect(isExpiredUser ? '/profile' : '/watch');
+      return isExpiredUser ? '/profile' : '/watch';
     }
 
     // Signup disabled redirect
     if (pathname.match(/signup/) && !currentSettings.enableSignUp) {
-      redirect('/signin');
+      return '/signin';
     }
 
     if (pathname.match(/^\/help(\/|$)/) && !currentSettings.enableHelpCentre) {
-      redirect('/');
+      return '/';
     }
 
     // Feature-disabled redirects
@@ -161,8 +162,30 @@ const Layout = ({
       ((pathname.match(/schedule/) && !userSettings.releaseSched) ||
         (pathname.match(/request/) && !userSettings.requestUrl))
     ) {
-      redirect('/watch');
+      return '/watch';
     }
+
+    return null;
+  }, [
+    initialized,
+    pathname,
+    user,
+    loading,
+    currentSettings.enableSignUp,
+    currentSettings.enableHelpCentre,
+    userSettings,
+    userSettingsLoading,
+    isExpiredUser,
+  ]);
+
+  useEffect(() => {
+    if (redirectTarget && redirectTarget !== pathname) {
+      router.replace(redirectTarget);
+    }
+  }, [redirectTarget, pathname, router]);
+
+  if (redirectTarget && redirectTarget !== pathname) {
+    return null;
   }
 
   return (


### PR DESCRIPTION
## Description
Fixes a runtime crash ("Rendered more hooks than during previous render") that occurred whenever an authenticated user manually navigated to `/`, and an unhandled promise rejection on logout.

**Root cause:** `Layout` called `redirect()` from `next/navigation` directly in its render body, gated by async state (`user`, `loading`,
`userSettings`) from SWR. Because that state only resolves on a render *after* the first, the `NEXT_REDIRECT` throw happened on a later render pass than usual, which desynced React's hook bookkeeping inside Next's internal Router. Navigating straight to `/watch` never hit this path (no redirect condition was ever true), which is why the bug only showed up on `/`.

**Fix:** compute the desired redirect as a plain memoized `redirectTarget` value and perform the actual navigation in a
`useEffect` via `router.replace()` — the same pattern already used by `useRouteGuard`. The component returns `null` while a redirect is pending so protected content doesn't flash before navigating away.

**Logout:** after destroying the session, the page called `revalidate()` with no arguments, which re-fetches `/api/v1/auth/me` — now `401` since the cookie is gone — and `axios` throws. `revalidate().then(...)` had no `.catch()`, so this surfaced as an uncaught error. Switched to `revalidate(undefined, false)`, which writes the cleared user straight into the SWR cache without a network round-trip (matches the existing `revalidate(data, false)` convention used in `SignIn`/`LocalSignIn`). Layout's redirect guard then takes the now-signed-out user to `/signin` automatically.

## Has This Been Tested?

- [x] Authenticate successfully
- [x] Logout successfully
- [x] Signed-in user navigating directly to `/` redirects to `/watch` (or `/profile` if expired) without the hook-count crash
- [x] Logging out no longer throws an uncaught error and lands on `/signin`
- [x] Cookies and Auth functionality remain working

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
