### PR TITLE
fix(auth): set token on successful auth and redirect after logout

### DIFF
--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -451,12 +451,6 @@ authRoutes.get('/plex/token', isAuthenticated(), async (req, res, next) => {
       return next({ status: 404, message: 'Plex token not found' });
     }
 
-    logger.debug('Plex token retrieved', {
-      label: 'API',
-      userId: user.id,
-      displayName: user.displayName,
-    });
-
     res.status(200).json({ token: user.plexToken });
   } catch (e) {
     logger.error('Error fetching Plex token', {

--- a/src/app/logout/page.tsx
+++ b/src/app/logout/page.tsx
@@ -19,13 +19,15 @@ const LogOutPage = () => {
         // fail silently
       }
 
-      const response = await axios.post('/api/v1/auth/logout');
-
-      if (response.data?.status === 'ok') {
-        revalidate(undefined, false);
-      }
+      await axios
+        .post('/api/v1/auth/logout')
+        .then(() => {
+          revalidate(undefined, false);
+        })
+        .finally(() => {
+          router.replace('/signin');
+        });
     };
-
     logout();
   }, [revalidate, router]);
 

--- a/src/components/SignIn/index.tsx
+++ b/src/components/SignIn/index.tsx
@@ -33,9 +33,23 @@ const SignIn = () => {
         if (response.data?.id) {
           const { data: authenticatedUser } =
             await axios.get('/api/v1/auth/me');
-          revalidate(authenticatedUser, false).then(() =>
-            router.push('/watch')
-          );
+          revalidate(authenticatedUser, false)
+            .then(async () => {
+              try {
+                const response = await axios.get('/api/v1/auth/plex/token');
+                const { token } = response.data;
+
+                if (token) {
+                  if (localStorage.getItem('myPlexAccessToken') !== token) {
+                    localStorage.setItem('myPlexAccessToken', token);
+                  }
+                }
+              } catch {
+                // Token fetch failed or user doesn't have a Plex token
+                // Do not set tokenRef.current = true here; allow retry on next render
+              }
+            })
+            .then(() => router.push('/watch'));
         }
       } catch (e) {
         setError(


### PR DESCRIPTION
## Description
This pull request primarily fixes an intermittent race condition where upon successful auth and being redirected to the plex web page, setting of the `plexAuthToken` would fail and plex web remained unauthenticated. Similarly to the logout route, there was an intermittent race condition where the redirect to `/signin` would fail until SWR revalidated on it's own - causing a long delay after logout.

**Changes:**
- We now set the `plexAuthToken` in `localstorage` upon successful auth as well as in the layout. This ensures both newly authed users and users already authed, receive an up to date `plexAuthToken` for seamless plex web auth.
- Refactored logout function with `.then()` and a `finally()` to ensure redirect always happens. Removed success condition from revalidation.

## Has This Been Tested?

- [x] Successfully authenticate to Streamarr via plex
- [x] Successfully auth in plex web automatically
- [x] Successfully logout of Streamarr and be redirected to signin

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
