### PR TITLE
fix(newsletter): add loading state for newsletter preview

### DIFF
--- a/src/components/Admin/Settings/Newsletters/NewsletterModal.tsx
+++ b/src/components/Admin/Settings/Newsletters/NewsletterModal.tsx
@@ -93,6 +93,7 @@ const NewsletterModal = ({
   const { locale } = useLocale();
   const bodyRef = useRef<HTMLTextAreaElement | null>(null);
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
 
   useEffect(() => {
     registerDatePickerLocale(locale);
@@ -436,6 +437,7 @@ const NewsletterModal = ({
         }
 
         const previewNewsletter = async () => {
+          setPreviewLoading(true);
           try {
             const response = await axios.post(
               '/api/v1/settings/newsletter/preview',
@@ -455,6 +457,8 @@ const NewsletterModal = ({
               type: 'error',
               icon: <XCircleIcon className="size-7" />,
             });
+          } finally {
+            setPreviewLoading(false);
           }
         };
 
@@ -503,10 +507,18 @@ const NewsletterModal = ({
               onOk={() => handleSubmit()}
               okDisabled={isSubmitting || !isValid}
               secondaryButtonType="default"
-              secondaryText={intl.formatMessage({
-                id: 'common.preview',
-                defaultMessage: 'Preview',
-              })}
+              secondaryDisabled={previewLoading || isSubmitting}
+              secondaryText={
+                previewLoading
+                  ? intl.formatMessage({
+                      id: 'common.previewLoading',
+                      defaultMessage: 'Loading…',
+                    })
+                  : intl.formatMessage({
+                      id: 'common.preview',
+                      defaultMessage: 'Preview',
+                    })
+              }
               onSecondary={() => previewNewsletter()}
               title={
                 newsletter

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -590,6 +590,9 @@
   "common.preview": {
     "defaultMessage": "Preview"
   },
+  "common.previewLoading": {
+    "defaultMessage": "Loading…"
+  },
   "common.previous": {
     "defaultMessage": "Previous"
   },


### PR DESCRIPTION
## Description
This pull request improves the user experience in the `NewsletterModal` component by adding a loading state to the newsletter preview functionality. Now, when users request a preview, the preview button is disabled and displays a loading message until the preview is ready.

**Newsletter preview loading state:**

* Added a `previewLoading` state to manage the loading status during newsletter preview requests.
* Set `previewLoading` to `true` when the preview is requested and reset it to `false` after completion, ensuring the loading state is accurately reflected even if an error occurs. [[1]](diffhunk://#diff-23191ca416c8148b3e875211a022b3ea0ffe14abed281879f79aa6be29d70f1fR440) [[2]](diffhunk://#diff-23191ca416c8148b3e875211a022b3ea0ffe14abed281879f79aa6be29d70f1fR460-R461)
* Disabled the preview button and updated its text to show a loading message while the preview is being generated.

- Fixes #557 

## Has This Been Tested?

- [x] Selecting preview correctly indicates a loading state

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
