### PR TITLE
fix(cache): fix undefined logo merge and cap TMDB image TTL

### DIFF
--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -23,6 +23,8 @@ const baseCacheDirectory = process.env.CONFIG_DIRECTORY
   ? `${process.env.CONFIG_DIRECTORY}/cache/images`
   : path.join(__dirname, '../../config/cache/images');
 
+const TMDB_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
 class ImageProxy {
   private static isRunning = false;
 
@@ -110,11 +112,17 @@ class ImageProxy {
             return;
           }
 
-          const [, expireAtSt] = imageFile.split('.');
+          const [maxAgeSt, expireAtSt] = imageFile.split('.');
+          const maxAge = Number(maxAgeSt);
           const expireAt = Number(expireAtSt);
           const now = Date.now();
 
-          if (now > expireAt) {
+          const cappedExpireAt =
+            key === 'tmdb' && maxAge > TMDB_MAX_AGE_SECONDS
+              ? expireAt - (maxAge - TMDB_MAX_AGE_SECONDS) * 1000
+              : expireAt;
+
+          if (now > cappedExpireAt) {
             await promises.rm(path.join(filePath, imageFile));
             deletedImages += 1;
           }
@@ -310,7 +318,10 @@ class ImageProxy {
         (response.headers['cache-control'] as string | undefined) ?? ''
       ).match(/max-age=(\d+)/);
       const parsedMaxAge = Number(maxAgeMatch?.[1]);
-      const maxAge = parsedMaxAge > 0 ? parsedMaxAge : this.defaultMaxAge;
+      let maxAge = parsedMaxAge > 0 ? parsedMaxAge : this.defaultMaxAge;
+      if (this.key === 'tmdb' && maxAge > TMDB_MAX_AGE_SECONDS) {
+        maxAge = TMDB_MAX_AGE_SECONDS;
+      }
       const expireAt = Date.now() + maxAge * 1000;
       const etag = (response.headers.etag ?? '').replace(/"/g, '');
 

--- a/server/lib/logoUpload.ts
+++ b/server/lib/logoUpload.ts
@@ -77,7 +77,7 @@ class LogoUpload {
         fs.unlinkSync(filePath);
       }
 
-      settings.main = { ...settings.main, customLogo: undefined };
+      settings.main = { ...settings.main, customLogo: null };
     } else if (type === 'logoSmall' && settings.main.customLogoSmall) {
       const urlPath = settings.main.customLogoSmall.split('?')[0];
       const filename = path.basename(urlPath);
@@ -87,7 +87,7 @@ class LogoUpload {
         fs.unlinkSync(filePath);
       }
 
-      settings.main = { ...settings.main, customLogoSmall: undefined };
+      settings.main = { ...settings.main, customLogoSmall: null };
     }
 
     settings.save();

--- a/src/components/Layout/DynamicLogo/index.tsx
+++ b/src/components/Layout/DynamicLogo/index.tsx
@@ -16,7 +16,7 @@ const DynamicLogo = () => {
         width={190}
         height={35}
         unoptimized
-        className="h-[45px] w-[190px] object-contain object-left max-md:hidden"
+        className="h-11.25 w-47.5 object-contain object-left max-md:hidden"
       />
       <Image
         src={logoSmallSrc}
@@ -24,7 +24,7 @@ const DynamicLogo = () => {
         width={45}
         height={45}
         unoptimized
-        className="h-[45px] w-[45px] object-contain object-left md:hidden"
+        className="h-11.25 w-11.25 object-contain object-left md:hidden"
       />
     </>
   );


### PR DESCRIPTION
## Description
This pull request introduces several improvements and fixes related to image caching, logo upload handling, and UI consistency. The main changes include capping the cache duration for TMDB images, standardizing the removal of custom logos in settings, and updating logo component sizing for consistency.

**Image caching improvements:**

* Added a maximum cache age (`TMDB_MAX_AGE_SECONDS`, set to 30 days) for TMDB images to prevent excessively long caching, both when storing new images and when cleaning up expired images. (`[[1]](diffhunk://#diff-44f21bf50857c0d524084b42214f4cc4e3a1c58c87ee3c0bd2b553826dea9670R26-R27)`, `[[2]](diffhunk://#diff-44f21bf50857c0d524084b42214f4cc4e3a1c58c87ee3c0bd2b553826dea9670L113-R125)`, `[[3]](diffhunk://#diff-44f21bf50857c0d524084b42214f4cc4e3a1c58c87ee3c0bd2b553826dea9670L313-R324)`)

**Logo upload and settings handling:**

* Changed the removal of custom logos in `server/lib/logoUpload.ts` to set `customLogo` and `customLogoSmall` to `null` instead of `undefined` for consistency in settings state. (`[[1]](diffhunk://#diff-f01cac105cbe587e9ce96615d6e3c0e7dd0c3a943540995d0e58663383da3d73L80-R80)`, `[[2]](diffhunk://#diff-f01cac105cbe587e9ce96615d6e3c0e7dd0c3a943540995d0e58663383da3d73L90-R90)`)

**UI consistency:**

* Updated the CSS classes for logo image sizes in `DynamicLogo` to use consistent units (`h-11.25`, `w-47.5`, etc.), improving visual alignment across breakpoints. (`[src/components/Layout/DynamicLogo/index.tsxL19-R27](diffhunk://#diff-35f9e5c7f521757926b80196f7745efe18d6f1834c1130dc93b518d775d7e979L19-R27)`)

**Related Issues**
- Fixes #552 
- Fixes #558 

## Has This Been Tested?

- [x] Uploading custom logo functions correctly
- [x] Deleting a custom logo functions correctly
- [x] TMDB images are now cached for 1 month -
- [x] TMDB images already cached with old 1 year expiry are cleaned to 1 month as well

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
