### PR TITLE
fix(cleanuparr): use api v2 for health check and test connection

### DIFF
--- a/server/lib/serviceHealth.ts
+++ b/server/lib/serviceHealth.ts
@@ -101,7 +101,7 @@ interface CleanuparrStats {
 async function checkCleanuparr(service: ServiceSettings): Promise<CheckResult> {
   const intl = getIntl(getSettings().main.locale ?? 'en');
   try {
-    const url = buildUrl(service, 'api/stats', 11011);
+    const url = buildUrl(service, 'api/v2/stats', 11011);
     url.searchParams.set('hours', '1');
 
     const response = await fetch(url, {

--- a/server/routes/settings/index.ts
+++ b/server/routes/settings/index.ts
@@ -464,7 +464,7 @@ settingsRoutes.post('/cleanuparr/test', async (req, res, next) => {
       .filter(Boolean)
       .join('/');
     const url = new URL(
-      base ? `/${base}/api/stats` : '/api/stats',
+      base ? `/${base}/api/v2/stats` : '/api/v2/stats',
       `${protocol}://${hostname}:${portNumber}`
     );
     url.searchParams.set('hours', '1');


### PR DESCRIPTION
## Description
This pull request updates the Cleanuparr service integration to use the newer v2 API endpoint for stats retrieval. The main change is updating the API path from `/api/stats` to `/api/v2/stats` in both the service health check and the settings test route.

API endpoint update:

* Updated the Cleanuparr stats API path from `/api/stats` to `/api/v2/stats` in the `checkCleanuparr` health check function in `server/lib/serviceHealth.ts`.
* Updated the Cleanuparr stats API path from `/api/stats` to `/api/v2/stats` in the settings test route in `server/routes/settings/index.ts`.

## Has This Been Tested?

- [x] Confirmed working against live service

## Screenshots (if applicable)

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
