### PR TITLE
build(changelog): add effect property to changelog types

### DIFF
--- a/package.json
+++ b/package.json
@@ -214,43 +214,53 @@
             "types": [
               {
                 "type": "feat",
-                "section": "✨ Features"
+                "section": "✨ Features",
+                "effect": "bump"
               },
               {
                 "type": "fix",
-                "section": "🐛 Bug Fixes"
+                "section": "🐛 Bug Fixes",
+                "effect": "bump"
               },
               {
                 "type": "perf",
-                "section": "⚡ Performance"
+                "section": "⚡ Performance",
+                "effect": "bump"
               },
               {
                 "type": "revert",
-                "section": "⏪ Reverts"
+                "section": "⏪ Reverts",
+                "effect": "bump"
               },
               {
                 "type": "docs",
-                "section": "📚 Documentation"
+                "section": "📚 Documentation",
+                "effect": "changelog"
               },
               {
                 "type": "style",
-                "section": "💎 Styles"
+                "section": "💎 Styles",
+                "effect": "changelog"
               },
               {
                 "type": "refactor",
-                "section": "♻️ Refactoring"
+                "section": "♻️ Refactoring",
+                "effect": "changelog"
               },
               {
                 "type": "test",
-                "section": "🧪 Tests"
+                "section": "🧪 Tests",
+                "effect": "changelog"
               },
               {
                 "type": "build",
-                "section": "📦 Build System"
+                "section": "📦 Build System",
+                "effect": "changelog"
               },
               {
                 "type": "ci",
-                "section": "🤖 CI/CD"
+                "section": "🤖 CI/CD",
+                "effect": "changelog"
               },
               {
                 "type": "chore",


### PR DESCRIPTION
## Description
This pull request updates the commit type configuration in `package.json` to add an `effect` property for each type, which specifies how each commit type should impact versioning or changelog generation. It also adds support for the `feature` type as an alias for `feat`.

Configuration changes for commit types:

* Added an `effect` property to each commit type configuration, specifying either `bump` (for version bumps) or `changelog` (for changelog-only changes).
* Added a new `feature` type as an alias for `feat`, with the same section and effect.

## Has This Been Tested?

N/A

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
