### PR TITLE
fix(disk-space): calculate and display root path correctly in docker

### DIFF
--- a/src/components/Admin/Settings/System/DiskSpace/index.tsx
+++ b/src/components/Admin/Settings/System/DiskSpace/index.tsx
@@ -137,7 +137,17 @@ const DiskSpace = ({ appDataPath }: DiskSpaceProps) => {
     });
   }, []);
 
-  const { rootDiskItem, diskRows } = useMemo(() => {
+  const { rootDiskItem, diskRows, rootPath } = useMemo(() => {
+    const calculateRootPath = (
+      appDataPath: string,
+      mountPoint?: string
+    ): string => {
+      if (mountPoint === '/') return '/';
+      if (appDataPath === '/') return '/';
+      const parts = appDataPath.split('/').filter(Boolean);
+      return '/' + parts.slice(0, -1).join('/');
+    };
+
     const appDataDirLabel =
       appDataNorm === '/'
         ? '/'
@@ -147,6 +157,8 @@ const DiskSpace = ({ appDataPath }: DiskSpaceProps) => {
       diskSpaceItems.find((d) => normalizePath(d.path) === appDataNorm) ?? null;
     const appDataUsedBytes = appDataItem?.pathUsedBytes ?? 0;
     const rootDiskItem = appDataItem ?? diskSpaceItems[0] ?? null;
+
+    const rootPath = calculateRootPath(appDataNorm, rootDiskItem?.mountPoint);
 
     const diskRows = diskSpaceItems.map((disk) => {
       const path = normalizePath(disk.path);
@@ -193,7 +205,7 @@ const DiskSpace = ({ appDataPath }: DiskSpaceProps) => {
       };
     });
 
-    return { rootDiskItem, diskRows };
+    return { rootDiskItem, diskRows, rootPath };
   }, [diskSpaceItems, appDataNorm]);
 
   const childCountByParent = useMemo(() => {
@@ -285,7 +297,7 @@ const DiskSpace = ({ appDataPath }: DiskSpaceProps) => {
                       onToggle={() => toggleRow(ROOT_NODE_KEY)}
                     />
                     <span className="min-w-0 truncate font-mono">
-                      {rootDiskItem.mountPoint}
+                      {rootPath}
                     </span>
                   </span>
                 </div>


### PR DESCRIPTION
## Description
This pull request refactors the way the root disk path is displayed in the DiskSpace component by introducing a new calculation for the root path. The main change is to show a more accurate root path instead of the raw mount point.

**Disk path display improvements:**

* Added a `calculateRootPath` function to determine the root path based on `appDataPath` and the mount point, ensuring the displayed path is accurate and user-friendly.
* Updated the `useMemo` return value to include the newly calculated `rootPath`. [[1]](diffhunk://#diff-1d24e3c2554533b9dd5c3eea89f1f2ae1a0607e6df07d65e6af02f36736f6950R161-R162) [[2]](diffhunk://#diff-1d24e3c2554533b9dd5c3eea89f1f2ae1a0607e6df07d65e6af02f36736f6950L196-R208)
* Changed the rendered value in the UI from `rootDiskItem.mountPoint` to `rootPath` for the root disk row.

**Related Issues**
- Fixes #553 

## Has This Been Tested?

- [x] Correctly displayed root in bare metal
- [x] Correctly displayed root in docker w/ mount

## Screenshots (if applicable)
<img width="850" height="283" alt="image" src="https://github.com/user-attachments/assets/440aef3e-6368-45ef-b6ce-bae8e8b1b2a4" />

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
