### PR TITLE
chore(deps): downgrade conventional-changelog... to v9.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "@types/xml2js": "^0.4.14",
     "@types/yamljs": "^0.2.34",
     "commitizen": "4.3.2",
-    "conventional-changelog-conventionalcommits": "^10.0.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "copyfiles": "^2.4.1",
     "cy-mobile-commands": "^0.3.0",
     "cypress": "^15.13.1",
@@ -214,58 +214,48 @@
             "types": [
               {
                 "type": "feat",
-                "section": "✨ Features",
-                "effect": "bump"
+                "section": "✨ Features"
               },
               {
                 "type": "fix",
-                "section": "🐛 Bug Fixes",
-                "effect": "bump"
+                "section": "🐛 Bug Fixes"
               },
               {
                 "type": "perf",
-                "section": "⚡ Performance",
-                "effect": "bump"
+                "section": "⚡ Performance"
               },
               {
                 "type": "revert",
-                "section": "⏪ Reverts",
-                "effect": "bump"
+                "section": "⏪ Reverts"
               },
               {
                 "type": "docs",
-                "section": "📚 Documentation",
-                "effect": "changelog"
+                "section": "📚 Documentation"
               },
               {
                 "type": "style",
-                "section": "💎 Styles",
-                "effect": "changelog"
+                "section": "💎 Styles"
               },
               {
                 "type": "refactor",
-                "section": "♻️ Refactoring",
-                "effect": "changelog"
+                "section": "♻️ Refactoring"
               },
               {
                 "type": "test",
-                "section": "🧪 Tests",
-                "effect": "changelog"
+                "section": "🧪 Tests"
               },
               {
                 "type": "build",
-                "section": "📦 Build System",
-                "effect": "changelog"
+                "section": "📦 Build System"
               },
               {
                 "type": "ci",
-                "section": "🤖 CI/CD",
-                "effect": "changelog"
+                "section": "🤖 CI/CD"
               },
               {
                 "type": "chore",
                 "section": "🔧 Chores",
-                "effect": "hidden"
+                "hidden": true
               }
             ]
           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,8 +328,8 @@ importers:
         specifier: 4.3.2
         version: 4.3.2(@types/node@25.9.5)(typescript@6.0.3)
       conventional-changelog-conventionalcommits:
-        specifier: ^10.0.0
-        version: 10.3.0
+        specifier: ^9.3.1
+        version: 9.3.1
       copyfiles:
         specifier: ^2.4.1
         version: 2.4.1
@@ -3836,6 +3836,10 @@ packages:
   conventional-changelog-conventionalcommits@10.3.0:
     resolution: {integrity: sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==}
     engines: {node: '>=22'}
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    resolution: {integrity: sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==}
+    engines: {node: '>=18'}
 
   conventional-changelog-writer@8.4.0:
     resolution: {integrity: sha512-HHBFkk1EECxxmCi4CTu091iuDpQv5/OavuCUAuZmrkWpmYfyD816nom1CvtfXJ/uYfAAjavgHvXHX291tSLK8g==}
@@ -12235,6 +12239,10 @@ snapshots:
   conventional-changelog-conventionalcommits@10.3.0:
     dependencies:
       '@conventional-changelog/template': 1.3.0
+
+  conventional-changelog-conventionalcommits@9.3.1:
+    dependencies:
+      compare-func: 2.0.0
 
   conventional-changelog-writer@8.4.0:
     dependencies:


### PR DESCRIPTION
## Description
This pull request primarily downgrades the `conventional-changelog-conventionalcommits` dependency from version 10.3.0 to 9.3.1 and updates the changelog configuration to remove the `effect` property in favor of a `hidden` flag for chores. The most important changes are:

### Dependency version changes

* Downgraded `conventional-changelog-conventionalcommits` from version 10.3.0 to 9.3.1 in both `package.json` and `pnpm-lock.yaml` to ensure compatibility or resolve issues with the newer version. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L147-R147) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL331-R332) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR3840-R3843) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR12243-R12246)

### Changelog configuration updates

* Removed the `effect` property from changelog type definitions and replaced it with a `hidden: true` flag for the "chore" type in the `package.json` configuration, clarifying how changelog entries are categorized and hidden.

## Has This Been Tested?

CI change only

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
