### PR TITLE
fix(logging): convert logged dates to moment objects

### DIFF
--- a/server/lib/plexAuth/provision.ts
+++ b/server/lib/plexAuth/provision.ts
@@ -3,6 +3,7 @@ import { User } from '@server/entity/User';
 import { encryptDevice, provisionJwt } from '@server/lib/plexAuth/jwt';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import moment from '@server/utils/momentWithLocale';
 
 /**
  * Provisions a per-user Plex JWT device after a successful legacy sign-in
@@ -58,7 +59,9 @@ export const maybeProvisionPlexJwt = async (
     logger.info('Provisioned Plex JWT device for user', {
       label: 'Plex JWT',
       userId,
-      jwtExpiresAt: expiresAt.toISOString(),
+      jwtExpiresAt: moment(expiresAt)
+        .locale(getSettings().main.locale)
+        .format('MMM D YYYY, h:mm A'),
     });
   } catch (e) {
     logger.warn(

--- a/server/lib/refreshToken.ts
+++ b/server/lib/refreshToken.ts
@@ -4,6 +4,7 @@ import { User } from '@server/entity/User';
 import { decryptDevice, refreshJwt } from '@server/lib/plexAuth/jwt';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import moment from '@server/utils/momentWithLocale';
 import { isAxiosError } from 'axios';
 
 /**
@@ -129,7 +130,9 @@ class RefreshToken {
       logger.debug('Refreshed Plex JWT for user', {
         label: 'Plex JWT',
         userId: user.id,
-        jwtExpiresAt: expiresAt.toISOString(),
+        jwtExpiresAt: moment(expiresAt)
+          .locale(getSettings().main.locale)
+          .format('MMM D YYYY, h:mm A'),
       });
     } catch (e) {
       const status = isAxiosError(e) ? e.response?.status : undefined;


### PR DESCRIPTION
## Description
This pull request converts ISO string dates into moment with locale objects for better UX.

## Has This Been Tested?

- [x] Dates properly format to admin setting locale

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
