### PR TITLE
refactor(token): collapse token failure logging into single entry

### DIFF
--- a/server/api/plextv.ts
+++ b/server/api/plextv.ts
@@ -937,11 +937,7 @@ class PlexTvAPI extends ExternalAPI {
         throw new Error('No pong response');
       }
     } catch (e) {
-      logger.error('Failed to ping token', {
-        label: 'Plex Refresh Token',
-        errorMessage: e.message,
-      });
-      throw e;
+      throw new Error(e instanceof Error ? e.message : String(e), { cause: e });
     }
   }
 }

--- a/server/lib/refreshToken.ts
+++ b/server/lib/refreshToken.ts
@@ -60,6 +60,8 @@ class RefreshToken {
       .orWhere('user.plexJwtDevice IS NOT NULL')
       .getMany();
 
+    let userPingFailed: { userId: number; errorMessage: string }[] = [];
+
     for (const user of users) {
       if (!this.isRunning) {
         logger.info('Plex refresh token job cancelled.', {
@@ -67,23 +69,33 @@ class RefreshToken {
         });
         return;
       }
-      this.refreshUserLegacyToken(user);
+      await this.refreshUserLegacyToken(user).catch((e) => {
+        userPingFailed.push({
+          userId: user.id,
+          errorMessage: e instanceof Error ? e.message : String(e),
+        });
+      });
       await this.refreshUserJwt(user);
+    }
+
+    if (userPingFailed.length > 0) {
+      logger.error('Failed to ping tokens', {
+        label: 'Plex Refresh Token',
+        failureCount: userPingFailed.length,
+        failures: userPingFailed,
+      });
     }
 
     this.isRunning = false;
   }
 
-  private refreshUserLegacyToken(user: User) {
+  private async refreshUserLegacyToken(user: User) {
     if (!user.plexToken) {
       return;
     }
 
     const plexTvApi = new PlexTvAPI(user.plexToken);
-    plexTvApi.pingToken().catch(() => {
-      // Failures are already logged inside pingToken; keep-alive pings are
-      // best-effort and must not become unhandled rejections.
-    });
+    await plexTvApi.pingToken();
   }
 
   private async refreshUserJwt(user: User) {


### PR DESCRIPTION
## Description
This pull request improves error handling and logging for Plex token refresh operations. The main changes ensure that errors during token pings are properly collected and logged, and that error messages are consistently formatted.

**Error handling and logging improvements:**

* Changed `PlexTvAPI.pingToken` to throw a new error with a consistent message format, removing inline logging from this method.
* Updated `RefreshToken` to collect all user ping failures during the refresh process and log them together after processing, providing clearer visibility into which user tokens failed.
* Refactored `refreshUserLegacyToken` to be asynchronous and to await `pingToken`, ensuring errors are properly caught and handled in the main refresh loop.

## Has This Been Tested?

- [x] Errors are now collected into a single log entry

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
