### PR TITLE
feat(notifications): add retention settings for in-app notifications

### DIFF
--- a/server/job/schedule.ts
+++ b/server/job/schedule.ts
@@ -3,7 +3,6 @@ import expiredInvites from '@server/lib/expiredInvites';
 import ImageProxy from '@server/lib/imageproxy';
 import { plexAccess } from '@server/lib/plexAccessLost';
 import refreshToken from '@server/lib/refreshToken';
-import { plexFullScanner } from '@server/lib/scanners/plex';
 import type { JobId } from '@server/lib/settings';
 import { getSettings } from '@server/lib/settings';
 import trialExpiry from '@server/lib/trialExpiry';
@@ -25,23 +24,6 @@ export const scheduledJobs: ScheduledJob[] = [];
 
 export const startJobs = (): void => {
   const jobs = getSettings().jobs;
-
-  // Run full plex scan every 24 hours
-  scheduledJobs.push({
-    id: 'plex-full-scan',
-    name: 'Plex Full Library Scan',
-    type: 'process',
-    interval: 'hours',
-    cronSchedule: jobs['plex-full-scan'].schedule,
-    job: schedule.scheduleJob(jobs['plex-full-scan'].schedule, () => {
-      logger.info('Starting scheduled job: Plex Full Library Scan', {
-        label: 'Jobs',
-      });
-      plexFullScanner.run();
-    }),
-    running: () => plexFullScanner.status().running,
-    cancelFn: () => plexFullScanner.cancel(),
-  });
 
   // Run image cache cleanup every 24 hours
   scheduledJobs.push({
@@ -100,6 +82,18 @@ export const startJobs = (): void => {
     interval: 'hours',
     cronSchedule: jobs['notification-cleanup']?.schedule,
     job: schedule.scheduleJob(jobs['notification-cleanup']?.schedule, () => {
+      const settings = getSettings().notifications.agents.inApp.options;
+      const retentionLimit = Number(settings.retentionLimit);
+
+      if (!Number.isFinite(retentionLimit) || retentionLimit <= 0) {
+        logger.info(
+          'Notification retention is set to forever (0), skipping notification cleanup job.',
+          {
+            label: 'Jobs',
+          }
+        );
+        return;
+      }
       logger.info('Starting scheduled job: Notification Cleanup', {
         label: 'Jobs',
       });

--- a/server/lib/cleanUpNotifications.ts
+++ b/server/lib/cleanUpNotifications.ts
@@ -1,5 +1,6 @@
 import { getRepository } from '@server/datasource';
 import Notification from '@server/entity/Notification';
+import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
 import { LessThan } from 'typeorm';
 
@@ -29,8 +30,36 @@ class CleanUpNotifications {
 
     const notificationRepository = getRepository(Notification);
     const cutoffDate = new Date();
+    const settings = getSettings().notifications.agents.inApp.options;
+
+    const retentionLimit = Number(settings.retentionLimit);
+    const retentionTime = settings.retentionTime ?? 'years';
+
+    if (!Number.isFinite(retentionLimit) || retentionLimit <= 0) {
+      cutoffDate.setTime(0);
+    } else {
+      switch (retentionTime) {
+        case 'days':
+          cutoffDate.setDate(cutoffDate.getDate() - retentionLimit);
+          break;
+        case 'weeks':
+          cutoffDate.setDate(cutoffDate.getDate() - retentionLimit * 7);
+          break;
+        case 'months':
+          cutoffDate.setMonth(cutoffDate.getMonth() - retentionLimit);
+          break;
+        case 'years':
+          cutoffDate.setFullYear(cutoffDate.getFullYear() - retentionLimit);
+          break;
+        default:
+          logger.warn(
+            `Unknown notification retentionTime "${String(settings.retentionTime)}"; defaulting to years.`,
+            { label: 'Jobs' }
+          );
+          cutoffDate.setFullYear(cutoffDate.getFullYear() - retentionLimit);
+      }
+    }
     let deletedCount = 0;
-    cutoffDate.setFullYear(cutoffDate.getFullYear() - 1); // Notifications older than 1 year
 
     try {
       if (!this.isRunning) {

--- a/server/lib/settings.ts
+++ b/server/lib/settings.ts
@@ -307,6 +307,13 @@ export interface NotificationAgentNtfy extends NotificationAgentConfig {
   };
 }
 
+export interface NotificationAgentInApp extends NotificationAgentConfig {
+  options: {
+    retentionLimit: number;
+    retentionTime?: 'days' | 'weeks' | 'months' | 'years';
+  };
+}
+
 export enum NotificationAgentKey {
   DISCORD = 'discord',
   EMAIL = 'email',
@@ -332,7 +339,7 @@ export interface NotificationAgents {
   telegram: NotificationAgentTelegram;
   webhook: NotificationAgentWebhook;
   webpush: NotificationAgentConfig;
-  inApp: NotificationAgentConfig;
+  inApp: NotificationAgentInApp;
 }
 
 interface NotificationSettings {
@@ -590,7 +597,13 @@ class Settings {
             },
           },
           webpush: { enabled: false, options: {} },
-          inApp: { enabled: true, options: {} },
+          inApp: {
+            enabled: true,
+            options: {
+              retentionLimit: 1,
+              retentionTime: 'years',
+            },
+          },
         },
       },
       jobs: {

--- a/src/components/Admin/Settings/Notifications/InAppNotifications/index.tsx
+++ b/src/components/Admin/Settings/Notifications/InAppNotifications/index.tsx
@@ -30,13 +30,18 @@ const InAppNotifications = () => {
   return (
     <Formik
       initialValues={{
-        enabled: data?.enabled,
+        enabled: data?.enabled ?? false,
+        retentionLimit: data?.options?.retentionLimit ?? 1,
+        retentionTime: data?.options?.retentionTime ?? 'years',
       }}
       onSubmit={async (values) => {
         try {
           await axios.post('/api/v1/settings/notifications/inapp', {
             enabled: values.enabled,
-            options: {},
+            options: {
+              retentionLimit: values.retentionLimit,
+              retentionTime: values.retentionTime,
+            },
           });
           mutate('/api/v1/settings/public');
           Toast({
@@ -62,7 +67,7 @@ const InAppNotifications = () => {
         }
       }}
     >
-      {({ isSubmitting }) => {
+      {({ isSubmitting, values, setFieldValue }) => {
         const testSettings = async () => {
           setIsTesting(true);
           let toastId: string | undefined;
@@ -101,22 +106,110 @@ const InAppNotifications = () => {
         };
         return (
           <Form className="mt-5">
-            <div className="max-w-5xl max-sm:space-y-4 max-sm:space-y-reverse sm:grid sm:grid-cols-3 sm:items-center sm:gap-4">
-              <label htmlFor="preset">
-                <FormattedMessage
-                  id="notifications.enableAgent"
-                  defaultMessage="Enable Agent"
-                />
-                <span className="text-error ml-1">*</span>
-              </label>
-              <div className="sm:col-span-2">
-                <div className="flex">
-                  <Field
-                    type="checkbox"
-                    id="enabled"
-                    name="enabled"
-                    className="checkbox checkbox-sm checkbox-primary rounded-md"
+            <div className="max-w-5xl space-y-4">
+              <div className="space-y-4 sm:grid sm:grid-cols-3 sm:items-center">
+                <label htmlFor="enabled">
+                  <FormattedMessage
+                    id="notifications.enableAgent"
+                    defaultMessage="Enable Agent"
                   />
+                </label>
+                <div className="mt-2 sm:col-span-2 sm:mt-0">
+                  <div className="flex">
+                    <Field
+                      type="checkbox"
+                      id="enabled"
+                      name="enabled"
+                      className="checkbox checkbox-sm checkbox-primary rounded-md"
+                    />
+                  </div>
+                </div>
+                <label htmlFor="retentionAge">
+                  <FormattedMessage
+                    id="notifications.retentionAge"
+                    defaultMessage="Retention Age"
+                  />
+                  <span className="text-error ml-1">*</span>
+                  <span className="text-neutral block text-sm">
+                    <FormattedMessage
+                      id="inAppNotifications.retentionAgeDescription"
+                      defaultMessage="The maximum age of in-app notifications before they are automatically deleted."
+                    />
+                  </span>
+                </label>
+                <div className="mt-2 sm:col-span-2 sm:mt-0">
+                  <div className="flex">
+                    <div className="col-span-2 space-x-2">
+                      <Field
+                        as="select"
+                        name="retentionLimit"
+                        id="retentionLimit"
+                        className="select select-sm select-primary w-auto min-w-20 shrink-0 rounded-md"
+                        onChange={(e) =>
+                          setFieldValue(
+                            'retentionLimit',
+                            Number(e.target.value)
+                          )
+                        }
+                      >
+                        <option id={`retention-forever`} value={0}>
+                          <FormattedMessage
+                            id="common.forever"
+                            defaultMessage="Forever"
+                          />
+                        </option>
+                        {[...Array(100)].map((_item, i) => (
+                          <option
+                            id={`retention-${i + 1}`}
+                            value={i + 1}
+                            key={`$retention-${i + 1}`}
+                          >
+                            {i + 1}
+                          </option>
+                        ))}
+                      </Field>
+                      {values.retentionLimit > 0 && (
+                        <Field
+                          as="select"
+                          name="retentionTime"
+                          id="retentionTime"
+                          className="select select-sm select-primary w-auto min-w-20 shrink-0 rounded-md"
+                          onChange={(e) =>
+                            setFieldValue('retentionTime', e.target.value)
+                          }
+                        >
+                          <option id={`retention-days`} value={'days'}>
+                            <FormattedMessage
+                              id="common.day"
+                              defaultMessage="{count, plural, one {Day} other {Days}}"
+                              values={{ count: values.retentionLimit }}
+                            />
+                          </option>
+                          <option id={`retention-weeks`} value={'weeks'}>
+                            <FormattedMessage
+                              id="common.week"
+                              defaultMessage="{count, plural, one {Week} other {Weeks}}"
+                              values={{ count: values.retentionLimit }}
+                            />
+                          </option>
+                          <option id={`retention-months`} value={'months'}>
+                            <FormattedMessage
+                              id="common.month"
+                              defaultMessage="{count, plural, one {Month} other {Months}}"
+                              values={{ count: values.retentionLimit }}
+                            />
+                          </option>
+                          <option id={`retention-years`} value={'years'}>
+                            <FormattedMessage
+                              id="common.year"
+                              defaultMessage="{count, plural, one {Year} other {Years}}"
+                              values={{ count: values.retentionLimit }}
+                            />
+                          </option>
+                        </Field>
+                      )}
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -332,6 +332,9 @@
   "common.date": {
     "defaultMessage": "Date"
   },
+  "common.day": {
+    "defaultMessage": "{count, plural, one {Day} other {Days}}"
+  },
   "common.days": {
     "defaultMessage": "{count, plural, one {# day} other {# days}}"
   },
@@ -419,6 +422,9 @@
   "common.finish": {
     "defaultMessage": "Finish"
   },
+  "common.forever": {
+    "defaultMessage": "Forever"
+  },
   "common.futuredays": {
     "defaultMessage": "Future Days"
   },
@@ -496,6 +502,9 @@
   },
   "common.message": {
     "defaultMessage": "Message"
+  },
+  "common.month": {
+    "defaultMessage": "{count, plural, one {Month} other {Months}}"
   },
   "common.movies": {
     "defaultMessage": "Movies"
@@ -847,6 +856,12 @@
   },
   "common.webPush": {
     "defaultMessage": "Web Push"
+  },
+  "common.week": {
+    "defaultMessage": "{count, plural, one {Week} other {Weeks}}"
+  },
+  "common.year": {
+    "defaultMessage": "{count, plural, one {Year} other {Years}}"
   },
   "confirmAccount.disableWebPush": {
     "defaultMessage": "Disable Web Push"
@@ -3329,6 +3344,9 @@
   "imageUpload.uploading": {
     "defaultMessage": "Uploading…"
   },
+  "inAppNotifications.retentionAgeDescription": {
+    "defaultMessage": "The maximum age of in-app notifications before they are automatically deleted."
+  },
   "inAppNotifications.saveError": {
     "defaultMessage": "In App notification settings failed to save."
   },
@@ -4498,6 +4516,9 @@
   },
   "notifications.pushover.userKeyRequired": {
     "defaultMessage": "You must provide your Pushover user key"
+  },
+  "notifications.retentionAge": {
+    "defaultMessage": "Retention Age"
   },
   "notifications.slack.webhookUrlRequired": {
     "defaultMessage": "You must provide a valid Slack webhook URL"

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -2035,6 +2035,16 @@ components:
         types:
           type: number
           example: 2
+        options:
+          type: object
+          properties:
+            retentionLimit:
+              type: number
+              example: 1
+            retentionTime:
+              type: string
+              enum: [days, weeks, months, years]
+              example: 'years'
     RestartStatus:
       type: object
       properties:


### PR DESCRIPTION
## Description
This pull request adds customizable retention settings for in-app notifications, allowing admins to control how long notifications are kept before automatic deletion. The changes include both backend logic and frontend UI updates to support these new options.

**In-app notification retention settings:**
- Added new `retentionLimit` and `retentionTime` options to the in-app notification settings, allowing configuration of how long notifications are retained (in days, weeks, months, or years). The backend cleanup logic now uses these settings to determine which notifications to delete. [[1]](diffhunk://#diff-520bb25d3321468eb99f5cc0cd44754a1ab93a5502c4d373a3f1477f1d020d96R310-R316) [[2]](diffhunk://#diff-520bb25d3321468eb99f5cc0cd44754a1ab93a5502c4d373a3f1477f1d020d96L335-R342) [[3]](diffhunk://#diff-520bb25d3321468eb99f5cc0cd44754a1ab93a5502c4d373a3f1477f1d020d96L593-R606) [[4]](diffhunk://#diff-4ce936cac6e9066abf7d35a183bb448caa86432922e4721986c09387693a61d9R3) [[5]](diffhunk://#diff-4ce936cac6e9066abf7d35a183bb448caa86432922e4721986c09387693a61d9R33-L33)
- The scheduled notification cleanup job now skips execution if retention is set to "forever" (i.e., limit is 0).

**Frontend/UI updates:**
- The admin notification settings page now includes UI controls for selecting the retention period and unit, with appropriate labels and descriptions. These values are submitted to the backend when settings are saved. [[1]](diffhunk://#diff-e80d165d6b6f746200f9d29b5bce692e40b2cad1aa5ad8634bf2d499f105e549R34-R44) [[2]](diffhunk://#diff-e80d165d6b6f746200f9d29b5bce692e40b2cad1aa5ad8634bf2d499f105e549L65-R70) [[3]](diffhunk://#diff-e80d165d6b6f746200f9d29b5bce692e40b2cad1aa5ad8634bf2d499f105e549L104-R117) [[4]](diffhunk://#diff-e80d165d6b6f746200f9d29b5bce692e40b2cad1aa5ad8634bf2d499f105e549R127-R214)

**Localization:**
- Added new i18n strings for retention age, time units (day, week, month, year), and the "forever" option, along with a description for the retention setting. [[1]](diffhunk://#diff-44dad73c083519cc1ee6cc31426a9c033cfd8ed9080b6ac8403bea720d807c72R335-R337) [[2]](diffhunk://#diff-44dad73c083519cc1ee6cc31426a9c033cfd8ed9080b6ac8403bea720d807c72R425-R427) [[3]](diffhunk://#diff-44dad73c083519cc1ee6cc31426a9c033cfd8ed9080b6ac8403bea720d807c72R506-R508) [[4]](diffhunk://#diff-44dad73c083519cc1ee6cc31426a9c033cfd8ed9080b6ac8403bea720d807c72R860-R865) [[5]](diffhunk://#diff-44dad73c083519cc1ee6cc31426a9c033cfd8ed9080b6ac8403bea720d807c72R3347-R3349) [[6]](diffhunk://#diff-44dad73c083519cc1ee6cc31426a9c033cfd8ed9080b6ac8403bea720d807c72R4520-R4522)

**Other changes:**
- Removed the scheduled Plex full library scan job from the job scheduler. [[1]](diffhunk://#diff-4a36f41fe9feab73af5159b5e2604cb6ac81539f72bd94d5916cfa883da30a21L6) [[2]](diffhunk://#diff-4a36f41fe9feab73af5159b5e2604cb6ac81539f72bd94d5916cfa883da30a21L29-L45)

**Related Issues**
- Closes #554 
- Closes #555 

## Has This Been Tested?

- [x] Retention settings correctly save
- [x] Retention settings correctly validate
- [x] Retention period is respected

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
