### PR TITLE
fix(settings): prevent disk-space/cache scans from freezing app

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -106,14 +106,15 @@ docker compose up -d
 
 ## Environment Variables
 
-| Variable           | Default            | Description                                                                   |
-| ------------------ | ------------------ | ----------------------------------------------------------------------------- |
-| `CONFIG_DIRECTORY` | `/app/config`      | Override the configuration directory path                                     |
-| `NODE_ENV`         | `production`       | Set to `development` for development mode                                     |
-| `LOG_LEVEL`        | `debug`            | Winston log level (`error`, `warn`, `info`, `debug`)                          |
-| `TZ`               | `UTC`              | Timezone for the container                                                    |
-| `PORT`             | `3000`             | Port the web interface and API listen on                                      |
-| `HOST`             | _(all interfaces)_ | Network interface/address to bind to. Leave unset to listen on all interfaces |
+| Variable             | Default            | Description                                                                                                                                                                                                                                                         |
+| -------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CONFIG_DIRECTORY`   | `/app/config`      | Override the configuration directory path                                                                                                                                                                                                                           |
+| `NODE_ENV`           | `production`       | Set to `development` for development mode                                                                                                                                                                                                                           |
+| `LOG_LEVEL`          | `debug`            | Winston log level (`error`, `warn`, `info`, `debug`)                                                                                                                                                                                                                |
+| `TZ`                 | `UTC`              | Timezone for the container                                                                                                                                                                                                                                          |
+| `PORT`               | `3000`             | Port the web interface and API listen on                                                                                                                                                                                                                            |
+| `HOST`               | _(all interfaces)_ | Network interface/address to bind to. Leave unset to listen on all interfaces                                                                                                                                                                                       |
+| `UV_THREADPOOL_SIZE` | `4` (Node default) | Size of Node's libuv threadpool, used for filesystem and other async I/O. Consider raising this (e.g. `8`) if `config` lives on slow or network-mounted storage — see [Streamarr is slow / freezes briefly](../support/faq.md#streamarr-is-slow-or-freezes-briefly) |
 
 {% hint style="info" %}
 If you change `PORT`, update your container port mapping (e.g. `-p 8080:8080`) and the `Application URL` in **Settings → General** accordingly.

--- a/docs/support/faq.md
+++ b/docs/support/faq.md
@@ -248,6 +248,33 @@ Counts refresh automatically once Plex is reachable. To force an immediate refre
 3. Clear image cache if it's very large
 4. Check network connectivity to external services
 
+### Streamarr is slow or freezes briefly
+
+If the app briefly freezes or becomes unresponsive — often noticeable when
+opening **System Settings** (Disk Space) or **Jobs & Cache**, and
+occasionally paired with a log entry like `Falling back to recursive path
+size calculation` — this is usually disk I/O contention:
+
+- Streamarr's SQLite database is synchronous and lives in `config/db/`,
+  alongside `config/cache`. When something scans a large `cache` directory
+  (many cached images) on a slow or network-mounted disk (NAS, SMB/NFS
+  share, or Docker Desktop's file-sharing layer on macOS/Windows), that scan
+  can compete with the database for disk access and briefly stall other
+  requests.
+- This is more likely to show up over long uptimes, as the image cache
+  grows, or on hosts with slow/high-latency storage.
+
+To reduce this:
+
+1. Update to the latest version — recent releases cache disk-space and
+   image-cache stats server-side and cap how long a filesystem scan can run.
+2. If `config` is on a NAS/network share, moving it to local/faster storage
+   will help the most.
+3. Try raising `UV_THREADPOOL_SIZE` (e.g. to `8`) — see
+   [Environment Variables](../getting-started/installation.md#environment-variables).
+4. Periodically clear the image cache from **Settings → Jobs & Cache** if it
+   has grown very large.
+
 ### High memory usage
 
 1. Disable image caching if not needed

--- a/server/index.ts
+++ b/server/index.ts
@@ -72,6 +72,10 @@ app
   .then(async () => {
     const dbConnection = await dataSource.initialize();
 
+    if (dataSource.options.type === 'better-sqlite3') {
+      await dbConnection.query('PRAGMA synchronous=NORMAL');
+    }
+
     // Run migrations in production
     if (process.env.NODE_ENV === 'production') {
       await dbConnection.query('PRAGMA foreign_keys=OFF');

--- a/server/interfaces/api/settingsInterfaces.ts
+++ b/server/interfaces/api/settingsInterfaces.ts
@@ -107,6 +107,7 @@ export interface CacheResponse {
     avatar: { size: number; imageCount: number };
     qrcode: { size: number; imageCount: number };
   };
+  cachedAt: number;
 }
 
 export interface StatusResponse {

--- a/server/lib/imageproxy.ts
+++ b/server/lib/imageproxy.ts
@@ -1,5 +1,6 @@
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
+import { getPathUsedBytes } from '@server/utils/pathSize';
 import axios from 'axios';
 import rateLimit, { type rateLimitOptions } from 'axios-rate-limit';
 import { createHash } from 'crypto';
@@ -140,30 +141,19 @@ class ImageProxy {
   ): Promise<{ size: number; imageCount: number }> {
     const cacheDirectory = path.join(baseCacheDirectory, key);
 
-    const imageTotalSize = await ImageProxy.getDirectorySize(cacheDirectory);
-    const imageCount = await ImageProxy.getImageCount(cacheDirectory);
+    const [imageTotalSize, imageCount] = await Promise.all([
+      getPathUsedBytes(cacheDirectory).catch((e) => {
+        logger.warn('Failed to calculate image cache size', {
+          label: 'Image Cache',
+          cacheDirectory,
+          errorMessage: e instanceof Error ? e.message : 'Unknown error',
+        });
+        return 0;
+      }),
+      ImageProxy.getImageCount(cacheDirectory),
+    ]);
 
     return { size: imageTotalSize, imageCount };
-  }
-
-  private static async getDirectorySize(dir: string): Promise<number> {
-    try {
-      const files = await promises.readdir(dir, { withFileTypes: true });
-      const paths = files.map(async (file) => {
-        const path = join(dir, file.name);
-        if (file.isDirectory()) return await ImageProxy.getDirectorySize(path);
-        if (file.isFile()) {
-          const { size } = await promises.stat(path);
-          return size;
-        }
-        return 0;
-      });
-      return (await Promise.all(paths))
-        .flat(Infinity)
-        .reduce((i, size) => i + size, 0);
-    } catch {
-      return 0;
-    }
   }
 
   private static async getImageCount(dir: string) {

--- a/server/lib/qrcodeproxy.ts
+++ b/server/lib/qrcodeproxy.ts
@@ -1,4 +1,5 @@
 import logger from '@server/logger';
+import { getPathUsedBytes } from '@server/utils/pathSize';
 import { createHash } from 'crypto';
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -94,6 +95,26 @@ class QRCodeProxy {
       });
       return null;
     }
+  }
+
+  public async getCacheStats(): Promise<{ size: number; imageCount: number }> {
+    const cacheDirectory = this.getCacheDirectory();
+
+    const [size, entries] = await Promise.all([
+      getPathUsedBytes(cacheDirectory).catch((e) => {
+        logger.warn('Failed to calculate QR cache size', {
+          label: 'QRCodeProxy',
+          cacheDirectory,
+          errorMessage: e instanceof Error ? e.message : 'Unknown error',
+        });
+        return 0;
+      }),
+      fs.readdir(cacheDirectory).catch(() => [] as string[]),
+    ]);
+
+    const imageCount = entries.filter((file) => file.endsWith('.png')).length;
+
+    return { size, imageCount };
   }
 
   public async deleteImage(cacheKey: string) {

--- a/server/lib/rateLimiters.ts
+++ b/server/lib/rateLimiters.ts
@@ -66,6 +66,13 @@ export const settingsAboutDiskSpaceLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+export const settingsCacheLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 export const newsletterPreviewLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 30,

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -9,6 +9,7 @@ import Invite from '@server/entity/Invite';
 import { User } from '@server/entity/User';
 import type { PlexConnection } from '@server/interfaces/api/plexInterfaces';
 import type {
+  CacheResponse,
   LogMessage,
   LogsResultsResponse,
   ServiceHealthResponse,
@@ -19,18 +20,17 @@ import { scheduledJobs } from '@server/job/schedule';
 import { getAudiobookshelfAPI } from '@server/lib/audiobookshelf';
 import type { AvailableCacheIds } from '@server/lib/cache';
 import cacheManager from '@server/lib/cache';
-import ImageProxy from '@server/lib/imageproxy';
 import { Permission } from '@server/lib/permissions';
 import {
   markPlexHealthy,
   resetPlexHealth,
   revalidatePlexLibraries,
 } from '@server/lib/plexHealthCheck';
-import QRCodeProxy from '@server/lib/qrcodeproxy';
 import {
   arrAuthLimiter,
   settingsAboutDiskSpaceLimiter,
   settingsAboutLimiter,
+  settingsCacheLimiter,
 } from '@server/lib/rateLimiters';
 import restartManager from '@server/lib/restartManager';
 import { plexFullScanner } from '@server/lib/scanners/plex';
@@ -50,10 +50,11 @@ import logger from '@server/logger';
 import { isAuthenticated } from '@server/middleware/auth';
 import { appDataPath } from '@server/utils/appDataVolume';
 import { getAppVersion } from '@server/utils/appVersion';
+import { getCachedImageCacheOverview } from '@server/utils/cacheOverview';
 import { getCachedConfigDiskSpace } from '@server/utils/diskSpace';
 import { Router } from 'express';
 import rateLimit from 'express-rate-limit';
-import fs, { promises as fsPromises } from 'fs';
+import fs from 'fs';
 import { escapeRegExp, merge, omit, set, sortBy } from 'lodash';
 import { rescheduleJob } from 'node-schedule';
 import path from 'path';
@@ -1192,7 +1193,7 @@ settingsRoutes.post<{ jobId: JobId }>(
   }
 );
 
-settingsRoutes.get('/cache', async (_req, res) => {
+settingsRoutes.get('/cache', settingsCacheLimiter, async (req, res) => {
   const cacheManagerCaches = cacheManager.getAllCaches();
 
   const apiCaches = Object.values(cacheManagerCaches).map((cache) => ({
@@ -1201,37 +1202,16 @@ settingsRoutes.get('/cache', async (_req, res) => {
     stats: cache.getStats(),
   }));
 
-  const tmdbImageCache = await ImageProxy.getImageStats('tmdb');
-  const plexImageCache = await ImageProxy.getImageStats('plex');
-  const avatarImageCache = await ImageProxy.getImageStats('avatar');
-
-  // QR code cache stats
-  const qrProxy = new QRCodeProxy();
-  const qrCacheDir = qrProxy.getCacheDirectory();
-  let qrImageCount = 0;
-  let qrCacheSize = 0;
-  try {
-    const files = await fsPromises.readdir(qrCacheDir);
-    for (const file of files) {
-      if (file.endsWith('.png')) {
-        qrImageCount++;
-        const stat = await fsPromises.stat(path.join(qrCacheDir, file));
-        qrCacheSize += stat.size;
-      }
-    }
-  } catch {
-    // ignore errors, just show 0s
-  }
+  const force = req.query.force === 'true';
+  const { imageCache, cachedAt } = await getCachedImageCacheOverview({
+    force,
+  });
 
   res.status(200).json({
     apiCaches,
-    imageCache: {
-      tmdb: tmdbImageCache,
-      plex: plexImageCache,
-      avatar: avatarImageCache,
-      qrcode: { imageCount: qrImageCount, size: qrCacheSize },
-    },
-  });
+    imageCache,
+    cachedAt,
+  } as CacheResponse);
 });
 
 settingsRoutes.post<{ cacheId: AvailableCacheIds }>(

--- a/server/utils/cacheOverview.ts
+++ b/server/utils/cacheOverview.ts
@@ -1,0 +1,65 @@
+import ImageProxy from '@server/lib/imageproxy';
+import QRCodeProxy from '@server/lib/qrcodeproxy';
+
+export type ImageCacheOverview = {
+  tmdb: { size: number; imageCount: number };
+  plex: { size: number; imageCount: number };
+  avatar: { size: number; imageCount: number };
+  qrcode: { size: number; imageCount: number };
+};
+
+export type CacheOverviewResult = {
+  imageCache: ImageCacheOverview;
+  cachedAt: number;
+};
+
+const IMAGE_CACHE_TTL_MS = 60 * 1000;
+
+let imageCacheOverviewCache: {
+  expiresAt: number;
+  promise: Promise<CacheOverviewResult>;
+} | null = null;
+
+const computeImageCacheOverview = async (): Promise<CacheOverviewResult> => {
+  const qrProxy = new QRCodeProxy();
+
+  const [tmdb, plex, avatar, qrcode] = await Promise.all([
+    ImageProxy.getImageStats('tmdb'),
+    ImageProxy.getImageStats('plex'),
+    ImageProxy.getImageStats('avatar'),
+    qrProxy.getCacheStats(),
+  ]);
+
+  return {
+    imageCache: { tmdb, plex, avatar, qrcode },
+    cachedAt: Date.now(),
+  };
+};
+
+export const getCachedImageCacheOverview = async ({
+  force = false,
+}: { force?: boolean } = {}): Promise<CacheOverviewResult> => {
+  const now = Date.now();
+
+  if (
+    !force &&
+    imageCacheOverviewCache &&
+    imageCacheOverviewCache.expiresAt > now
+  ) {
+    return imageCacheOverviewCache.promise;
+  }
+
+  const promise = computeImageCacheOverview();
+  imageCacheOverviewCache = {
+    expiresAt: now + IMAGE_CACHE_TTL_MS,
+    promise,
+  };
+
+  promise.catch(() => {
+    if (imageCacheOverviewCache?.promise === promise) {
+      imageCacheOverviewCache = null;
+    }
+  });
+
+  return promise;
+};

--- a/server/utils/diskSpace.ts
+++ b/server/utils/diskSpace.ts
@@ -3,15 +3,13 @@ import type {
   DiskSpaceItem,
 } from '@server/interfaces/api/settingsInterfaces';
 import logger from '@server/logger';
+import { getPathUsedBytes } from '@server/utils/pathSize';
 import { execFile } from 'child_process';
 import { promises as fsPromises } from 'fs';
-import type { Dir } from 'node:fs';
 import path from 'path';
 import { promisify } from 'util';
 
 const execFileAsync = promisify(execFile);
-
-const DU_TIMEOUT_MS = 30 * 1000;
 
 /**
  * Walks up the directory tree from `targetPath` until it finds a path that
@@ -101,102 +99,6 @@ export const getDiskSpaceStats = async (diskPath: string) => {
       usedPercent: totalBytes > 0 ? (usedBytes / totalBytes) * 100 : 0,
     };
   }
-};
-
-/**
- * Returns the total bytes used under `targetPath`. Prefers the native `du`
- * command, which is significantly faster than a recursive JS walk and runs
- * off the event loop. Note: `du` reports on-disk (block-allocated) usage
- * rather than apparent file size, so totals can differ slightly. Falls back to
- * a recursive walk when `du` is unavailable (e.g. non-POSIX host) or fails.
- */
-export const getPathUsedBytes = async (targetPath: string): Promise<number> => {
-  try {
-    // -s: summarize to a single total; -k: report in 1024-byte block units.
-    // `--` guards against a path that begins with `-` being read as a flag.
-    const { stdout } = await execFileAsync('du', ['-sk', '--', targetPath], {
-      timeout: DU_TIMEOUT_MS,
-    });
-    const blocksKb = Number(stdout.trim().split(/\s+/)[0]);
-
-    if (Number.isFinite(blocksKb)) {
-      return blocksKb * 1024;
-    }
-
-    throw new Error(`Unable to parse du output for path: ${targetPath}`);
-  } catch (e) {
-    logger.warn('Falling back to recursive path size calculation', {
-      label: 'Settings',
-      targetPath,
-      errorMessage: e instanceof Error ? e.message : 'Unknown error',
-    });
-
-    return getPathUsedBytesRecursive(targetPath);
-  }
-};
-
-/**
- * Recursively calculates the total size in bytes of all files under
- * `targetPath`. Skips symbolic links and unreadable entries. Used as a
- * fallback when the native `du` command is unavailable.
- */
-const getPathUsedBytesRecursive = async (
-  targetPath: string
-): Promise<number> => {
-  try {
-    const rootStats = await fsPromises.lstat(targetPath);
-
-    if (rootStats.isFile()) {
-      return rootStats.size;
-    }
-
-    if (!rootStats.isDirectory()) {
-      return 0;
-    }
-  } catch {
-    return 0;
-  }
-
-  let totalBytes = 0;
-  const stack = [targetPath];
-
-  while (stack.length > 0) {
-    const currentPath = stack.pop();
-
-    if (!currentPath) {
-      continue;
-    }
-
-    let dir: Dir;
-
-    try {
-      dir = await fsPromises.opendir(currentPath);
-    } catch {
-      continue;
-    }
-
-    for await (const entry of dir) {
-      const entryPath = path.join(currentPath, entry.name);
-
-      try {
-        const entryStats = await fsPromises.lstat(entryPath);
-
-        if (entryStats.isSymbolicLink()) {
-          continue;
-        }
-
-        if (entryStats.isDirectory()) {
-          stack.push(entryPath);
-        } else if (entryStats.isFile()) {
-          totalBytes += entryStats.size;
-        }
-      } catch {
-        // Ignore unreadable entries and continue calculating what we can.
-      }
-    }
-  }
-
-  return totalBytes;
 };
 
 /**

--- a/server/utils/pathSize.ts
+++ b/server/utils/pathSize.ts
@@ -1,0 +1,124 @@
+import logger from '@server/logger';
+import { diskScanQueue } from '@server/utils/scanQueue';
+import { execFile } from 'child_process';
+import { promises as fsPromises } from 'fs';
+import type { Dir } from 'node:fs';
+import path from 'path';
+import { promisify } from 'util';
+
+const execFileAsync = promisify(execFile);
+
+const DU_TIMEOUT_MS = 30 * 1000;
+const RECURSIVE_WALK_TIMEOUT_MS = 45 * 1000;
+const DEADLINE_CHECK_INTERVAL = 200;
+
+export class PathSizeTimeoutError extends Error {
+  constructor(targetPath: string) {
+    super(`Timed out calculating size for path: ${targetPath}`);
+    this.name = 'PathSizeTimeoutError';
+  }
+}
+
+export const getPathUsedBytes = (targetPath: string): Promise<number> =>
+  diskScanQueue.enqueue(() => getPathUsedBytesUnqueued(targetPath));
+
+const getPathUsedBytesUnqueued = async (
+  targetPath: string
+): Promise<number> => {
+  try {
+    // -s: summarize to a single total; -k: report in 1024-byte block units.
+    // `--` guards against a path that begins with `-` being read as a flag.
+    const { stdout } = await execFileAsync('du', ['-sk', '--', targetPath], {
+      timeout: DU_TIMEOUT_MS,
+    });
+    const blocksKb = Number(stdout.trim().split(/\s+/)[0]);
+
+    if (Number.isFinite(blocksKb)) {
+      return blocksKb * 1024;
+    }
+
+    throw new Error(`Unable to parse du output for path: ${targetPath}`);
+  } catch (e) {
+    logger.warn('Falling back to recursive path size calculation', {
+      label: 'PathSize',
+      targetPath,
+      errorMessage: e instanceof Error ? e.message : 'Unknown error',
+    });
+
+    return getPathUsedBytesRecursive(targetPath);
+  }
+};
+
+const getPathUsedBytesRecursive = async (
+  targetPath: string
+): Promise<number> => {
+  const deadline = Date.now() + RECURSIVE_WALK_TIMEOUT_MS;
+
+  try {
+    const rootStats = await fsPromises.lstat(targetPath);
+
+    if (rootStats.isFile()) {
+      return rootStats.size;
+    }
+
+    if (!rootStats.isDirectory()) {
+      return 0;
+    }
+  } catch {
+    return 0;
+  }
+
+  let totalBytes = 0;
+  let entriesSinceDeadlineCheck = 0;
+  const stack = [targetPath];
+
+  while (stack.length > 0) {
+    if (Date.now() > deadline) {
+      throw new PathSizeTimeoutError(targetPath);
+    }
+
+    const currentPath = stack.pop();
+
+    if (!currentPath) {
+      continue;
+    }
+
+    let dir: Dir;
+
+    try {
+      dir = await fsPromises.opendir(currentPath);
+    } catch {
+      continue;
+    }
+
+    for await (const entry of dir) {
+      entriesSinceDeadlineCheck += 1;
+      if (entriesSinceDeadlineCheck >= DEADLINE_CHECK_INTERVAL) {
+        entriesSinceDeadlineCheck = 0;
+        if (Date.now() > deadline) {
+          throw new PathSizeTimeoutError(targetPath);
+        }
+      }
+
+      const entryPath = path.join(currentPath, entry.name);
+
+      try {
+        const entryStats = await fsPromises.lstat(entryPath);
+
+        if (entryStats.isSymbolicLink()) {
+          continue;
+        }
+
+        if (entryStats.isDirectory()) {
+          stack.push(entryPath);
+        } else if (entryStats.isFile()) {
+          totalBytes += entryStats.size;
+        }
+      } catch {
+        // Ignore unreadable entries and continue calculating what we can.
+      }
+    }
+  }
+
+  return totalBytes;
+};

--- a/server/utils/scanQueue.ts
+++ b/server/utils/scanQueue.ts
@@ -1,0 +1,16 @@
+class ScanQueue {
+  private tail: Promise<unknown> = Promise.resolve();
+
+  enqueue<T>(task: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(task, task);
+
+    this.tail = result.then(
+      () => undefined,
+      () => undefined
+    );
+
+    return result;
+  }
+}
+
+export const diskScanQueue = new ScanQueue();

--- a/src/components/Admin/Settings/JobsCache/index.tsx
+++ b/src/components/Admin/Settings/JobsCache/index.tsx
@@ -11,6 +11,7 @@ import { momentWithLocale as moment } from '@app/utils/momentLocale';
 import { formatBytes } from '@app/utils/numberHelper';
 import { PencilIcon, PlayIcon, TrashIcon } from '@heroicons/react/24/outline';
 import {
+  ArrowPathIcon,
   CheckBadgeIcon,
   StopIcon,
   XCircleIcon,
@@ -102,8 +103,9 @@ const JobsCacheSettings = () => {
     mutate: cacheRevalidate,
     isLoading,
   } = useSWR<CacheResponse>('/api/v1/settings/cache', {
-    refreshInterval: 10000,
+    refreshInterval: 60000,
   });
+  const [isRefreshingCache, setIsRefreshingCache] = useState(false);
 
   const [jobModalState, dispatch] = useReducer(jobModalReducer, {
     isOpen: false,
@@ -177,6 +179,18 @@ const JobsCacheSettings = () => {
       icon: <CheckBadgeIcon className="size-7" />,
     });
     cacheRevalidate();
+  };
+
+  const refreshCache = async () => {
+    setIsRefreshingCache(true);
+    try {
+      const { data: freshCacheData } = await axios.get<CacheResponse>(
+        '/api/v1/settings/cache?force=true'
+      );
+      cacheRevalidate(freshCacheData, { revalidate: false });
+    } finally {
+      setIsRefreshingCache(false);
+    }
   };
 
   const scheduleJob = async () => {
@@ -553,12 +567,39 @@ const JobsCacheSettings = () => {
         </Table>
       </div>
       <div>
-        <h3 className="text-2xl font-extrabold">
-          <FormattedMessage
-            id="imageCache.title"
-            defaultMessage="Image Cache"
-          />
-        </h3>
+        <div className="flex flex-wrap items-center justify-between gap-x-2">
+          <h3 className="text-2xl font-extrabold">
+            <FormattedMessage
+              id="imageCache.title"
+              defaultMessage="Image Cache"
+            />
+          </h3>
+          <div className="flex items-center gap-3">
+            {cacheData?.cachedAt && (
+              <span className="text-neutral text-xs">
+                <FormattedMessage
+                  id="cache.lastUpdated"
+                  defaultMessage="Updated {time}"
+                  values={{ time: moment(cacheData.cachedAt).from(now) }}
+                />
+              </span>
+            )}
+            <Button
+              type="button"
+              buttonSize="xs"
+              buttonType="ghost"
+              disabled={isRefreshingCache}
+              onClick={() => refreshCache()}
+            >
+              <ArrowPathIcon
+                className={`size-5 ${isRefreshingCache ? 'animate-spin' : ''}`}
+              />
+              <span className="sr-only">
+                <FormattedMessage id="cache.refresh" defaultMessage="Refresh" />
+              </span>
+            </Button>
+          </div>
+        </div>
         <p className="mb-5 w-full overflow-hidden">
           <FormattedMessage
             id="imageCache.description"

--- a/src/i18n/locale/en.json
+++ b/src/i18n/locale/en.json
@@ -113,6 +113,12 @@
   "cache.flushed": {
     "defaultMessage": "{cacheName} cache flushed."
   },
+  "cache.lastUpdated": {
+    "defaultMessage": "Updated {time}"
+  },
+  "cache.refresh": {
+    "defaultMessage": "Refresh"
+  },
   "cache.table.cacheName": {
     "defaultMessage": "Cache Name"
   },

--- a/streamarr-api.yml
+++ b/streamarr-api.yml
@@ -4738,9 +4738,21 @@ paths:
   /settings/cache:
     get:
       summary: Get a list of active caches
-      description: Retrieves a list of all active caches and their current stats.
+      description: >-
+        Retrieves a list of all active caches and their current stats.
+        Image/QR cache size stats are cached server-side for a short period;
+        pass `force=true` to bypass that cache and recompute immediately.
       tags:
         - settings
+      parameters:
+        - in: query
+          name: force
+          schema:
+            type: boolean
+            default: false
+          description: >-
+            Bypass the server-side cache and recompute image/QR cache stats
+            immediately.
       responses:
         '200':
           description: Caches returned
@@ -4749,6 +4761,10 @@ paths:
               schema:
                 type: object
                 properties:
+                  cachedAt:
+                    type: number
+                    description: Epoch ms when the imageCache stats were computed.
+                    example: 1735689600000
                   imageCache:
                     type: object
                     properties:
@@ -4771,6 +4787,15 @@ paths:
                             type: number
                             example: 123
                       avatar:
+                        type: object
+                        properties:
+                          size:
+                            type: number
+                            example: 123456
+                          imageCount:
+                            type: number
+                            example: 123
+                      qrcode:
                         type: object
                         properties:
                           size:


### PR DESCRIPTION
## Description
This pull request improves the accuracy, performance, and reliability of image cache size reporting and disk usage calculations, especially for slow or network-mounted filesystems. It introduces a new shared utility for disk usage measurement, adds caching and rate-limiting to cache stats endpoints, and provides better user guidance for related performance issues.

**Backend improvements for cache and disk usage stats:**

- Introduced a new utility module (`server/utils/pathSize.ts`) for measuring disk usage with a queue, timeouts, and a fallback to recursive scanning when the native `du` command is unavailable, improving reliability and responsiveness for slow or large directories.
- Updated image cache stats collection to use the new `getPathUsedBytes` utility, replacing custom and duplicated directory size logic in both `ImageProxy` and `QRCodeProxy`. [[1]](diffhunk://#diff-44f21bf50857c0d524084b42214f4cc4e3a1c58c87ee3c0bd2b553826dea9670L143-L168) [[2]](diffhunk://#diff-c8036cd5b2602c2c107d552a0a593be2c5fbe2789b5cc06a93cba306fd6bb8a5R100-R112)
- Refactored the `/settings/cache` endpoint to use a new centralized caching layer (`getCachedImageCacheOverview` in `server/utils/cacheOverview.ts`), reducing redundant filesystem scans and adding a `cachedAt` timestamp to the API response. [[1]](diffhunk://#diff-2a1474814fd776a83702a982642fa1f670f173aac17338c8798ce1a08a64dfe0R1-R65) [[2]](diffhunk://#diff-40a513ebf788fbd640c7a87c61eafd0531acec6153701802eab3adf2ad1dc3b5R110) [[3]](diffhunk://#diff-6bfb870aaae2a6a7d991a6dcbad3c4f8a1096576565230c9b688d0257a8012b6L1204-R1214)

**Performance and rate limiting:**

- Added a rate limiter (`settingsCacheLimiter`) to the `/settings/cache` endpoint to prevent excessive disk scans and potential performance degradation. [[1]](diffhunk://#diff-e9b493c2e0c12ab16eb8a0e37a770d04c35e637a943644a095d97ea6dcebe3b9R69-R75) [[2]](diffhunk://#diff-6bfb870aaae2a6a7d991a6dcbad3c4f8a1096576565230c9b688d0257a8012b6L1195-R1196)
- Set SQLite’s `PRAGMA synchronous=NORMAL` to reduce disk contention and improve performance for database operations on slow filesystems.

**Documentation and user guidance:**

- Expanded the FAQ with a new section on diagnosing and mitigating app freezes due to disk I/O contention, and documented the `UV_THREADPOOL_SIZE` environment variable to help users tune performance for slow or network-mounted storage. [[1]](diffhunk://#diff-4ab9cf94e569f4d7b4122140a9013dcef0a2c277c5fd7681075d410bc7769b20R251-R277) [[2]](diffhunk://#diff-6828264893dbf2a68733af90bf5996b5b8afec681e5d6f216edca2ec9c8d1fa5L110-R117)

**Code cleanup and maintainability:**

- Removed redundant and legacy disk usage code from `server/utils/diskSpace.ts`, consolidating all path size logic into the new shared utility.
- Simplified cache stats gathering in route handlers by delegating to shared utilities. [[1]](diffhunk://#diff-6bfb870aaae2a6a7d991a6dcbad3c4f8a1096576565230c9b688d0257a8012b6L22-R33) [[2]](diffhunk://#diff-6bfb870aaae2a6a7d991a6dcbad3c4f8a1096576565230c9b688d0257a8012b6R53-R57)

These changes collectively enhance the backend’s ability to report cache and disk usage accurately and efficiently, while also improving user experience and providing clearer guidance for performance troubleshooting.

- Fixes #585 

## Has This Been Tested?

- [x] Correctly reported disk space in system
- [x] Correctly reported item count and size for cached images
- [x] UI loads correctly as intended for both

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [x] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
