### PR TITLE
fix(notifications): add createdBy field to notifications

### DIFF
--- a/server/lib/plexAccessLost.ts
+++ b/server/lib/plexAccessLost.ts
@@ -132,6 +132,7 @@ export const handlePlexAccessLost = async (user: User): Promise<void> => {
           actionUrl: `/admin/users/${user.id}/settings`,
           actionUrlTitle: 'View User Settings',
           severity: NotificationSeverity.WARNING,
+          createdBy: user,
         })
       );
     } catch (e) {

--- a/server/routes/user/usersettings.ts
+++ b/server/routes/user/usersettings.ts
@@ -391,6 +391,7 @@ userSettingsRoutes.post<{ id: string }>(
           actionUrl: `/admin/users/${user.id}/settings/linked-accounts`,
           actionUrlTitle: 'View User Settings',
           severity: NotificationSeverity.WARNING,
+          createdBy: req.user,
         })
       );
 
@@ -586,6 +587,7 @@ userSettingsRoutes.post<{ id: string }>(
           actionUrl: `/admin/users/${user.id}/settings`,
           actionUrlTitle: 'Manage User',
           severity: NotificationSeverity.WARNING,
+          createdBy: req.user,
         })
       );
 

--- a/server/subscriber/InviteSubscriber.ts
+++ b/server/subscriber/InviteSubscriber.ts
@@ -135,6 +135,7 @@ export class InviteSubscriber implements EntitySubscriberInterface<Invite> {
         ),
         actionUrl: '/invites',
         actionUrlTitle: 'View Invites',
+        createdBy: entity.createdBy,
       })
     );
   }

--- a/server/subscriber/UserSubscriber.ts
+++ b/server/subscriber/UserSubscriber.ts
@@ -65,6 +65,7 @@ export class UserSubscriber implements EntitySubscriberInterface<User> {
         actionUrl: '/admin/users',
         actionUrlTitle: 'View Users',
         severity: NotificationSeverity.PRIMARY,
+        createdBy: entity.redeemedInvite?.createdBy,
       })
     );
   }


### PR DESCRIPTION
## Description
This pull request adds a new property, `createdBy`, to various notification creation calls throughout the backend. This change ensures that notifications now track which user or entity initiated the action, improving traceability and auditing capabilities.

**Notification enhancements:**

* Added the `createdBy` property to user-related notifications in `handlePlexAccessLost` to associate the notification with the affected user.
* Included the `createdBy` property in linked account and user management notifications within `userSettingsRoutes` to specify the user responsible for the action. [[1]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926R394) [[2]](diffhunk://#diff-314dd8a274300910cf93378ae2d6755ba8b006906b8e49f4d2ba198b31e0c926R590)

**Entity subscriber improvements:**

* Updated the `InviteSubscriber` to set `createdBy` on invite-related notifications, using the creator of the invite entity.
* Modified the `UserSubscriber` to include the acting user as `createdBy` in user-related notifications.

## Has This Been Tested?

- [x] CreatedBy correctly registers from initiating entity

## Screenshots (if applicable)

N/A

## Checklist:

- [x] I have read and followed the contribution [guidelines](https://github.com/nickelsh1ts/streamarr/blob/develop/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Successful build `pnpm build`
- [ ] Translation keys `pnpm i18n:extract`
- [ ] Database migration (if required)
