### PR TITLE
style: remove padding to GuideTab for mobile and LiveTVViewPage

### DIFF
--- a/public/watch.css
+++ b/public/watch.css
@@ -215,6 +215,9 @@ svg {
     background-image: var(--logo-sm-url);
     width: 45px;
   }
+  [class*="GuideTab-container-"] {
+    padding: 20px 0 0;
+  }
 }
 @media (max-width: 452px) {
   [class*="PageHeaderLeft-pageHeaderLeft-"], [class*="PageHeaderRight-pageHeaderRight-"] {
@@ -360,11 +363,6 @@ svg {
 @media (max-width: 390px) {
   [class*="DirectoryListJumpBar-jumpBar-"] {
     display: none ;
-  }
-}
-@media (min-width: 1024px) {
-  [class*="LiveTVViewPage-page-"] {
-    margin-left: 12rem;
   }
 }
 [class*="SignInLaunchPagePoll-button-"]:after {


### PR DESCRIPTION
## Description
This pull request makes minor updates to the `/watch.css` file, focusing on layout adjustments for guide tab containers and removing a desktop-specific margin style.

Layout and Spacing Adjustments:

* Added padding to elements with class names containing `GuideTab-container-` to improve spacing at the top of guide tab containers.

Responsive Design Cleanup:

* Removed the left margin for `[class*="LiveTVViewPage-page-"]` on screens wider than 1024px, simplifying desktop layout rules.

**Related Issues**
- Closes #571

## Has This Been Tested?

Visual changes only

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
